### PR TITLE
Genez para negocios de servicios: agenda, equipo, abonos y finanzas

### DIFF
--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -134,6 +134,16 @@ Lo que toca varias tablas a la vez vive en Postgres, no en el navegador:
 4. **No se cobra sin caja abierta.** Se verifica en la base.
 5. **Lo que toca varias tablas va en una función**, no en varias llamadas
    desde el navegador.
+6. **Toda consulta de lista filtra por `empresa_id`, explícito.** RLS
+   contesta *si podés ver algo*, no *de qué comercio es*. Para un usuario
+   de comercio las dos respuestas coinciden, y por eso apoyarse en la
+   política parecía alcanzar. No alcanza: el dueño de plataforma ve todo, y
+   entrando como Almha se le cargaban los 972 productos de Super 25 —la
+   Coca-Cola apareciendo en el informe de una estética—. Las funciones de
+   `src/datos/` que traen listas revientan si no reciben la empresa, a
+   propósito: un id olvidado tiene que fallar ahí y no convertirse en datos
+   de otro negocio. Lo cubre `probar-rls.mjs`, en "Alcance de la
+   plataforma".
 
 ## El salón
 

--- a/docs/pedido-negocios-de-servicios.md
+++ b/docs/pedido-negocios-de-servicios.md
@@ -1,0 +1,222 @@
+# Encargo · Genez para negocios de servicios
+
+Qué hay que construir para que Genez sirva a un negocio que vende turnos:
+estética, pilates, barbería, tatuajes, gimnasio, consultorio, peluquería
+canina. El primer caso es una estética con pilates, pero **el primer caso no
+es la especificación**.
+
+Las maquetas de referencia son 23 capturas que tiene el cliente. Hay que
+pedírselas: no están en el repositorio.
+
+Ver `ARQUITECTURA.md` para el modelo de datos actual y `DISENO.md` para las
+reglas visuales. Lo que este documento diga distinto de esos dos, es porque
+lo cambia a propósito y está dicho acá.
+
+## Lo esencial
+
+Un motor único —clientes, servicios, turnos, profesionales, recursos,
+ventas, finanzas— con **configuraciones verticales encima**. No un sistema
+por rubro.
+
+La misma regla que el centro de pedidos: no crear nada paralelo. El
+catálogo, los clientes, las operaciones, la caja, los pagos, los permisos y
+la impresión ya existen y se reusan.
+
+## Decisiones tomadas (22/08/2026)
+
+1. **El acento es naranja.** Hay maquetas en violeta; se descartan. El
+   naranja es lo que está en `index.css` y lo que ya usan Super 25 y el bar.
+   Cambiarlo obligaba a repintar el sistema entero, no solo lo nuevo.
+2. **El menú es dato, no código.** Ver la sección siguiente.
+3. **`DISENO.md` manda.** Las maquetas se adaptan al estilo que ya tiene el
+   sistema —esquinas discretas, bordes de 1px, poco color— y no al revés.
+4. **Los permisos configurables quedan para después.** Los roles de hoy
+   funcionan y el módulo arrastra RLS detrás.
+5. **CRM y Comunicaciones quedan últimos**, cuando haya turnos cargados
+   sobre los que probarlos.
+
+## El menú es dato
+
+Es el cambio arquitectónico de fondo y la razón de ser de todo lo demás.
+
+Hoy el menú es una lista fija pensada para un minimercado. Si se la
+reemplaza por una lista fija pensada para una estética, el tercer rubro
+vuelve a romper todo. Así que los grupos, qué módulos caen en cada uno y
+cómo se llaman las cosas se definen **por rubro y en la base**, igual que
+`canales` define el flujo de un pedido sin un solo `if`.
+
+Los diez grupos de referencia —Inicio, Agenda, Clientes y equipo, Servicios
+y recursos, Ventas, Finanzas, CRM y marketing, Comunicaciones, Reportes,
+Configuración— son la configuración del rubro servicios. Gastronomía tiene
+los suyos, con Salón y Cocina. Comercio, los suyos, con Stock y Compras.
+
+El menú que ve una persona es el cruce de tres cosas:
+
+    grupos del rubro  ∩  módulos que el comercio contrató  ∩  lo que el rol habilita
+
+Las dos últimas ya existen (`empresas.modulos` y `ROLES`). Falta la primera.
+
+**La terminología también es del rubro.** Turno, clase, sesión, cita.
+Cliente, paciente, alumno. Profesional, profe, barbero, tatuador. Es el
+mismo mecanismo que `VOZ_MESA` y `VOZ_CANAL` en la comanda: una pantalla,
+distintas palabras, cero componentes duplicados.
+
+## El mapa
+
+| Hoy | Va a | Qué pasa |
+|---|---|---|
+| `Inicio.jsx` | Inicio | Se rehacen los indicadores; la estructura de tarjetas se reusa |
+| — | **Agenda** | Nuevo. Sobre `reservas`, `recursos` e `items` |
+| `Clientes.jsx` | Clientes y equipo → Clientes | Primero hay que migrarlo a la base |
+| — | Clientes y equipo → Equipo, Suplencias | Nuevo |
+| `Productos.jsx` | Servicios y recursos → Servicios | Misma tabla `items`, otra vista: duración y capacidad en vez de stock |
+| `PlanoSalon.jsx` | Servicios y recursos → Salas | El editor de plano se reusa entero |
+| `Vender.jsx` | Ventas → Venta rápida | Se conserva |
+| — | Ventas → Presupuestos, Abonos, Packs | `operaciones.tipo` ya admite `presupuesto`. Los abonos son nuevos |
+| `Caja.jsx` | Finanzas → Caja | Se conserva y gana pestañas hermanas |
+| — | Finanzas → Ingresos, Egresos, Pendientes | Vistas nuevas sobre `movimientos_caja` |
+| `Reportes.jsx` | Reportes | Se conserva el armazón; las métricas se rehacen |
+| `Ajustes.jsx` | Configuración | Se conserva |
+| `Comandas`, `CentroPedidos`, `Stock`, `Compras` | Grupos de gastronomía y comercio | No se tocan y no se le muestran a una estética |
+
+Nada se borra. Lo que era un módulo suelto pasa a ser una vista de un grupo.
+
+## Lo que se reutiliza sin tocar
+
+`Card`, `Boton`, `Modal`, `Tabs`, `Kpi`, `Vacio`, `TablaSimple` y los campos.
+El sistema de colores por variables. La impresión de comandera. El lector de
+códigos. La cola de ventas sin internet. Toda la capa `src/datos/`. El
+editor de plano, tal cual, para dibujar salas y boxes.
+
+De la base: `items` (con `tipo = 'servicio'` y `duracion_min`, que ya estaba
+previsto para esto), `recursos`, `reservas`, `clientes`, `operaciones`,
+`pagos`, `movimientos_caja`, `sesiones_caja`, `bitacora`.
+
+## Lo que hay que construir
+
+### Tablas nuevas
+
+- **`personal`** — la persona. Nombre, tipo (profesional o recepción),
+  modalidad de pago, valor, y un `perfil_id` **opcional**: hoy los profes no
+  entran al sistema, pero si mañana uno quiere, se le engancha una cuenta sin
+  migrar nada. Dejarlo previsto ahora cuesta una columna; agregarlo después
+  cuesta una migración de datos.
+- **`personal_servicios`** — quién puede dar qué.
+- **`horarios`** — de una persona o de un recurso: día, desde, hasta.
+  Sin esto no se puede ofrecer un turno, ni siquiera a mano.
+- **`excepciones`** — ausencias, vacaciones, feriados.
+- **`franjas`** — el hueco agendado: cuándo, qué servicio, quién lo da, en
+  qué sala, cuántos lugares. **Con cupo 1 es un turno individual y con cupo 6
+  es una clase de pilates.** Un solo modelo para los dos casos, y de paso
+  sirve para un gimnasio con cupo 20.
+- **`abonos`** — el crédito del cliente: cuántas clases, cuántas usó, cuándo
+  vence, qué operación lo pagó.
+- **`lista_espera`** — quién quiere entrar a una franja llena, y en qué orden.
+- **`horas`** — las horas de cada persona por día, con su origen: propuestas
+  desde la agenda o cargadas a mano.
+- **`liquidaciones`** — período, persona, horas, valor, total, estado.
+- **`liquidacion_notas`** — los reemplazos y lo que haga falta, **pegados al
+  período que se está liquidando**. Ahí es donde tienen sentido: son la
+  explicación de por qué esas horas no cierran con lo habitual.
+- **`suplencias`** — franja, titular, suplente, motivo.
+- **`menu_rubro`** — los grupos y módulos de cada rubro, y las palabras.
+
+### Cambios sobre lo que existe
+
+`reservas` gana `franja_id`, `personal_id`, `item_id` y `abono_id`: hoy sabe
+la sala pero no quién atiende ni qué se hace.
+
+Los planes y los packs **son items del catálogo**, con `tipo = 'plan'`.
+Abajo siempre son un item —así entran en el cobro, la caja y los informes
+sin nada nuevo— y lo que el comercio elige es desde qué pantalla los
+administra. Un modelo, dos puertas.
+
+### Funciones de Postgres
+
+Por la regla 5 de `ARQUITECTURA.md`, lo que toca varias tablas no se resuelve
+con varias llamadas desde el navegador:
+
+| Función | Qué hace |
+|---|---|
+| `disponibilidad(...)` | Los huecos reales, cruzando horarios, franjas, salas y excepciones. La usan la agenda y el turno online |
+| `reservar_turno(jsonb)` | Valida cupo, sala, profesional y tope del plan; descuenta del abono |
+| `marcar_asistencia(...)` | Aplica la política de ausencias y consume el crédito |
+| `cancelar_turno(...)` | Aplica la ventana de cancelación, libera el lugar y avisa a la lista de espera |
+| `vender_abono(...)` | Crea el crédito al confirmar la venta |
+| `liquidar(...)` | Arma la liquidación de un período y genera el egreso al pagarla |
+
+## Lo que es configuración, no código
+
+Cada comercio decide, y el sistema soporta las variantes desde el principio:
+
+- **Ausencias**: pierde la clase, la pierde salvo que avise a tiempo, o la
+  recupera. El tercero obliga a llevar un saldo de clases a recuperar aparte
+  del crédito normal, y por eso hay que preverlo ahora.
+- **Ventanas**: cuántas horas antes se confirma y hasta cuándo se cancela sin
+  perder. Las maquetas usan 12 y 24 horas.
+- **Planes**: libres o con tope semanal. El tope se controla **al reservar**,
+  no al cobrar: es la diferencia entre un sistema que sirve y uno que
+  registra.
+- **Vencimiento de packs.**
+- **Modalidad de pago al personal**: por hora, por clase, por comisión sobre
+  el servicio, o sueldo fijo. Las cuatro, y por persona. **Por hora es el
+  valor de fábrica** —es lo que usa el primer negocio— pero ninguna puede
+  estar escrita en el código: una maqueta muestra "40% de comisión" y un
+  comercio va a querer fijo. Es un sistema que se adapta, no que impone.
+- **Reemplazos**: si al titular se le paga igual o no. Por defecto cobra
+  quien trabajó.
+- **Cierre de la semana de liquidación** y **redondeo de horas**: una clase
+  de 55 minutos, ¿es una hora? ¿el hueco entre dos clases cuenta?
+
+## Las etapas
+
+Cada una tiene que dejar algo usable.
+
+0. **Clientes a la base** y **el menú como dato**. Habilita todo lo demás y
+   le sirve también a los comercios que ya existen.
+1. **Servicios, salas, personal y horarios.** El catálogo del rubro.
+2. **Agenda.** Turnos individuales y grupales, cupo, estados, asistencia.
+   Con esto solo ya reemplaza el cuaderno.
+3. **Ventas.** Abonos, packs y planes; cobrar desde el turno; presupuestos.
+   Sin esto la plata no cierra.
+4. **Finanzas.** Ingresos, egresos, pendientes y el corte mensual.
+5. **Personal.** Horas, liquidación semanal, suplencias y notas.
+6. **Lista de espera y reprogramación.**
+7. **Turnos online.** Página pública sin login.
+8. **CRM y Comunicaciones.**
+9. **Permisos configurables y auditoría.**
+
+El orden no es negociable en un punto: los turnos online van después de los
+horarios y de la asistencia. Ofrecer turnos sin horarios cargados no se
+puede, y sin asistencia la agenda se llena de gente que no viene.
+
+## Dos cosas que arrastra el proyecto
+
+**Los clientes están en memoria.** La tabla existe en la base pero la
+pantalla usa datos simulados que se pierden al refrescar. Un turno sin
+cliente de verdad no sirve, así que migrarlos es la primera tarea.
+
+**La fecha congelada.** Varios cálculos usan un "hoy" fijo del 9 de agosto
+de 2026, heredado del prototipo. Una agenda no puede vivir con eso: este
+módulo usa la fecha real y va a convivir un tiempo con pantallas que todavía
+usan la vieja.
+
+## Fuera de alcance por ahora
+
+Cobro recurrente automático de cuotas, autenticación en dos pasos, sesiones
+activas, campañas automatizadas, y cualquier integración de mensajería que
+no sea abrir WhatsApp con el mensaje ya escrito.
+
+## Lo que todavía falta saber
+
+- **Los datos reales del negocio, que son todos.** Lo que se ve en las
+  maquetas —los nueve servicios con su precio, las salas, los profesionales,
+  los packs— es inventado, confirmado por el cliente. Hasta que lleguen los
+  de verdad, la semilla va marcada como demo y se borra de una, igual que la
+  del Bar Rivadavia. Hacen falta: servicios con duración y precio, salas con
+  capacidad, la gente con su valor hora, los horarios de cada uno, y los
+  planes y packs que vende hoy.
+- Si se cobra seña al reservar online.
+- Cuántas sucursales.
+- El nombre exacto del rubro, que es lo que después permite vender "Genez
+  para gimnasios" sin tocar nada.

--- a/docs/pedido-negocios-de-servicios.md
+++ b/docs/pedido-negocios-de-servicios.md
@@ -18,6 +18,29 @@ Un motor único —clientes, servicios, turnos, profesionales, recursos,
 ventas, finanzas— con **configuraciones verticales encima**. No un sistema
 por rubro.
 
+## Dónde vive el personal
+
+Lo que en este documento se llamó "el módulo de personal" **no es una
+sección**: se parte en dos, y el corte es el mismo que usa el resto del
+sistema —la operación por un lado, la plata por el otro—.
+
+- **Clientes y equipo → Equipo.** Quiénes son, qué servicios da cada uno,
+  horarios, ausencias, vacaciones y suplencias. Es lo que la agenda
+  necesita para poder ofrecer un turno.
+- **Finanzas → Liquidaciones.** Horas del período, valor hora, total y el
+  pago. Con las notas de reemplazo al costado.
+
+Van separadas porque **pagarle a alguien es un egreso**. Con la liquidación
+adentro de "Clientes y equipo", Finanzas no se entera del gasto más grande
+y más regular del negocio, y los egresos del mes mienten. Al marcarse
+pagada, la liquidación genera el movimiento y la caja cierra sola.
+
+Además las usan personas distintas: recepción mira Equipo todos los días
+—quién cubre, quién faltó—; el dueño mira Liquidaciones una vez por semana.
+
+Las horas las **propone** la agenda sumando las clases dadas y se corrigen
+a mano en la liquidación, que es el momento en que se las mira.
+
 La misma regla que el centro de pedidos: no crear nada paralelo. El
 catálogo, los clientes, las operaciones, la caja, los pagos, los permisos y
 la impresión ya existen y se reusan.

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -532,6 +532,119 @@ await comoUsuario(MOZO, async () => {
   decir(v.n === 0, `un comercio no ve el equipo ni los sueldos de otro (${v.n} de ${CON_EQUIPO})`);
 });
 
+/* ------------------------------------------------------------
+   11 · La agenda
+
+   Dos cosas distintas se prueban acá. Una es el aislamiento: que nadie
+   agende adentro de otro comercio ni con la sala o la persona de otro.
+   La otra son los choques, que tienen que impedirse en la base y no en la
+   pantalla: dos personas agendando desde dos dispositivos al mismo tiempo
+   solo se resuelven acá.
+   ------------------------------------------------------------ */
+console.log("\nAgenda");
+
+const ALMHA = await una("select id from empresas where nombre = 'Almha'");
+
+if (!ALMHA) {
+  decir(false, "hace falta Almha para probar la agenda (corré supabase/seed/almha.sql)");
+} else {
+  const SOFIA = await una(
+    "select id from personal where empresa_id = $1 and nombre = 'Sofía González'", [ALMHA.id]);
+  const SALA = await una(
+    "select id from recursos where empresa_id = $1 order by orden limit 1", [ALMHA.id]);
+  const SERVICIO = await una(
+    "select id, duracion_min from items where empresa_id = $1 and tipo = 'servicio' limit 1", [ALMHA.id]);
+  /* Un lunes a las 9 hora de Buenos Aires, que es cuando Sofía trabaja. */
+  const CUANDO = (await una(
+    `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+             + interval '9 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
+
+  const turno = (extra = {}) => JSON.stringify({
+    empresa_id: ALMHA.id, personal_id: SOFIA.id, recurso_id: SALA.id,
+    item_id: SERVICIO.id, nombre: "Prueba RLS", desde: CUANDO,
+    duracion_min: 60, ...extra,
+  });
+
+  await comoUsuario(PLATAFORMA, async () => {
+    const t1 = await una("select agendar_turno($1::jsonb) id", [turno()]);
+    decir(!!t1.id, "se puede agendar un turno");
+
+    const leido = await una(
+      "select servicio, profesional, sala from agenda_vista where id = $1", [t1.id]);
+    decir(leido && leido.profesional === "Sofía González" && !!leido.servicio && !!leido.sala,
+      `la vista resuelve los nombres (${leido ? leido.servicio + " · " + leido.sala : "nada"})`);
+
+    /* Cada choque va en su savepoint: si no, el primer error aborta la
+       transacción entera y las pruebas de abajo no llegan a correr. */
+    const choque = async (etiqueta, args, codigo) => {
+      await c.query("savepoint ch");
+      try {
+        await c.query("select agendar_turno($1::jsonb)", [args]);
+        await c.query("rollback to savepoint ch");
+        decir(false, etiqueta);
+      } catch (e) {
+        await c.query("rollback to savepoint ch");
+        decir(e.code === codigo, `${etiqueta}${e.code === codigo ? "" : ` (dio ${e.code})`}`);
+      }
+    };
+
+    await choque("no deja pisar la misma sala", turno({ personal_id: null }), "P0034");
+    await choque("no deja pisarle el horario a la misma persona", turno({ recurso_id: null }), "P0035");
+
+    const tarde = (await una(
+      `select ($1::timestamptz + interval '12 hours') as t`, [CUANDO])).t;
+    await choque("no deja agendar fuera del horario de la persona",
+      turno({ desde: tarde, recurso_id: null }), "P0036");
+
+    await choque("no deja usar una sala de otro comercio",
+      turno({ recurso_id: (await una("select id from recursos where empresa_id <> $1 limit 1", [ALMHA.id])).id, personal_id: null }),
+      "P0032");
+
+    /* La persona ajena se crea acá adentro: hoy solo Almha tiene equipo,
+       y buscar una que no existe devolvía null, con lo cual la validación
+       se salteaba y la prueba pasaba sin probar nada. Se va con el
+       rollback junto con todo lo demás. */
+    const otraEmpresa = await una("select id from empresas where id <> $1 limit 1", [ALMHA.id]);
+    const ajena = await una(
+      `insert into personal (empresa_id, nombre, tipo) values ($1, 'Prueba ajena', 'profesional') returning id`,
+      [otraEmpresa.id]);
+    await choque("no deja usar una persona de otro comercio",
+      turno({ personal_id: ajena.id, recurso_id: null }), "P0033");
+
+    /* Reprogramar usa las mismas reglas e ignora al propio turno: moverlo
+       media hora no puede chocar contra sí mismo. */
+    const media = (await una(`select ($1::timestamptz + interval '30 minutes') as t`, [CUANDO])).t;
+    await c.query("select mover_turno($1, $2)", [t1.id, media]);
+    decir(true, "se puede reprogramar sin chocar contra sí mismo");
+
+    /* Un bloqueo tapa el horario aunque no haya ningún turno. */
+    await c.query(
+      `insert into excepciones (empresa_id, personal_id, desde, hasta, motivo)
+       values ($1, $2, $3::timestamptz + interval '3 hours', $3::timestamptz + interval '4 hours', 'ausencia')`,
+      [ALMHA.id, SOFIA.id, CUANDO]);
+    await choque("no deja agendar sobre una ausencia",
+      turno({ desde: (await una(`select ($1::timestamptz + interval '3 hours') as t`, [CUANDO])).t, recurso_id: null }),
+      "P0037");
+  });
+
+  /* Y el aislamiento, desde otro comercio. */
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from agenda_vista where empresa_id = $1", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve los turnos de otro");
+
+    await c.query("savepoint ag");
+    let pudo = false;
+    try {
+      await c.query("select agendar_turno($1::jsonb)", [turno()]);
+      pudo = true;
+      await c.query("rollback to savepoint ag");
+    } catch {
+      await c.query("rollback to savepoint ag");
+    }
+    decir(!pudo, "un comercio no puede agendar adentro de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -466,6 +466,44 @@ await comoUsuario(PLATAFORMA, async () => {
   decir(u.rowCount === 1, "la plataforma sí puede editar un rubro");
 });
 
+/* ------------------------------------------------------------
+   9 · La plataforma ve todo, y por eso la aplicación tiene que filtrar
+
+   Esto NO es un agujero: es lo que hace que el panel de plataforma pueda
+   existir. Lo que sí fue un error es haberse apoyado en RLS para saber de
+   qué comercio era cada fila.
+
+   RLS contesta "¿podés ver esto?". No contesta "¿de qué comercio es?".
+   Para un usuario de comercio las dos respuestas coinciden y por eso el
+   problema no aparecía nunca... hasta que el dueño de plataforma entró
+   como Almha y se le cargaron los 972 productos de Super 25, con la
+   Coca-Cola apareciendo en el informe de una estética.
+
+   Esta prueba deja escrito el comportamiento para que nadie lo "arregle"
+   apretando la política: si alguien la cambia, el panel de plataforma deja
+   de funcionar. Lo que tiene que filtrar es cada consulta de `src/datos/`,
+   con su `empresa_id` explícito.
+   ------------------------------------------------------------ */
+console.log("\nAlcance de la plataforma");
+
+const TOTAL_ITEMS = (await una("select count(*)::int n from items where tipo = 'producto'")).n;
+
+await comoUsuario(PLATAFORMA, async () => {
+  const v = await una("select count(*)::int n from items_vista where tipo = 'producto'");
+  decir(v.n === TOTAL_ITEMS, `sin filtro ve el catálogo de todos los comercios (${v.n} de ${TOTAL_ITEMS})`);
+
+  const emp = await una("select empresa_id from empresas e join items i on i.empresa_id = e.id where e.nombre = 'Almha' limit 1");
+  if (emp) {
+    const propio = await una("select count(*)::int n from items_vista where tipo = 'producto' and empresa_id = $1", [emp.empresa_id]);
+    decir(propio.n < TOTAL_ITEMS, `filtrando por empresa ve solo lo de ese comercio (${propio.n})`);
+  }
+});
+
+await comoUsuario(MOZO, async () => {
+  const v = await una("select count(*)::int n from items_vista where tipo = 'producto'");
+  decir(v.n > 0 && v.n < TOTAL_ITEMS, `un comercio, en cambio, nunca ve el catálogo de otro (${v.n} de ${TOTAL_ITEMS})`);
+});
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -765,6 +765,136 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   13 · Abonos
+
+   Lo que se prueba es el crédito: que se descuente al reservar, que
+   vuelva al cancelar y que el tope semanal no se pueda pasar. Y que el
+   saldo salga de los turnos y no de un contador, que es lo que evita que
+   se desincronice.
+   ------------------------------------------------------------ */
+console.log("\nAbonos");
+
+if (ALMHA) {
+  const SOFIA = await una("select id from personal where empresa_id = $1 and nombre = 'Sofía González'", [ALMHA.id]);
+  /* Un lunes bastante adelante, por dos razones.
+
+     Una: el abono arranca hoy, así que reservar contra él para un día que
+     ya pasó da "el abono arranca el 22/08", que es correcto y no es lo que
+     se quiere probar.
+
+     Dos, y más importante: estas pruebas corren contra la base de verdad,
+     donde hay turnos que alguien cargó de verdad. Elegir un horario
+     cercano hace que la prueba choque contra el trabajo real de alguien y
+     falle por un motivo que no tiene nada que ver con lo que prueba. Ya
+     pasó: el lunes que viene a las nueve estaba ocupado.
+
+     Sigue dentro de la vigencia de 60 días del plan de prueba. */
+  const LUNES = (await una(
+    `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+             + interval '28 days' + interval '9 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
+
+  await comoUsuario(PLATAFORMA, async () => {
+    /* El plan va al catálogo como cualquier otro item. */
+    const plan = await una(
+      `insert into items (empresa_id, tipo, nombre, precio, controla_stock, campos_extra)
+       values ($1, 'plan', 'Pack 3 clases', 30000, false,
+               '{"clases":3,"vigenciaDias":60,"topeSemanal":2}'::jsonb)
+       returning id`, [ALMHA.id]);
+    decir(!!plan.id, "un plan es un item del catálogo");
+
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Compradora') returning id`, [ALMHA.id]);
+
+    /* Cobrar un abono es cobrar: sin caja abierta la base lo rechaza,
+       igual que cualquier venta (regla 4). */
+    const ses = await una(
+      `insert into sesiones_caja (empresa_id, monto_inicial) values ($1, 0) returning id`, [ALMHA.id]);
+
+    const abono = await una("select vender_abono($1::jsonb) id", [JSON.stringify({
+      empresa_id: ALMHA.id, cliente_id: cli.id, item_id: plan.id,
+      sesion_id: ses.id,
+      pagos: [{ medio: "efectivo", monto: 30000 }],
+    })]);
+    decir(!!abono.id, "vender el abono crea el crédito");
+
+    /* La venta pasó por el camino de siempre: hay operación, línea y pago. */
+    const venta = await una(
+      `select o.total::float t, count(l.id)::int lineas,
+              (select count(*)::int from pagos where operacion_id = o.id) pagos,
+              (select count(*)::int from movimientos_caja where operacion_id = o.id) caja
+         from abonos a
+         join operaciones o on o.id = a.operacion_id
+         left join operacion_lineas l on l.operacion_id = o.id
+        where a.id = $1 group by o.id, o.total`, [abono.id]);
+    decir(venta && venta.t === 30000 && venta.lineas === 1 && venta.pagos === 1 && venta.caja === 1,
+      `la venta entra por el camino de siempre (línea, pago y caja)`);
+
+    const v0 = await una("select clases, usadas, restantes, estado from abonos_vista where id = $1", [abono.id]);
+    decir(Number(v0.restantes) === 3 && v0.estado === "activo", `arranca con ${v0.restantes} de ${v0.clases}`);
+
+    const conAbono = (dias, extra = {}) => JSON.stringify({
+      empresa_id: ALMHA.id, cliente_id: cli.id, abono_id: abono.id,
+      personal_id: SOFIA.id, nombre: "Compradora",
+      desde: new Date(new Date(LUNES).getTime() + dias * 86400000).toISOString(),
+      duracion_min: 60, ...extra,
+    });
+
+    const t1 = await una("select agendar_turno($1::jsonb) id", [conAbono(0)]);
+    const v1 = await una("select restantes from abonos_vista where id = $1", [abono.id]);
+    decir(Number(v1.restantes) === 2, `reservar descuenta una (${v1.restantes} restantes)`);
+
+    /* El tope es de dos por semana: la tercera del lunes al domingo no entra. */
+    await c.query("select agendar_turno($1::jsonb)", [conAbono(2)]);
+    await c.query("savepoint tope");
+    try {
+      await c.query("select agendar_turno($1::jsonb)", [conAbono(4)]);
+      await c.query("rollback to savepoint tope");
+      decir(false, "no deja pasar el tope semanal");
+    } catch (e) {
+      await c.query("rollback to savepoint tope");
+      decir(e.code === "P0059", `no deja pasar el tope semanal${e.code === "P0059" ? "" : ` (dio ${e.code})`}`);
+    }
+
+    /* Cancelar devuelve la clase. */
+    await c.query("update reservas set estado = 'cancelada' where id = $1", [t1.id]);
+    const v2 = await una("select restantes from abonos_vista where id = $1", [abono.id]);
+    decir(Number(v2.restantes) === 2, `cancelar devuelve la clase (${v2.restantes} restantes)`);
+
+    /* Faltar la gasta o no, según el comercio. */
+    await c.query("update reservas set estado = 'ausente' where id = $1", [t1.id]);
+    const conPolitica = await una("select restantes from abonos_vista where id = $1", [abono.id]);
+    decir(Number(conPolitica.restantes) === 1, "por defecto, faltar gasta la clase");
+
+    await c.query(
+      `update empresas set config = jsonb_set(config, '{turnos}', '{"ausenciaConsume": false}'::jsonb) where id = $1`,
+      [ALMHA.id]);
+    const sinCastigo = await una("select restantes from abonos_vista where id = $1", [abono.id]);
+    decir(Number(sinCastigo.restantes) === 2, "con la política del comercio en no, la devuelve");
+
+    /* Un abono es de quien lo compró. */
+    const otro = await una(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Otro') returning id`, [ALMHA.id]);
+    await c.query("savepoint aj");
+    try {
+      await c.query("select agendar_turno($1::jsonb)", [JSON.stringify({
+        empresa_id: ALMHA.id, cliente_id: otro.id, abono_id: abono.id,
+        nombre: "Otro", desde: new Date(new Date(LUNES).getTime() + 6 * 86400000).toISOString(), duracion_min: 60,
+      })]);
+      await c.query("rollback to savepoint aj");
+      decir(false, "no deja usar el abono de otra persona");
+    } catch (e) {
+      await c.query("rollback to savepoint aj");
+      decir(e.code === "P0055", "no deja usar el abono de otra persona");
+    }
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from abonos where empresa_id = $1", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve los abonos de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -424,6 +424,48 @@ await comoUsuario(MOZO, async () => {
   decir(!colado, "no puede crear un cliente en otro comercio");
 });
 
+/* ------------------------------------------------------------
+   8 · El menú lo lee cualquiera, lo escribe la plataforma
+
+   Los rubros no son datos de un comercio sino la forma del producto, así
+   que la política es al revés que en todo lo demás: leer, todos; escribir,
+   solo plataforma. Si esto se invirtiera, un comercio podría reacomodarle
+   el menú a los otros.
+   ------------------------------------------------------------ */
+console.log("\nRubros");
+
+const PLATAFORMA = "nehuengonzalez1@gmail.com";
+
+await comoUsuario(MOZO, async () => {
+  const mio = await una(
+    `select r.clave, jsonb_array_length(r.menu) grupos
+     from rubros r join empresas e on e.rubro = r.clave
+     where e.id = (select empresa_id from perfiles where id = auth.uid())`);
+  decir(!!mio && mio.grupos > 0, `lee el menú de su rubro (${mio ? mio.clave : "ninguno"})`);
+
+  const otros = await una("select count(*)::int n from rubros");
+  decir(otros.n >= 3, `ve los demás rubros, que no son secreto (${otros.n})`);
+
+  const u = await c.query("update rubros set nombre = 'Pirateado' where clave = 'servicios'");
+  decir(u.rowCount === 0, "no puede reacomodarle el menú a otro rubro");
+
+  await c.query("savepoint ru");
+  let creo = false;
+  try {
+    await c.query("insert into rubros (clave, nombre) values ('trucho', 'Trucho')");
+    creo = true;
+    await c.query("rollback to savepoint ru");
+  } catch {
+    await c.query("rollback to savepoint ru");
+  }
+  decir(!creo, "no puede inventar un rubro");
+});
+
+await comoUsuario(PLATAFORMA, async () => {
+  const u = await c.query("update rubros set orden = orden where clave = 'servicios'");
+  decir(u.rowCount === 1, "la plataforma sí puede editar un rubro");
+});
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -369,6 +369,61 @@ await comoUsuario(MOZO, async () => {
   decir(d.rowCount === 0, "no se puede borrar un asiento");
 });
 
+/* ------------------------------------------------------------
+   7 · Los clientes son de cada comercio
+
+   Dejaron de vivir en memoria, así que ahora lo que separa la cartera
+   de un comercio de la del otro es una política y nada más.
+   ------------------------------------------------------------ */
+console.log("\nClientes");
+
+/* La empresa ajena se busca ACÁ, como administrador, y no adentro de la
+   sesión del mozo: ahí RLS también le tapa `empresas`, la consulta volvía
+   vacía y las dos pruebas que importan se salteaban sin decir nada. */
+const OTRA = await una(
+  "select e.id from empresas e where e.id <> (select empresa_id from perfiles p join auth.users u on u.id = p.id where u.email = $1) limit 1",
+  [MOZO]);
+
+await comoUsuario(MOZO, async () => {
+  const emp = await una("select empresa_id from perfiles where id = auth.uid()");
+
+  const nuevo = await una(
+    `insert into clientes (empresa_id, razon_social, tipo_doc, doc, condicion)
+     values ($1, 'Prueba RLS', 'DNI', '12345678', 'CF') returning id`,
+    [emp.empresa_id]);
+  decir(!!nuevo.id, "puede dar de alta un cliente propio");
+
+  const leido = await una("select razon_social from clientes where id = $1", [nuevo.id]);
+  decir(leido && leido.razon_social === "Prueba RLS", "lo vuelve a leer");
+
+  const u = await c.query("update clientes set tel = '11 0000 0000' where id = $1", [nuevo.id]);
+  decir(u.rowCount === 1, "puede editarlo");
+
+  /* Desactivar y no borrar: un cliente con ventas atrás dejaría
+     comprobantes emitidos sin a quién apuntar. */
+  const b = await c.query("update clientes set activo = false where id = $1", [nuevo.id]);
+  decir(b.rowCount === 1, "puede desactivarlo");
+
+  /* Lo que de verdad importa: la cartera del comercio de al lado. */
+  if (!OTRA) { decir(false, "hace falta una segunda empresa para probar el aislamiento"); return; }
+
+  const cuantos = await una(
+    "select count(*)::int n from clientes where empresa_id = $1", [OTRA.id]);
+  decir(cuantos.n === 0, "no ve los clientes de otro comercio");
+
+  let colado = false;
+  await c.query("savepoint cl");
+  try {
+    await c.query(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Colado')`, [OTRA.id]);
+    colado = true;
+    await c.query("rollback to savepoint cl");
+  } catch {
+    await c.query("rollback to savepoint cl");
+  }
+  decir(!colado, "no puede crear un cliente en otro comercio");
+});
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -645,6 +645,126 @@ if (!ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   12 · Clases grupales
+
+   Lo que se prueba acá es el cupo, que es donde esto se rompe feo: dos
+   personas apretando "anotar" sobre el último lugar tienen que terminar
+   con una adentro y una afuera, no con siete en una clase de seis.
+
+   Y lo otro es que las inscripciones NO ocupen la sala. Si ocuparan, la
+   segunda persona de una clase daría "sala ocupada" y nadie podría
+   anotarse.
+   ------------------------------------------------------------ */
+console.log("\nClases grupales");
+
+if (ALMHA) {
+  const SOFIA = await una("select id from personal where empresa_id = $1 and nombre = 'Sofía González'", [ALMHA.id]);
+  const SALA = await una(
+    "select id, capacidad from recursos where empresa_id = $1 and capacidad >= 6 order by orden limit 1", [ALMHA.id]);
+  const GRUPAL = await una(
+    `select id from items where empresa_id = $1 and tipo = 'servicio'
+       and campos_extra ->> 'modalidad' = 'grupal' limit 1`, [ALMHA.id]);
+  const CUANDO = (await una(
+    `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+             + interval '10 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
+
+  await comoUsuario(PLATAFORMA, async () => {
+    const clase = await una("select crear_clase($1::jsonb) id", [JSON.stringify({
+      empresa_id: ALMHA.id, personal_id: SOFIA.id, recurso_id: SALA.id,
+      item_id: GRUPAL.id, nombre: "Reformer intermedio", desde: CUANDO,
+      duracion_min: 60, cupo: 3,
+    })]);
+    decir(!!clase.id, "se puede abrir una clase");
+
+    const vacia = await una(
+      "select forma, cupo, anotados, lugares from agenda_vista where id = $1", [clase.id]);
+    decir(vacia.forma === "clase" && vacia.anotados === "0" && Number(vacia.lugares) === 3,
+      `la clase existe sin nadie anotado (${vacia.lugares} lugares)`);
+
+    /* Tres inscripciones entran; la cuarta no. Y ninguna tiene que dar
+       "sala ocupada": ahí estaba el error que esta migración corrige. */
+    for (let i = 1; i <= 3; i++) {
+      try {
+        await c.query("select inscribir($1::jsonb)", [JSON.stringify({ clase_id: clase.id, nombre: `Alumna ${i}` })]);
+        decir(true, `entra la alumna ${i}`);
+      } catch (e) {
+        decir(false, `entra la alumna ${i} (${e.message})`);
+      }
+    }
+
+    await c.query("savepoint cl");
+    try {
+      await c.query("select inscribir($1::jsonb)", [JSON.stringify({ clase_id: clase.id, nombre: "Alumna 4" })]);
+      await c.query("rollback to savepoint cl");
+      decir(false, "no deja pasarse del cupo");
+    } catch (e) {
+      await c.query("rollback to savepoint cl");
+      decir(e.code === "P0045", `no deja pasarse del cupo${e.code === "P0045" ? "" : ` (dio ${e.code})`}`);
+    }
+
+    /* La misma persona dos veces ocupa un lugar que otro necesitaba. */
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Cliente prueba') returning id`, [ALMHA.id]);
+    /* Sin sala ni profesor: si los tuviera chocaría con la clase de
+       arriba, que ocupa esa sala a esa hora. */
+    const clase2 = await una("select crear_clase($1::jsonb) id", [JSON.stringify({
+      empresa_id: ALMHA.id, item_id: GRUPAL.id, nombre: "Otra",
+      desde: CUANDO, duracion_min: 60, cupo: 4,
+    })]);
+    await c.query("select inscribir($1::jsonb)", [JSON.stringify({ clase_id: clase2.id, cliente_id: cli.id, nombre: "Cliente prueba" })]);
+    await c.query("savepoint dup");
+    try {
+      await c.query("select inscribir($1::jsonb)", [JSON.stringify({ clase_id: clase2.id, cliente_id: cli.id, nombre: "Cliente prueba" })]);
+      await c.query("rollback to savepoint dup");
+      decir(false, "no deja anotar dos veces a la misma persona");
+    } catch (e) {
+      await c.query("rollback to savepoint dup");
+      decir(e.code === "P0046", "no deja anotar dos veces a la misma persona");
+    }
+
+    /* El cupo no puede pasarse de lo que entra en la sala. */
+    await c.query("savepoint cap");
+    try {
+      await c.query("select crear_clase($1::jsonb)", [JSON.stringify({
+        empresa_id: ALMHA.id, recurso_id: SALA.id, nombre: "Imposible",
+        desde: CUANDO, duracion_min: 60, cupo: (SALA.capacidad || 6) + 10,
+      })]);
+      await c.query("rollback to savepoint cap");
+      decir(false, "no deja abrir una clase más grande que la sala");
+    } catch (e) {
+      await c.query("rollback to savepoint cap");
+      decir(e.code === "P0041", "no deja abrir una clase más grande que la sala");
+    }
+
+    /* Y la clase sí ocupa: un turno individual encima tiene que chocar. */
+    await c.query("savepoint enc");
+    try {
+      await c.query("select agendar_turno($1::jsonb)", [JSON.stringify({
+        empresa_id: ALMHA.id, recurso_id: SALA.id, nombre: "Encima",
+        desde: CUANDO, duracion_min: 60,
+      })]);
+      await c.query("rollback to savepoint enc");
+      decir(false, "una clase ocupa la sala para un turno individual");
+    } catch (e) {
+      await c.query("rollback to savepoint enc");
+      decir(e.code === "P0034", "una clase ocupa la sala para un turno individual");
+    }
+
+    /* La lista de espera. */
+    await c.query(
+      `insert into espera (empresa_id, clase_id, nombre) values ($1, $2, 'La que espera')`,
+      [ALMHA.id, clase.id]);
+    const esp = await una("select esperando from agenda_vista where id = $1", [clase.id]);
+    decir(Number(esp.esperando) === 1, "la lista de espera cuenta en la vista");
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from espera where empresa_id = $1", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve la lista de espera de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -504,6 +504,34 @@ await comoUsuario(MOZO, async () => {
   decir(v.n > 0 && v.n < TOTAL_ITEMS, `un comercio, en cambio, nunca ve el catálogo de otro (${v.n} de ${TOTAL_ITEMS})`);
 });
 
+/* ------------------------------------------------------------
+   10 · Las vistas no pueden ser una puerta de atrás
+
+   Una vista sin `security_invoker` corre con los permisos de quien la
+   creó y saltea RLS por completo. Es un error silencioso: la vista
+   funciona, devuelve datos, y recién se nota cuando alguien ve lo que no
+   tenía que ver. `equipo_vista` nació así y expuso los sueldos de todos
+   los comercios hasta que se corrigió.
+
+   Se comprueban todas de una: la próxima que se agregue mal, cae acá.
+   ------------------------------------------------------------ */
+console.log("\nVistas");
+
+const VISTAS = (await c.query(
+  `select c.relname, coalesce(array_to_string(c.reloptions, ','), '') as opciones
+     from pg_class c join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public' and c.relkind = 'v' order by 1`)).rows;
+
+for (const v of VISTAS) {
+  decir(v.opciones.includes("security_invoker=true"), `${v.relname} respeta RLS`);
+}
+
+const CON_EQUIPO = (await una("select count(*)::int n from personal")).n;
+await comoUsuario(MOZO, async () => {
+  const v = await una("select count(*)::int n from equipo_vista");
+  decir(v.n === 0, `un comercio no ve el equipo ni los sueldos de otro (${v.n} de ${CON_EQUIPO})`);
+});
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -895,6 +895,91 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   14 · Liquidaciones
+
+   Lo que importa acá es que pagarle a alguien deje su egreso: si la
+   liquidación no genera el movimiento, los egresos del mes mienten y el
+   gasto más grande del negocio no aparece en ningún lado.
+   ------------------------------------------------------------ */
+console.log("\nLiquidaciones");
+
+if (ALMHA) {
+  const SOFIA = await una("select id, valor::float v from personal where empresa_id = $1 and nombre = 'Sofía González'", [ALMHA.id]);
+
+  await comoUsuario(PLATAFORMA, async () => {
+    /* Un par de turnos suyos, en un período apartado para no mezclarse
+       con los que alguien haya cargado de verdad. */
+    const lunes = (await una(
+      `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+               + interval '35 days' + interval '9 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
+
+    for (const d of [0, 2]) {
+      await c.query("select agendar_turno($1::jsonb)", [JSON.stringify({
+        empresa_id: ALMHA.id, personal_id: SOFIA.id, nombre: "Alguien",
+        desde: new Date(new Date(lunes).getTime() + d * 86400000).toISOString(),
+        duracion_min: 60,
+      })]);
+    }
+
+    const desde = (await una(`select ($1::timestamptz at time zone 'America/Argentina/Buenos_Aires')::date d`, [lunes])).d;
+    const hasta = (await una(`select (($1::timestamptz + interval '6 days') at time zone 'America/Argentina/Buenos_Aires')::date d`, [lunes])).d;
+
+    const liq = await una("select liquidar($1, $2, $3) id", [SOFIA.id, desde, hasta]);
+    decir(!!liq.id, "se arma la liquidación del período");
+
+    const v = await una("select horas::float h, total::float t, a_pagar::float p, estado from liquidaciones_vista where id = $1", [liq.id]);
+    decir(v.h === 2, `las horas salen de la agenda (${v.h} hs)`);
+    decir(v.t === SOFIA.v * 2, `el total usa su valor hora (${v.t})`);
+
+    /* Volver a armarla no duplica ni pisa el ajuste cargado a mano. */
+    await c.query("update liquidaciones set ajuste = 5000 where id = $1", [liq.id]);
+    await c.query("select liquidar($1, $2, $3)", [SOFIA.id, desde, hasta]);
+    const v2 = await una("select ajuste::float a, a_pagar::float p from liquidaciones_vista where id = $1", [liq.id]);
+    decir(v2.a === 5000, "recalcular respeta el ajuste cargado a mano");
+
+    /* Y lo que de verdad importa: pagar deja el egreso. */
+    const antes = (await una("select count(*)::int n from movimientos_caja where empresa_id = $1 and tipo = 'egreso'", [ALMHA.id])).n;
+    await c.query("select pagar_liquidacion($1, 'transferencia')", [liq.id]);
+    const despues = (await una("select count(*)::int n from movimientos_caja where empresa_id = $1 and tipo = 'egreso'", [ALMHA.id])).n;
+    decir(despues === antes + 1, "pagarla deja el egreso en la caja");
+
+    const mov = await una(
+      `select m.monto::float mo, m.categoria, m.sesion_id
+         from liquidaciones l join movimientos_caja m on m.id = l.movimiento_id
+        where l.id = $1`, [liq.id]);
+    decir(mov && mov.mo === v2.p && mov.categoria === "sueldos",
+      `el egreso es por lo que se paga y va como sueldo (${mov ? mov.mo : "?"})`);
+    decir(mov && mov.sesion_id === null,
+      "se puede pagar por transferencia sin caja abierta");
+
+    await c.query("savepoint dos");
+    try {
+      await c.query("select pagar_liquidacion($1, 'efectivo')", [liq.id]);
+      await c.query("rollback to savepoint dos");
+      decir(false, "no deja pagar dos veces la misma liquidación");
+    } catch (e) {
+      await c.query("rollback to savepoint dos");
+      decir(e.code === "P0061", "no deja pagar dos veces la misma liquidación");
+    }
+
+    await c.query("savepoint rec");
+    try {
+      await c.query("select liquidar($1, $2, $3)", [SOFIA.id, desde, hasta]);
+      await c.query("rollback to savepoint rec");
+      decir(false, "no deja recalcular una liquidación ya pagada");
+    } catch (e) {
+      await c.query("rollback to savepoint rec");
+      decir(e.code === "P0061", "no deja recalcular una liquidación ya pagada");
+    }
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from liquidaciones where empresa_id = $1", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve las liquidaciones de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/src/Genezapp.jsx
+++ b/src/Genezapp.jsx
@@ -5,6 +5,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { Login, ClaveNueva, Sistema, PanelGenez } from "./genez/PanelGenez.jsx";
 import { cargarSesion, cargarComercios, salir, alRecuperarClave } from "./datos/sesion.js";
+import { cargarRubro } from "./datos/rubros.js";
 
 /* La sesión sobrevive al refresco: Supabase la guarda en el navegador.
    Mientras se resuelve no se puede mostrar ni el login ni el sistema,
@@ -26,6 +27,8 @@ export default function App() {
   const [tema, setTema] = useState("oscuro");
   const [imagenFondo, setImagenFondo] = useState(null);   // fondo propio del login
   const [iniciando, setIniciando] = useState(true);
+  /* undefined = todavía no se sabe. Distinto de null, que es "no tiene". */
+  const [rubro, setRubro] = useState(undefined);
   const [errorInicio, setErrorInicio] = useState("");
   const [recuperando, setRecuperando] = useState(false);
 
@@ -60,6 +63,30 @@ export default function App() {
       .catch((e) => console.error("No se pudieron cargar los comercios:", e));
     return () => { vigente = false; };
   }, [sesion && sesion.tipo, sesion && sesion.nombre]);
+
+  /* El comercio que se está mirando: el propio, o el que abrió la
+     plataforma. En el panel de plataforma no hay ninguno. */
+  const comercio = sesion ? sesion.viendo || sesion.comercio : null;
+
+  /* El rubro decide la forma del sistema: el menú, por dónde entra y qué
+     tablero muestra el inicio. Se resuelve acá, antes de montar Sistema, y
+     no adentro: si llegara tarde, una estética abriría un instante en la
+     pantalla de cobro y recién después se corregiría sola, que es peor que
+     esperar. */
+  useEffect(() => {
+    if (!comercio) { setRubro(null); return; }
+    let vigente = true;
+    setRubro(undefined);
+    cargarRubro(comercio.rubro)
+      .then((r) => { if (vigente) setRubro(r); })
+      .catch((e) => {
+        /* Sin rubro el sistema igual se usa: Sistema tiene su menú de
+           respaldo. No vale la pena frenar a nadie por esto. */
+        console.error("No se pudo cargar el rubro:", e);
+        if (vigente) setRubro(null);
+      });
+    return () => { vigente = false; };
+  }, [comercio && comercio.id]);
 
   const cerrarSesion = useCallback(async () => {
     await salir();
@@ -115,8 +142,9 @@ export default function App() {
     );
   }
 
-  // El comercio que se está mirando: el propio, o el que abrió la plataforma.
-  const comercio = sesion.viendo || sesion.comercio;
+  // Sin saber el rubro no se puede dibujar: se decidiría dos veces.
+  if (rubro === undefined) return envolver(<Cargando />);
+
   const sesionSistema = sesion.viendo
     ? { tipo: "comercio", comercio, rol: "dueno", nombre: sesion.nombre, usuario: sesion.usuario, comoAdmin: true }
     : sesion;
@@ -124,6 +152,7 @@ export default function App() {
   return envolver(
     <Sistema
       key={comercio.id}
+      rubro={rubro}
       tema={tema} setTema={setTema}
       sesion={sesionSistema}
       setComercios={setComercios}

--- a/src/datos/abonos.js
+++ b/src/datos/abonos.js
@@ -1,0 +1,196 @@
+/* ============================================================
+   ABONOS · el crédito de un cliente
+   ============================================================
+
+   Un pack de ocho clases, una cuota mensual, un plan de dos por semana.
+   Los tres son lo mismo: crédito comprado ahora y consumido después. Ver
+   la migración 0035 para por qué los planes son items del catálogo y por
+   qué el saldo no se guarda sino que se cuenta.
+
+   El crédito se descuenta **al reservar**, no al asistir. Es lo que hace
+   que "dos por semana" se pueda hacer cumplir: si se descontara al venir,
+   el tope no se puede controlar en el momento en que importa.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+
+export const ESTADOS_ABONO = [
+  { k: "activo", n: "Activo", tono: "bien" },
+  { k: "consumido", n: "Sin clases", tono: "ojo" },
+  { k: "vencido", n: "Vencido", tono: "mal" },
+  { k: "anulado", n: "Anulado", tono: "tenue" },
+];
+
+export const estadoAbono = (k) => ESTADOS_ABONO.find((e) => e.k === k) || { k, n: k, tono: "tenue" };
+
+function aAbono(f) {
+  return {
+    id: f.id,
+    clienteId: f.cliente_id,
+    cliente: f.cliente || "",
+    itemId: f.item_id || null,
+    operacionId: f.operacion_id || null,
+    nombre: f.nombre,
+    area: f.area || "",
+    /* En null es libre: no se cuentan clases, se controla con el tope y
+       la vigencia. */
+    clases: f.clases,
+    usadas: n(f.usadas),
+    restantes: f.restantes === null || f.restantes === undefined ? null : n(f.restantes),
+    topeSemanal: f.tope_semanal,
+    desde: f.desde ? new Date(`${f.desde}T12:00:00`) : null,
+    vence: f.vence ? new Date(`${f.vence}T12:00:00`) : null,
+    estado: f.estado,
+    notas: f.notas || "",
+    creado: f.creado_en ? new Date(f.creado_en) : null,
+  };
+}
+
+export async function cargarAbonos(empresaId, { clienteId = null, soloActivos = false } = {}) {
+  if (!empresaId) throw new Error("cargarAbonos necesita saber de qué comercio.");
+
+  let q = supabase.from("abonos_vista").select("*").eq("empresa_id", empresaId);
+  if (clienteId) q = q.eq("cliente_id", clienteId);
+  q = q.order("creado_en", { ascending: false }).limit(1000);
+
+  const { data, error } = await q;
+  if (error) throw error;
+
+  const xs = (data || []).map(aAbono);
+  return soloActivos ? xs.filter((a) => a.estado === "activo") : xs;
+}
+
+/* Los planes del catálogo. Son items como cualquier otro, con sus
+   condiciones en `campos_extra`: cuántas clases da, cuánto dura y cuántas
+   veces por semana se puede usar. */
+export async function cargarPlanes(empresaId) {
+  if (!empresaId) throw new Error("cargarPlanes necesita saber de qué comercio.");
+
+  const { data, error } = await supabase
+    .from("items")
+    .select("id, nombre, precio, categoria, activo, campos_extra")
+    .eq("empresa_id", empresaId)
+    .eq("tipo", "plan")
+    .order("nombre");
+  if (error) throw error;
+
+  return (data || []).map((i) => ({
+    id: i.id,
+    nombre: i.nombre,
+    precio: n(i.precio),
+    categoria: i.categoria || "",
+    activo: i.activo,
+    clases: i.campos_extra && i.campos_extra.clases != null ? Number(i.campos_extra.clases) : null,
+    vigenciaDias: i.campos_extra && i.campos_extra.vigenciaDias != null ? Number(i.campos_extra.vigenciaDias) : null,
+    topeSemanal: i.campos_extra && i.campos_extra.topeSemanal != null ? Number(i.campos_extra.topeSemanal) : null,
+  }));
+}
+
+export async function guardarPlan(empresaId, plan) {
+  const fila = {
+    empresa_id: empresaId,
+    tipo: "plan",
+    nombre: plan.nombre,
+    precio: Number(plan.precio) || 0,
+    categoria: plan.categoria || null,
+    controla_stock: false,
+    activo: plan.activo !== false,
+    campos_extra: {
+      clases: plan.clases === "" || plan.clases == null ? null : Number(plan.clases),
+      vigenciaDias: plan.vigenciaDias === "" || plan.vigenciaDias == null ? null : Number(plan.vigenciaDias),
+      topeSemanal: plan.topeSemanal === "" || plan.topeSemanal == null ? null : Number(plan.topeSemanal),
+    },
+  };
+
+  if (plan.id) {
+    const { error } = await supabase.from("items").update(fila).eq("id", plan.id);
+    if (error) throw error;
+    return plan.id;
+  }
+
+  const { data, error } = await supabase.from("items").insert(fila).select("id").single();
+  if (error) throw error;
+  return data.id;
+}
+
+const MOTIVOS = {
+  P0038: "No podés vender en ese comercio.",
+  P0050: "Un abono necesita un cliente: es de alguien.",
+  P0051: "Ese cliente no es de este comercio.",
+  P0052: "Ese plan no existe en el catálogo.",
+  P0053: "No existe ese abono.",
+  P0054: "Ese abono está anulado.",
+  P0055: "Ese abono es de otra persona.",
+  P0056: "Ese abono ya venció.",
+  P0057: "Ese abono todavía no arrancó.",
+  P0058: "Ese abono ya no tiene clases.",
+  P0059: "Ese plan no permite tantas veces por semana.",
+};
+
+function traducir(error) {
+  const codigo = error && error.code;
+  /* El mensaje de la base ya viene armado con el número —"Ese plan
+     permite 2 por semana"— así que si lo tenemos, gana sobre el genérico. */
+  if (codigo && MOTIVOS[codigo] && error.message && /\d/.test(error.message)) return new Error(error.message);
+  return new Error(MOTIVOS[codigo] || (error && error.message) || "No se pudo.");
+}
+
+/* Cobra el plan y crea el crédito en una transacción. Por dentro pasa por
+   `registrar_venta`, el mismo camino que cualquier venta: la operación,
+   la línea, el pago y el movimiento de caja quedan como corresponde.
+
+   Sin caja abierta la base lo rechaza, igual que cualquier cobro. */
+export async function venderAbono({
+  empresaId, clienteId, itemId = null, sucursalId = null, sesionId = null,
+  precio = null, nombre = null, clases = null, topeSemanal = null,
+  vigenciaDias = null, pagos = [], notas = "",
+}) {
+  const { data, error } = await supabase.rpc("vender_abono", {
+    p: {
+      empresa_id: empresaId,
+      cliente_id: clienteId,
+      item_id: itemId,
+      sucursal_id: sucursalId,
+      sesion_id: sesionId,
+      precio,
+      nombre,
+      clases,
+      tope_semanal: topeSemanal,
+      vigencia_dias: vigenciaDias,
+      pagos,
+      notas,
+    },
+  });
+  if (error) throw traducir(error);
+  return data;
+}
+
+/* No se borra: puede tener turnos tomados atrás, y borrarlo los dejaría
+   sin crédito de dónde salieron. */
+export async function anularAbono(id) {
+  const { error } = await supabase.from("abonos").update({ anulado: true }).eq("id", id);
+  if (error) throw error;
+}
+
+/* Los turnos que salieron de un abono, para poder mirar en qué se gastó. */
+export async function cargarConsumos(empresaId, abonoId) {
+  const { data, error } = await supabase
+    .from("agenda_vista")
+    .select("id, desde, estado, servicio, profesional, sala")
+    .eq("empresa_id", empresaId)
+    .eq("abono_id", abonoId)
+    .order("desde", { ascending: false });
+  if (error) throw error;
+  return (data || []).map((t) => ({
+    id: t.id,
+    desde: new Date(t.desde),
+    estado: t.estado,
+    servicio: t.servicio || "",
+    profesional: t.profesional || "",
+    sala: t.sala || "",
+  }));
+}

--- a/src/datos/agenda.js
+++ b/src/datos/agenda.js
@@ -48,6 +48,15 @@ function aTurno(f) {
     notas: f.notas || "",
     personas: f.personas,
 
+    /* `forma` la resuelve la vista: turno, clase o inscripción. La
+       pantalla no tiene que deducirla mirando si hay cupo. */
+    forma: f.forma || "turno",
+    claseId: f.clase_id || null,
+    cupo: f.cupo,
+    anotados: n(f.anotados),
+    lugares: f.lugares === null || f.lugares === undefined ? null : n(f.lugares),
+    esperando: n(f.esperando),
+
     clienteId: f.cliente_id || null,
     cliente: f.cliente || f.nombre || "Sin nombre",
     telefono: f.telefono || "",
@@ -218,4 +227,157 @@ export function choca(turnos, { desde, duracion, ignorar = null }) {
   const fin = new Date(desde.getTime() + duracion * 60000);
   return turnos.some((t) =>
     t.id !== ignorar && OCUPAN.includes(t.estado) && t.desde < fin && t.hasta > desde);
+}
+
+/* ============================================================
+   CLASES GRUPALES
+   ============================================================
+
+   Una clase es una reserva con cupo; anotarse es una reserva que apunta a
+   ella. Ver la migración 0034 para por qué van en la misma tabla y por
+   qué las inscripciones no ocupan la sala.
+   ============================================================ */
+
+const MOTIVOS_CLASE = {
+  P0040: "Una clase necesita al menos un lugar.",
+  P0041: "En esa sala no entra tanta gente.",
+  P0042: "No existe esa clase.",
+  P0043: "Eso no es una clase.",
+  P0044: "Esa clase está cancelada.",
+  P0045: "Esa clase ya está completa.",
+  P0046: "Esa persona ya está anotada.",
+};
+
+function traducirClase(error) {
+  const codigo = error && error.code;
+  return new Error(MOTIVOS_CLASE[codigo] || MOTIVOS[codigo] || (error && error.message) || "No se pudo.");
+}
+
+export async function crearClase({
+  empresaId, sucursalId = null, personalId = null, recursoId = null,
+  itemId = null, nombre, desde, duracion = 60, cupo = 1, notas = "",
+}) {
+  const { data, error } = await supabase.rpc("crear_clase", {
+    p: {
+      empresa_id: empresaId,
+      sucursal_id: sucursalId,
+      personal_id: personalId,
+      recurso_id: recursoId,
+      item_id: itemId,
+      nombre: nombre || "Clase",
+      desde: desde.toISOString(),
+      duracion_min: duracion,
+      cupo,
+      notas,
+    },
+  });
+  if (error) throw traducirClase(error);
+  return data;
+}
+
+/* El cupo lo controla la base con la clase bloqueada: dos personas
+   apretando "anotar" sobre el último lugar terminan con una adentro y una
+   afuera, y no con siete en una clase de seis. */
+export async function inscribir({ claseId, clienteId = null, nombre, telefono = null, notas = "" }) {
+  const { data, error } = await supabase.rpc("inscribir", {
+    p: { clase_id: claseId, cliente_id: clienteId, nombre: nombre || "Sin nombre", telefono, notas },
+  });
+  if (error) throw traducirClase(error);
+  return data;
+}
+
+export async function cargarInscriptos(empresaId, claseId) {
+  if (!empresaId) throw new Error("cargarInscriptos necesita saber de qué comercio.");
+  const { data, error } = await supabase
+    .from("agenda_vista")
+    .select("*")
+    .eq("empresa_id", empresaId)
+    .eq("clase_id", claseId)
+    .order("creada_en");
+  if (error) throw error;
+  return (data || []).map(aTurno);
+}
+
+/* ------------------------------------------------------------
+   Lista de espera
+
+   No se promueve sola. Liberar un lugar y meter a alguien sin avisarle es
+   peor que el problema: la persona se entera cuando ya no puede ir.
+   ------------------------------------------------------------ */
+
+export async function cargarEspera(empresaId, claseId) {
+  const { data, error } = await supabase
+    .from("espera")
+    .select("id, cliente_id, nombre, telefono, notas, estado, orden, creada_en")
+    .eq("empresa_id", empresaId)
+    .eq("clase_id", claseId)
+    .in("estado", ["esperando", "avisado"])
+    .order("orden")
+    .order("creada_en");
+  if (error) throw error;
+  return data || [];
+}
+
+export async function anotarEnEspera({ empresaId, claseId, clienteId = null, nombre, telefono = null }) {
+  const { error } = await supabase.from("espera").insert({
+    empresa_id: empresaId, clase_id: claseId, cliente_id: clienteId,
+    nombre: nombre || "Sin nombre", telefono,
+  });
+  if (error) throw error;
+}
+
+export async function marcarEspera(id, estado) {
+  const { error } = await supabase.from("espera").update({ estado }).eq("id", id);
+  if (error) throw error;
+}
+
+/* ------------------------------------------------------------
+   Bloqueos y ausencias
+
+   Con `personalId` en null el bloqueo es de todo el comercio: eso es un
+   feriado o un corte de luz.
+   ------------------------------------------------------------ */
+
+export const MOTIVOS_BLOQUEO = [
+  { k: "ausencia", n: "Ausencia" },
+  { k: "vacaciones", n: "Vacaciones" },
+  { k: "feriado", n: "Feriado" },
+  { k: "licencia", n: "Licencia" },
+];
+
+export async function cargarBloqueos(empresaId, { desde, hasta }) {
+  if (!empresaId) throw new Error("cargarBloqueos necesita saber de qué comercio.");
+  const { data, error } = await supabase
+    .from("excepciones")
+    .select("id, personal_id, desde, hasta, motivo, nota")
+    .eq("empresa_id", empresaId)
+    .lt("desde", hasta.toISOString())
+    .gt("hasta", desde.toISOString())
+    .order("desde");
+  if (error) throw error;
+  return (data || []).map((b) => ({
+    id: b.id,
+    personalId: b.personal_id || null,
+    desde: new Date(b.desde),
+    hasta: new Date(b.hasta),
+    motivo: b.motivo,
+    nota: b.nota || "",
+  }));
+}
+
+export async function bloquear({ empresaId, personalId = null, desde, hasta, motivo = "ausencia", nota = "" }) {
+  const { error } = await supabase.from("excepciones").insert({
+    empresa_id: empresaId,
+    personal_id: personalId,
+    desde: desde.toISOString(),
+    hasta: hasta.toISOString(),
+    motivo,
+    nota: nota || null,
+  });
+  if (error) throw error;
+}
+
+export async function quitarBloqueo(id) {
+  const { error } = await supabase.from("excepciones").delete().eq("id", id);
+  if (error) throw error;
 }

--- a/src/datos/agenda.js
+++ b/src/datos/agenda.js
@@ -1,0 +1,221 @@
+/* ============================================================
+   AGENDA · los turnos
+   ============================================================
+
+   Un turno es una `reserva`: alguien compromete un recurso durante un
+   rato. Es la misma entidad que la reserva de mesa del bar, con dos
+   columnas más —quién atiende y qué servicio— que en gastronomía van en
+   null. Ver la migración 0032 para por qué no hay una tabla `turnos`.
+
+   Lo que puede impedir un turno vive en la base, no acá: `agendar_turno`
+   y `mover_turno` validan choques de sala, de persona, de horario y de
+   ausencias en la misma transacción. Esta capa solo traduce el error a
+   algo que se pueda leer.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+/* Los seis estados. `sentada` viene del salón —la mesa se sentó— y en la
+   agenda significa lo mismo: la persona llegó y está adentro. Se muestra
+   con otra palabra y no se renombra la columna, porque renombrarla
+   rompería el mapa de mesas. */
+export const ESTADOS = [
+  { k: "pendiente", n: "Pendiente", tono: "ojo", d: "Se pidió, falta que el cliente confirme" },
+  { k: "confirmada", n: "Confirmado", tono: "info", d: "El cliente dijo que viene" },
+  { k: "sentada", n: "En curso", tono: "acento", d: "Está siendo atendido" },
+  { k: "cumplida", n: "Asistió", tono: "bien", d: "Vino y se atendió" },
+  { k: "ausente", n: "No vino", tono: "mal", d: "No se presentó" },
+  { k: "cancelada", n: "Cancelado", tono: "tenue", d: "Se dio de baja" },
+];
+
+export const estadoDe = (k) => ESTADOS.find((e) => e.k === k) || { k, n: k, tono: "tenue" };
+
+/* Los que ocupan un lugar. Una cancelación y una ausencia lo liberan, así
+   que ese rato se puede volver a vender. */
+export const OCUPAN = ["pendiente", "confirmada", "sentada", "cumplida"];
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+
+function aTurno(f) {
+  return {
+    id: f.id,
+    desde: new Date(f.desde),
+    hasta: new Date(f.hasta),
+    duracion: f.duracion_min,
+    estado: f.estado,
+    notas: f.notas || "",
+    personas: f.personas,
+
+    clienteId: f.cliente_id || null,
+    cliente: f.cliente || f.nombre || "Sin nombre",
+    telefono: f.telefono || "",
+
+    personalId: f.personal_id || null,
+    profesional: f.profesional || "",
+    especialidad: f.especialidad || "",
+
+    itemId: f.item_id || null,
+    servicio: f.servicio || "",
+    area: f.area || "",
+    precio: n(f.precio),
+
+    recursoId: f.recurso_id || null,
+    sala: f.sala || "",
+
+    operacionId: f.operacion_id || null,
+    pagado: n(f.pagado),
+  };
+}
+
+/* Los turnos de una ventana de tiempo. La ventana se pide siempre: una
+   agenda sin límite trae el historial entero el día que el negocio lleve
+   dos años funcionando. */
+export async function cargarTurnos(empresaId, { desde, hasta, personalId = null, recursoId = null, itemId = null, estado = null } = {}) {
+  if (!empresaId) throw new Error("cargarTurnos necesita saber de qué comercio.");
+  if (!desde || !hasta) throw new Error("cargarTurnos necesita un desde y un hasta.");
+
+  let q = supabase
+    .from("agenda_vista")
+    .select("*")
+    .eq("empresa_id", empresaId)
+    .gte("desde", desde.toISOString())
+    .lt("desde", hasta.toISOString())
+    .order("desde")
+    .limit(2000);
+
+  if (personalId) q = q.eq("personal_id", personalId);
+  if (recursoId) q = q.eq("recurso_id", recursoId);
+  if (itemId) q = q.eq("item_id", itemId);
+  if (estado) q = q.eq("estado", estado);
+
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data || []).map(aTurno);
+}
+
+/* Los errores que puede tirar la base al agendar, con su explicación. Los
+   códigos los define la migración 0032; traducirlos acá evita que la
+   pantalla muestre "P0034" o un texto de Postgres. */
+const MOTIVOS = {
+  P0030: "El turno tiene que durar algo.",
+  P0031: "Un turno no puede cruzar la medianoche.",
+  P0032: "Esa sala no es de este comercio.",
+  P0033: "Esa persona no es de este comercio.",
+  P0034: "Esa sala ya está ocupada en ese horario.",
+  P0035: "Esa persona ya tiene un turno en ese horario.",
+  P0036: "Esa persona no trabaja en ese horario.",
+  P0037: "Hay una ausencia o un bloqueo en ese horario.",
+  P0038: "No podés agendar en ese comercio.",
+  P0039: "Un turno cumplido o cancelado no se reprograma.",
+};
+
+function traducir(error) {
+  const codigo = error && (error.code || (error.details && error.details.code));
+  const claro = MOTIVOS[codigo];
+  return new Error(claro || (error && error.message) || "No se pudo agendar.");
+}
+
+export async function agendarTurno({
+  empresaId, sucursalId = null, clienteId = null, personalId = null,
+  recursoId = null, itemId = null, nombre, telefono = null,
+  desde, duracion = 60, personas = 1, notas = "", estado = "pendiente",
+}) {
+  const { data, error } = await supabase.rpc("agendar_turno", {
+    p: {
+      empresa_id: empresaId,
+      sucursal_id: sucursalId,
+      cliente_id: clienteId,
+      personal_id: personalId,
+      recurso_id: recursoId,
+      item_id: itemId,
+      nombre: nombre || "Sin nombre",
+      telefono,
+      desde: desde.toISOString(),
+      duracion_min: duracion,
+      personas,
+      notas,
+      estado,
+    },
+  });
+  if (error) throw traducir(error);
+  return data;
+}
+
+export async function moverTurno(id, desde, duracion = null) {
+  const { error } = await supabase.rpc("mover_turno", {
+    p_id: id,
+    p_desde: desde.toISOString(),
+    p_duracion: duracion,
+  });
+  if (error) throw traducir(error);
+}
+
+/* El estado se cambia con un update simple: no toca varias tablas, así
+   que no necesita función. La bitácora la escribe un disparador. */
+export async function cambiarEstado(id, estado) {
+  const { error } = await supabase.from("reservas").update({ estado }).eq("id", id);
+  if (error) throw traducir(error);
+}
+
+export async function guardarNotas(id, notas) {
+  const { error } = await supabase.from("reservas").update({ notas: notas || null }).eq("id", id);
+  if (error) throw traducir(error);
+}
+
+/* Recepción y el profesional tienen que ver lo mismo. `reservas` ya está
+   publicada en tiempo real desde la migración 0024, así que esto no
+   necesitó nada del lado de la base.
+
+   Devuelve la función para desuscribirse; quien llama la usa en el
+   cleanup del efecto o deja el canal abierto para siempre. */
+export function escucharTurnos(empresaId, alCambiar) {
+  const canal = supabase
+    .channel(`agenda:${empresaId}`)
+    .on("postgres_changes",
+      { event: "*", schema: "public", table: "reservas", filter: `empresa_id=eq.${empresaId}` },
+      (msg) => alCambiar(msg))
+    .subscribe();
+
+  return () => { supabase.removeChannel(canal); };
+}
+
+/* ------------------------------------------------------------
+   Disponibilidad, del lado del navegador
+
+   Esto NO reemplaza la validación de la base: es para que la pantalla
+   pueda avisar antes de que el usuario apriete guardar, y para dibujar el
+   horario laboral de fondo. Lo que decide sigue siendo `revisar_turno`.
+   ------------------------------------------------------------ */
+
+/* Las franjas de trabajo de una persona en un día, en minutos desde la
+   medianoche. Sin horarios cargados devuelve el día entero: todavía nadie
+   los cargó y no corresponde bloquear a quien está trabajando. */
+export function franjasDelDia(persona, fecha) {
+  if (!persona || !persona.horarios || persona.horarios.length === 0) {
+    return [{ desde: 0, hasta: 24 * 60 }];
+  }
+  const dia = fecha.getDay();
+  return persona.horarios
+    .filter((h) => h.dia === dia)
+    .map((h) => ({ desde: aMinutos(h.desde), hasta: aMinutos(h.hasta) }))
+    .sort((a, b) => a.desde - b.desde);
+}
+
+export const aMinutos = (hhmm) => {
+  const [h, m] = String(hhmm || "0:0").split(":").map(Number);
+  return h * 60 + (m || 0);
+};
+
+export const aReloj = (min) =>
+  `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(Math.round(min % 60)).padStart(2, "0")}`;
+
+export const minutosDe = (fecha) => fecha.getHours() * 60 + fecha.getMinutes();
+
+/* Si un turno pisa a otro. Se usa para avisar en el formulario. */
+export function choca(turnos, { desde, duracion, ignorar = null }) {
+  const fin = new Date(desde.getTime() + duracion * 60000);
+  return turnos.some((t) =>
+    t.id !== ignorar && OCUPAN.includes(t.estado) && t.desde < fin && t.hasta > desde);
+}

--- a/src/datos/clientes.js
+++ b/src/datos/clientes.js
@@ -1,0 +1,106 @@
+/* ============================================================
+   CLIENTES · leer y guardar
+   ============================================================
+
+   La base guarda `razon_social` y `tipo_doc`; la aplicación viene hablando
+   de `razonSocial` y `tipoDoc` desde el prototipo. La traducción vive acá y
+   en ningún otro lado: los módulos siguen sin saber cómo se llaman las
+   columnas.
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+const COLUMNA = {
+  razonSocial: "razon_social",
+  tipoDoc: "tipo_doc",
+  doc: "doc",
+  condicion: "condicion",
+  domicilio: "domicilio",
+  email: "email",
+  tel: "tel",
+  camposExtra: "campos_extra",
+  activo: "activo",
+};
+
+const SELECT =
+  "id, razon_social, tipo_doc, doc, condicion, domicilio, email, tel, campos_extra, activo, creado_en";
+
+function aCliente(f) {
+  return {
+    id: f.id,
+    razonSocial: f.razon_social,
+    tipoDoc: f.tipo_doc || "CUIT",
+    doc: f.doc || "",
+    condicion: f.condicion || "CF",
+    domicilio: f.domicilio || "",
+    email: f.email || "",
+    tel: f.tel || "",
+    camposExtra: f.campos_extra || {},
+    activo: f.activo,
+    alta: f.creado_en ? new Date(f.creado_en) : null,
+  };
+}
+
+/* Solo viajan a la base los campos que existen como columna. El formulario
+   arrastra cosas que no lo son —el id, banderas de la pantalla— y mandarlas
+   haría fallar el insert entero. */
+function aFila(datos) {
+  const fila = {};
+  for (const [campo, valor] of Object.entries(datos)) {
+    if (COLUMNA[campo] !== undefined) fila[COLUMNA[campo]] = valor;
+  }
+  return fila;
+}
+
+/* Supabase corta en 1.000 filas por consulta. Una cartera de clientes real
+   pasa ese número sin ser grande, así que se pagina siempre. */
+const PAGINA = 1000;
+
+export async function cargarClientes() {
+  const filas = [];
+  for (let desde = 0; ; desde += PAGINA) {
+    const { data, error } = await supabase
+      .from("clientes")
+      .select(SELECT)
+      .eq("activo", true)
+      .order("razon_social")
+      .range(desde, desde + PAGINA - 1);
+    if (error) throw error;
+    filas.push(...data);
+    if (data.length < PAGINA) return filas.map(aCliente);
+  }
+}
+
+export async function crearCliente(empresaId, datos) {
+  const fila = { ...aFila(datos), empresa_id: empresaId };
+  if (!fila.razon_social) throw new Error("El cliente necesita un nombre.");
+
+  const { data, error } = await supabase
+    .from("clientes")
+    .insert(fila)
+    .select(SELECT)
+    .single();
+  if (error) throw error;
+  return aCliente(data);
+}
+
+export async function guardarCliente(id, cambios) {
+  const fila = aFila(cambios);
+  if (!Object.keys(fila).length) return null;
+
+  const { data, error } = await supabase
+    .from("clientes")
+    .update(fila)
+    .eq("id", id)
+    .select(SELECT)
+    .single();
+  if (error) throw error;
+  return aCliente(data);
+}
+
+/* Un cliente no se borra: se desactiva. Puede tener ventas atrás, y
+   borrarlo dejaría comprobantes emitidos sin a quién apuntar. */
+export async function desactivarCliente(id) {
+  const { error } = await supabase.from("clientes").update({ activo: false }).eq("id", id);
+  if (error) throw error;
+}

--- a/src/datos/clientes.js
+++ b/src/datos/clientes.js
@@ -56,12 +56,19 @@ function aFila(datos) {
    pasa ese número sin ser grande, así que se pagina siempre. */
 const PAGINA = 1000;
 
-export async function cargarClientes() {
+/* El filtro por empresa va explícito, igual que en el catálogo: RLS
+   contesta si podés ver algo, no de qué comercio es. El dueño de
+   plataforma ve todo, así que sin este filtro entraba a un comercio y se
+   le mezclaba la cartera de los otros. */
+export async function cargarClientes(empresaId) {
+  if (!empresaId) throw new Error("cargarClientes necesita saber de qué comercio.");
+
   const filas = [];
   for (let desde = 0; ; desde += PAGINA) {
     const { data, error } = await supabase
       .from("clientes")
       .select(SELECT)
+      .eq("empresa_id", empresaId)
       .eq("activo", true)
       .order("razon_social")
       .range(desde, desde + PAGINA - 1);

--- a/src/datos/equipo.js
+++ b/src/datos/equipo.js
@@ -1,0 +1,207 @@
+/* ============================================================
+   EQUIPO · quién trabaja, qué hace y cuándo
+   ============================================================
+
+   Ver la migración 0030 para por qué `personal` no es `perfiles` ni
+   `recursos`.
+
+   Todas las consultas filtran por `empresa_id` explícito, como manda la
+   regla 6 de ARQUITECTURA.md: RLS contesta si podés ver algo, no de qué
+   comercio es.
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+export const DIAS = [
+  { d: 1, n: "Lunes", corto: "Lun" },
+  { d: 2, n: "Martes", corto: "Mar" },
+  { d: 3, n: "Miércoles", corto: "Mié" },
+  { d: 4, n: "Jueves", corto: "Jue" },
+  { d: 5, n: "Viernes", corto: "Vie" },
+  { d: 6, n: "Sábado", corto: "Sáb" },
+  { d: 0, n: "Domingo", corto: "Dom" },
+];
+
+export const MODALIDADES = [
+  { k: "hora", n: "Por hora", d: "Se le paga por hora trabajada" },
+  { k: "clase", n: "Por clase", d: "Se le paga por cada clase que da" },
+  { k: "comision", n: "Comisión", d: "Un porcentaje de lo que factura" },
+  { k: "fijo", n: "Sueldo fijo", d: "Un monto por mes, sin importar las horas" },
+];
+
+export const TIPOS = [
+  { k: "profesional", n: "Profesional" },
+  { k: "recepcion", n: "Recepción" },
+  { k: "otro", n: "Otro" },
+];
+
+const COLUMNA = {
+  nombre: "nombre",
+  tipo: "tipo",
+  especialidad: "especialidad",
+  tel: "tel",
+  email: "email",
+  modalidad: "modalidad",
+  valor: "valor",
+  comision: "comision",
+  orden: "orden",
+  activo: "activo",
+  perfilId: "perfil_id",
+  sucursalId: "sucursal_id",
+};
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+
+/* La hora llega de Postgres como "08:00:00" y en pantalla se escribe
+   "08:00". Los segundos no le importan a nadie acá. */
+const hhmm = (t) => String(t || "").slice(0, 5);
+
+function aPersona(f) {
+  return {
+    id: f.id,
+    nombre: f.nombre,
+    tipo: f.tipo,
+    especialidad: f.especialidad || "",
+    tel: f.tel || "",
+    email: f.email || "",
+    modalidad: f.modalidad,
+    valor: n(f.valor),
+    comision: n(f.comision),
+    orden: f.orden,
+    activo: f.activo,
+    perfilId: f.perfil_id || null,
+    tieneCuenta: !!f.tiene_cuenta,
+    horasSemana: n(f.horas_semana),
+    diasSemana: n(f.dias_semana),
+    /* Los llena `cargarEquipo`; van vacíos si alguien arma una persona
+       suelta, para que la pantalla nunca reciba undefined. */
+    horarios: [],
+    servicios: [],
+  };
+}
+
+function aFila(datos) {
+  const fila = {};
+  for (const [campo, valor] of Object.entries(datos)) {
+    if (COLUMNA[campo] !== undefined) fila[COLUMNA[campo]] = valor;
+  }
+  return fila;
+}
+
+export async function cargarEquipo(empresaId) {
+  if (!empresaId) throw new Error("cargarEquipo necesita saber de qué comercio.");
+
+  const [gente, franjas, habilitados] = await Promise.all([
+    supabase.from("equipo_vista").select("*")
+      .eq("empresa_id", empresaId).eq("activo", true).order("orden").order("nombre"),
+    supabase.from("horarios").select("id, personal_id, dia, desde, hasta")
+      .eq("empresa_id", empresaId).eq("activo", true)
+      .not("personal_id", "is", null).order("dia").order("desde"),
+    supabase.from("personal_servicios").select("personal_id, item_id")
+      .eq("empresa_id", empresaId),
+  ]);
+
+  for (const r of [gente, franjas, habilitados]) if (r.error) throw r.error;
+
+  const porPersona = new Map();
+  for (const h of franjas.data || []) {
+    if (!porPersona.has(h.personal_id)) porPersona.set(h.personal_id, []);
+    porPersona.get(h.personal_id).push({ id: h.id, dia: h.dia, desde: hhmm(h.desde), hasta: hhmm(h.hasta) });
+  }
+
+  const servPorPersona = new Map();
+  for (const s of habilitados.data || []) {
+    if (!servPorPersona.has(s.personal_id)) servPorPersona.set(s.personal_id, []);
+    servPorPersona.get(s.personal_id).push(s.item_id);
+  }
+
+  return (gente.data || []).map((f) => ({
+    ...aPersona(f),
+    horarios: porPersona.get(f.id) || [],
+    servicios: servPorPersona.get(f.id) || [],
+  }));
+}
+
+/* El catálogo de prestaciones, para elegir qué da cada uno. Vive acá y no
+   en `items.js` porque `cargarProductos` trae solo `tipo = 'producto'`: un
+   servicio no es un producto y no comparte ni pantalla ni columnas útiles. */
+export async function cargarServicios(empresaId) {
+  if (!empresaId) throw new Error("cargarServicios necesita saber de qué comercio.");
+
+  const { data, error } = await supabase
+    .from("items")
+    .select("id, nombre, categoria, duracion_min, precio")
+    .eq("empresa_id", empresaId)
+    .eq("tipo", "servicio")
+    .eq("activo", true)
+    .order("categoria")
+    .order("nombre");
+  if (error) throw error;
+
+  return (data || []).map((i) => ({
+    id: i.id,
+    nombre: i.nombre,
+    categoria: i.categoria || "Sin categoría",
+    duracion: i.duracion_min || 0,
+    precio: n(i.precio),
+  }));
+}
+
+export async function crearPersona(empresaId, datos) {
+  const fila = { ...aFila(datos), empresa_id: empresaId };
+  if (!fila.nombre) throw new Error("La persona necesita un nombre.");
+
+  const { data, error } = await supabase.from("personal").insert(fila).select("id").single();
+  if (error) {
+    if (error.code === "23505") throw new Error("Ya hay alguien con ese nombre en el equipo.");
+    throw error;
+  }
+  return data.id;
+}
+
+export async function guardarPersona(id, cambios) {
+  const fila = aFila(cambios);
+  if (!Object.keys(fila).length) return;
+
+  const { error } = await supabase.from("personal").update(fila).eq("id", id);
+  if (error) {
+    if (error.code === "23505") throw new Error("Ya hay alguien con ese nombre en el equipo.");
+    throw error;
+  }
+}
+
+/* No se borra: se desactiva. Va a tener turnos dados y liquidaciones
+   pagadas atrás, y borrarla dejaría horas trabajadas sin dueño. */
+export async function desactivarPersona(id) {
+  const { error } = await supabase.from("personal").update({ activo: false }).eq("id", id);
+  if (error) throw error;
+}
+
+/* Los horarios se reemplazan enteros en vez de diferenciarse fila por
+   fila. Son cinco o seis franjas por persona: calcular qué cambió cuesta
+   más código y más bugs que rehacerlas. */
+export async function guardarHorarios(empresaId, personalId, franjas) {
+  const { error: eBorrar } = await supabase
+    .from("horarios").delete().eq("empresa_id", empresaId).eq("personal_id", personalId);
+  if (eBorrar) throw eBorrar;
+
+  const filas = (franjas || [])
+    .filter((f) => f.desde && f.hasta && f.hasta > f.desde)
+    .map((f) => ({ empresa_id: empresaId, personal_id: personalId, dia: f.dia, desde: f.desde, hasta: f.hasta }));
+
+  if (!filas.length) return;
+  const { error } = await supabase.from("horarios").insert(filas);
+  if (error) throw error;
+}
+
+export async function guardarServicios(empresaId, personalId, itemIds) {
+  const { error: eBorrar } = await supabase
+    .from("personal_servicios").delete().eq("empresa_id", empresaId).eq("personal_id", personalId);
+  if (eBorrar) throw eBorrar;
+
+  const filas = (itemIds || []).map((item_id) => ({ empresa_id: empresaId, personal_id: personalId, item_id }));
+  if (!filas.length) return;
+
+  const { error } = await supabase.from("personal_servicios").insert(filas);
+  if (error) throw error;
+}

--- a/src/datos/finanzas.js
+++ b/src/datos/finanzas.js
@@ -1,0 +1,313 @@
+/* ============================================================
+   FINANZAS · lo que entra, lo que sale y lo que falta cobrar
+   ============================================================
+
+   La caja del día ya la resuelve `caja.js`: apertura, arqueo y cierre.
+   Acá está lo que la excede — el mes, los movimientos de cualquier fecha,
+   lo que falta cobrar y lo que se le paga al equipo.
+
+   Una aclaración que importa: **un egreso no necesita caja abierta**.
+   Pagarle a un profesor por transferencia un lunes no es un movimiento
+   del cajón del mostrador, y obligar a abrir la caja para eso sería
+   inventar un arqueo que no existió. Por eso `sesion_id` puede ir en null.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+const suma = (xs, f) => xs.reduce((s, x) => s + n(f(x)), 0);
+
+export const CATEGORIAS_EGRESO = [
+  { k: "sueldos", n: "Sueldos" },
+  { k: "alquiler", n: "Alquiler" },
+  { k: "servicios", n: "Servicios" },
+  { k: "insumos", n: "Insumos" },
+  { k: "impuestos", n: "Impuestos" },
+  { k: "mantenimiento", n: "Mantenimiento" },
+  { k: "otros", n: "Otros" },
+];
+
+export const CATEGORIAS_INGRESO = [
+  { k: "turnos", n: "Turnos" },
+  { k: "abonos", n: "Abonos" },
+  { k: "productos", n: "Productos" },
+  { k: "otros", n: "Otros" },
+];
+
+export const nombreCategoria = (k) =>
+  (CATEGORIAS_EGRESO.find((c) => c.k === k) || CATEGORIAS_INGRESO.find((c) => c.k === k) || { n: k || "Sin categoría" }).n;
+
+function aMovimiento(f) {
+  return {
+    id: f.id,
+    tipo: f.tipo,
+    medio: f.medio,
+    monto: n(f.monto),
+    detalle: f.detalle || "",
+    categoria: f.categoria || null,
+    operacionId: f.operacion_id || null,
+    sesionId: f.sesion_id || null,
+    fecha: new Date(f.fecha),
+  };
+}
+
+export async function cargarMovimientos(empresaId, { desde, hasta, tipo = null, categoria = null } = {}) {
+  if (!empresaId) throw new Error("cargarMovimientos necesita saber de qué comercio.");
+  if (!desde || !hasta) throw new Error("cargarMovimientos necesita un desde y un hasta.");
+
+  let q = supabase
+    .from("movimientos_caja")
+    .select("id, tipo, medio, monto, detalle, categoria, operacion_id, sesion_id, fecha")
+    .eq("empresa_id", empresaId)
+    .gte("fecha", desde.toISOString())
+    .lt("fecha", hasta.toISOString())
+    .order("fecha", { ascending: false })
+    .limit(3000);
+
+  if (tipo) q = q.eq("tipo", tipo);
+  if (categoria) q = q.eq("categoria", categoria);
+
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data || []).map(aMovimiento);
+}
+
+/* Un movimiento suelto: un gasto, un ingreso que no vino de una venta.
+   Sin sesión es un movimiento del mes y no del cajón: así entra un
+   alquiler pagado por transferencia sin tener que abrir la caja. */
+export async function registrarMovimiento({ empresaId, sucursalId = null, sesionId = null, tipo, medio = "efectivo", monto, detalle, categoria = null, fecha = null }) {
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("movimientos_caja").insert({
+    empresa_id: empresaId,
+    sucursal_id: sucursalId,
+    sesion_id: sesionId,
+    tipo,
+    medio,
+    monto: Math.round(Number(monto) || 0),
+    detalle,
+    categoria,
+    usuario_id: user ? user.id : null,
+    ...(fecha ? { fecha: fecha.toISOString() } : {}),
+  });
+  if (error) throw error;
+}
+
+/* ------------------------------------------------------------
+   El mes
+
+   Se traen dos meses de una y se parten acá: es una sola consulta en vez
+   de dos, y la comparación contra el mes anterior sale gratis.
+   ------------------------------------------------------------ */
+
+export async function resumenDelMes(empresaId, mes = new Date()) {
+  if (!empresaId) throw new Error("resumenDelMes necesita saber de qué comercio.");
+
+  const desde = new Date(mes.getFullYear(), mes.getMonth() - 1, 1);
+  const hasta = new Date(mes.getFullYear(), mes.getMonth() + 1, 1);
+  const corte = new Date(mes.getFullYear(), mes.getMonth(), 1);
+
+  const movs = await cargarMovimientos(empresaId, { desde, hasta });
+  const esteMes = movs.filter((m) => m.fecha >= corte);
+  const anterior = movs.filter((m) => m.fecha < corte);
+
+  const cuenta = (xs) => {
+    const ingresos = xs.filter((m) => m.tipo === "ingreso");
+    const egresos = xs.filter((m) => m.tipo === "egreso");
+    return {
+      ingresos: suma(ingresos, (m) => m.monto),
+      egresos: suma(egresos, (m) => m.monto),
+      movimientos: xs.length,
+    };
+  };
+
+  const a = cuenta(esteMes);
+  const b = cuenta(anterior);
+
+  const agrupar = (xs, por) => {
+    const m = new Map();
+    for (const x of xs) {
+      const k = por(x) || "otros";
+      m.set(k, (m.get(k) || 0) + x.monto);
+    }
+    return [...m.entries()].map(([k, total]) => ({ k, total })).sort((x, y) => y.total - x.total);
+  };
+
+  return {
+    ingresos: a.ingresos,
+    egresos: a.egresos,
+    resultado: a.ingresos - a.egresos,
+    movimientos: a.movimientos,
+    previo: { ingresos: b.ingresos, egresos: b.egresos, resultado: b.ingresos - b.egresos },
+    /* Sin base contra la que comparar no hay variación: un "+100%" contra
+       cero no informa nada y encima alarma. */
+    variacion: b.ingresos > 0 ? a.ingresos / b.ingresos - 1 : null,
+    porMedio: agrupar(esteMes.filter((m) => m.tipo === "ingreso"), (m) => m.medio),
+    porCategoria: agrupar(esteMes.filter((m) => m.tipo === "egreso"), (m) => m.categoria),
+    /* Los últimos, para el resumen. */
+    ultimos: esteMes.slice(0, 8),
+  };
+}
+
+/* ------------------------------------------------------------
+   Lo que falta cobrar
+
+   El saldo se calcula: total de la operación menos lo pagado. No hay una
+   columna "saldo" a propósito, porque un número copiado se desincroniza
+   apenas alguien registre un pago a mano.
+   ------------------------------------------------------------ */
+
+export async function cargarPendientes(empresaId, { dias = 180 } = {}) {
+  if (!empresaId) throw new Error("cargarPendientes necesita saber de qué comercio.");
+
+  const desde = new Date(Date.now() - dias * 86400000);
+  const { data, error } = await supabase
+    .from("operaciones")
+    .select("id, total, fecha, numero, cliente_id, clientes(razon_social), pagos(monto)")
+    .eq("empresa_id", empresaId)
+    .in("tipo", ["venta", "comanda"])
+    .eq("estado", "confirmada")
+    .gte("fecha", desde.toISOString())
+    .order("fecha", { ascending: false })
+    .limit(2000);
+  if (error) throw error;
+
+  return (data || [])
+    .map((o) => ({
+      id: o.id,
+      numero: o.numero || "",
+      fecha: new Date(o.fecha),
+      cliente: (o.clientes && o.clientes.razon_social) || "Sin cliente",
+      clienteId: o.cliente_id || null,
+      total: n(o.total),
+      pagado: suma(o.pagos || [], (p) => p.monto),
+      falta: n(o.total) - suma(o.pagos || [], (p) => p.monto),
+    }))
+    /* El peso de tolerancia evita arrastrar centavos de redondeo como si
+       fueran una deuda. */
+    .filter((o) => o.falta > 1)
+    .sort((a, b) => a.fecha - b.fecha);
+}
+
+/* ------------------------------------------------------------
+   Liquidaciones
+   ------------------------------------------------------------ */
+
+const MOTIVOS = {
+  P0038: "No podés liquidar en ese comercio.",
+  P0060: "No existe esa persona.",
+  P0061: "Esa liquidación ya está pagada.",
+  P0062: "No existe esa liquidación.",
+};
+
+const traducir = (e) => new Error((e && MOTIVOS[e.code]) || (e && e.message) || "No se pudo.");
+
+function aLiquidacion(f) {
+  return {
+    id: f.id,
+    personalId: f.personal_id,
+    persona: f.persona,
+    tipoPersona: f.tipo_persona,
+    especialidad: f.especialidad || "",
+    desde: new Date(`${f.desde}T12:00:00`),
+    hasta: new Date(`${f.hasta}T12:00:00`),
+    modalidad: f.modalidad,
+    valor: n(f.valor),
+    horas: n(f.horas),
+    clases: n(f.clases),
+    ajuste: n(f.ajuste),
+    total: n(f.total),
+    aPagar: n(f.a_pagar),
+    estado: f.estado,
+    medio: f.medio || null,
+    notas: n(f.notas),
+    pagadaEn: f.pagada_en ? new Date(f.pagada_en) : null,
+  };
+}
+
+export async function cargarLiquidaciones(empresaId, { desde, hasta } = {}) {
+  if (!empresaId) throw new Error("cargarLiquidaciones necesita saber de qué comercio.");
+
+  let q = supabase.from("liquidaciones_vista").select("*").eq("empresa_id", empresaId);
+  if (desde) q = q.gte("desde", desde);
+  if (hasta) q = q.lte("hasta", hasta);
+
+  const { data, error } = await q.order("desde", { ascending: false }).limit(500);
+  if (error) throw error;
+  return (data || []).map(aLiquidacion);
+}
+
+/* Arma o recalcula el borrador de un período con lo que diga la agenda.
+   Las horas quedan editables: la agenda no sabe que se quedó media hora
+   más ordenando. */
+export async function liquidar(personalId, desde, hasta) {
+  const { data, error } = await supabase.rpc("liquidar", {
+    p_personal: personalId, p_desde: desde, p_hasta: hasta,
+  });
+  if (error) throw traducir(error);
+  return data;
+}
+
+export async function ajustarLiquidacion(id, { horas = null, ajuste = null, valor = null }) {
+  const fila = {};
+  if (horas !== null) fila.horas = horas;
+  if (ajuste !== null) fila.ajuste = ajuste;
+  if (valor !== null) fila.valor = valor;
+  if (!Object.keys(fila).length) return;
+
+  /* El total se recalcula acá y no en la base: al corregir las horas a
+     mano, lo que se está corrigiendo es el cálculo, no el dato. */
+  const { data: actual, error: e1 } = await supabase
+    .from("liquidaciones").select("modalidad, valor, horas, clases").eq("id", id).single();
+  if (e1) throw e1;
+
+  const v = fila.valor !== undefined ? fila.valor : n(actual.valor);
+  const h = fila.horas !== undefined ? fila.horas : n(actual.horas);
+  fila.total = actual.modalidad === "hora" ? Math.round(h * v)
+    : actual.modalidad === "clase" ? n(actual.clases) * v
+    : actual.modalidad === "fijo" ? v
+    : 0;
+
+  const { error } = await supabase.from("liquidaciones").update(fila).eq("id", id);
+  if (error) throw traducir(error);
+}
+
+export async function pagarLiquidacion(id, medio, sesionId = null) {
+  const { error } = await supabase.rpc("pagar_liquidacion", {
+    p_id: id, p_medio: medio, p_sesion: sesionId,
+  });
+  if (error) throw traducir(error);
+}
+
+export async function cargarNotas(empresaId, liquidacionId) {
+  const { data, error } = await supabase
+    .from("liquidacion_notas")
+    .select("id, texto, creada_en")
+    .eq("empresa_id", empresaId)
+    .eq("liquidacion_id", liquidacionId)
+    .order("creada_en");
+  if (error) throw error;
+  return (data || []).map((x) => ({ id: x.id, texto: x.texto, fecha: new Date(x.creada_en) }));
+}
+
+export async function anotar(empresaId, liquidacionId, texto) {
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("liquidacion_notas").insert({
+    empresa_id: empresaId, liquidacion_id: liquidacionId,
+    texto, usuario_id: user ? user.id : null,
+  });
+  if (error) throw error;
+}
+
+/* La semana de una fecha, de lunes a domingo, que es como la cuenta la
+   gente y como la cuenta el tope de los abonos. */
+export function semanaDe(d = new Date()) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  const dow = x.getDay();
+  const lunes = new Date(x.getTime() - (dow === 0 ? 6 : dow - 1) * 86400000);
+  const domingo = new Date(lunes.getTime() + 6 * 86400000);
+  const iso = (f) => `${f.getFullYear()}-${String(f.getMonth() + 1).padStart(2, "0")}-${String(f.getDate()).padStart(2, "0")}`;
+  return { desde: iso(lunes), hasta: iso(domingo), lunes, domingo };
+}

--- a/src/datos/items.js
+++ b/src/datos/items.js
@@ -64,10 +64,22 @@ function aProducto(f, historial) {
   };
 }
 
-export async function cargarProductos() {
+/* El filtro por empresa va explícito y no se delega en RLS.
+
+   RLS contesta "¿podés ver esto?", no "¿de qué comercio es esto?". Para un
+   usuario de comercio las dos respuestas coinciden y por eso esto anduvo
+   mucho tiempo. Pero el dueño de plataforma puede ver todo, así que
+   entrando como Almha se cargaba también el catálogo de Super 25 y el del
+   bar: 990 productos en un comercio que tiene nueve servicios y ninguno.
+
+   Sin empresa no se consulta. Un id olvidado tiene que reventar acá y no
+   aparecer como una Coca-Cola en el informe de una estética. */
+export async function cargarProductos(empresaId) {
+  if (!empresaId) throw new Error("cargarProductos necesita saber de qué comercio.");
+
   const [filas, costos] = await Promise.all([
-    traerTodo("items_vista", "*", (q) => q.eq("tipo", "producto").order("nombre")),
-    traerTodo("historial_costos", "item_id, costo, fecha", (q) => q.order("fecha")),
+    traerTodo("items_vista", "*", (q) => q.eq("empresa_id", empresaId).eq("tipo", "producto").order("nombre")),
+    traerTodo("historial_costos", "item_id, costo, fecha", (q) => q.eq("empresa_id", empresaId).order("fecha")),
   ]);
 
   const porItem = new Map();

--- a/src/datos/rubros.js
+++ b/src/datos/rubros.js
@@ -17,7 +17,7 @@ export async function cargarRubro(clave) {
 
   const { data, error } = await supabase
     .from("rubros")
-    .select("clave, nombre, menu, voces, modulos")
+    .select("clave, nombre, menu, voces, modulos, entrada, accion, inicio")
     .eq("clave", clave)
     .eq("activo", true)
     .maybeSingle();
@@ -31,6 +31,9 @@ export async function cargarRubro(clave) {
     grupos: Array.isArray(data.menu) ? data.menu : [],
     voces: data.voces || {},
     modulos: data.modulos || [],
+    entrada: data.entrada || "panel",
+    accion: data.accion || null,
+    inicio: data.inicio || "comercio",
   };
 }
 

--- a/src/datos/rubros.js
+++ b/src/datos/rubros.js
@@ -1,0 +1,43 @@
+/* ============================================================
+   RUBROS · la forma del sistema para cada tipo de negocio
+   ============================================================
+
+   El menú dejó de estar escrito en el código. Un rubro define qué grupos
+   tiene la barra lateral, qué módulos caen en cada uno, en qué orden y
+   cómo se llaman. Agregar "Genez para gimnasios" es un insert, no un
+   componente nuevo.
+
+   Ver la migración 0025 para la forma exacta de `menu`.
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+export async function cargarRubro(clave) {
+  if (!clave) return null;
+
+  const { data, error } = await supabase
+    .from("rubros")
+    .select("clave, nombre, menu, voces, modulos")
+    .eq("clave", clave)
+    .eq("activo", true)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  return {
+    clave: data.clave,
+    nombre: data.nombre,
+    grupos: Array.isArray(data.menu) ? data.menu : [],
+    voces: data.voces || {},
+    modulos: data.modulos || [],
+  };
+}
+
+/* Cómo llama este negocio a una cosa. Sin traducción cargada devuelve lo
+   que se le pasó, así una pantalla nueva puede usar `voz()` desde el
+   primer día aunque todavía nadie haya definido las palabras. */
+export function voz(rubro, clave, siNoEsta) {
+  const v = rubro && rubro.voces ? rubro.voces[clave] : null;
+  return v || siNoEsta || clave;
+}

--- a/src/datos/tablero.js
+++ b/src/datos/tablero.js
@@ -1,0 +1,325 @@
+/* ============================================================
+   TABLERO · lo que el negocio necesita saber al abrir
+   ============================================================
+
+   Una sola función arma el tablero entero. La pantalla recibe un objeto y
+   dibuja: no sabe —ni tiene por qué— qué salió de la base y qué todavía
+   no existe.
+
+   Eso es lo que permite ir migrando de a un indicador por vez. Cuando
+   exista la tabla de turnos, `turnosHoy` deja de venir del generador y
+   pasa a ser una consulta, y no hay que tocar una línea de la vista.
+
+   REGLA DE LOS DATOS DE EJEMPLO
+   ----------------------------
+   Solo se completan con ejemplos los comercios marcados `demo` en su
+   configuración. Hoy es únicamente Almha. Un comercio real ve sus
+   números reales aunque sean cero: mostrarle turnos inventados a alguien
+   que está por decidir con eso sería mucho peor que mostrarle un tablero
+   vacío.
+
+   Cada campo dice si es de ejemplo. La pantalla hoy no lo muestra, pero
+   el dato está para el día que se quiera distinguir a simple vista.
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+import { mulberry32 } from "./generador.js";
+
+const dia = 86400000;
+
+function alArrancarElDia(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+const suma = (xs, f) => xs.reduce((s, x) => s + Number(f(x) || 0), 0);
+
+/* Un dato del tablero. `demo` viaja con el valor y no aparte: si viajara
+   aparte, en algún refactor se iban a separar y nadie se iba a enterar. */
+const dato = (valor, extra = {}) => ({ valor, demo: false, ...extra });
+const ejemplo = (valor, extra = {}) => ({ valor, demo: true, ...extra });
+
+/* Un tablero en cero, con la forma completa. Lo usa quien tiene que
+   dibujar algo aunque la consulta se haya caído: con esto cada bloque
+   muestra su estado vacío, que es honesto. Sin esto, la pantalla se queda
+   colgada en el esqueleto de carga. */
+export function tableroVacio() {
+  return {
+    facturacionHoy: dato(0, { delta: null, serie: [], operaciones: 0 }),
+    ingresosMes: dato(0, { delta: null, serie: [] }),
+    ticketPromedio: dato(0, { delta: null }),
+    ingresosPorArea: dato([]),
+    topServicios: dato([]),
+    clientesNuevos: dato([]),
+    pagosPendientes: dato(0, { clientes: 0, operaciones: 0 }),
+    turnosHoy: dato(0),
+    asistenciaHoy: dato(0, { sobre: 0 }),
+    proximosTurnos: dato(0),
+    huecos: dato(0),
+    listaEspera: dato(0),
+    abonosPorVencer: dato(0),
+    agendaHoy: dato([]),
+    utilizacionSalas: dato([]),
+    turnosPorEstado: dato([]),
+    rendimiento: dato({ ingresos: 0, asistencia: null, conversion: null }),
+    acciones: dato([]),
+    alertas: dato([]),
+  };
+}
+
+/* ------------------------------------------------------------
+   Lo que ya sale de la base
+   ------------------------------------------------------------ */
+
+async function operacionesDesde(empresaId, desde) {
+  const { data, error } = await supabase
+    .from("operaciones")
+    .select("id, total, fecha, cliente_id")
+    .eq("empresa_id", empresaId)
+    /* Una mesa cobrada es venta del día aunque su tipo siga siendo
+       'comanda': lo que decide es el estado, no el tipo. Mismo criterio
+       que `resumenDelDia`. */
+    .in("tipo", ["venta", "comanda"])
+    .eq("estado", "confirmada")
+    .gte("fecha", desde.toISOString())
+    .limit(5000);
+  if (error) throw error;
+  return data || [];
+}
+
+/* Serie por día para los gráficos chiquitos de las tarjetas. */
+function serieDiaria(ops, dias, hasta) {
+  const fin = alArrancarElDia(hasta).getTime();
+  const acum = new Array(dias).fill(0);
+  for (const o of ops) {
+    const d = Math.round((fin - alArrancarElDia(new Date(o.fecha)).getTime()) / dia);
+    if (d >= 0 && d < dias) acum[dias - 1 - d] += Number(o.total || 0);
+  }
+  return acum;
+}
+
+async function lineasDelMes(empresaId, desde) {
+  const { data, error } = await supabase
+    .from("operacion_lineas")
+    .select("descripcion, cantidad, total, item_id, items(categoria), operaciones!inner(fecha, estado)")
+    .eq("empresa_id", empresaId)
+    .eq("operaciones.estado", "confirmada")
+    .gte("operaciones.fecha", desde.toISOString())
+    .limit(5000);
+  if (error) throw error;
+  return data || [];
+}
+
+async function clientesNuevos(empresaId) {
+  const { data, error } = await supabase
+    .from("clientes")
+    .select("id, razon_social, creado_en")
+    .eq("empresa_id", empresaId)
+    .eq("activo", true)
+    .order("creado_en", { ascending: false })
+    .limit(5);
+  if (error) throw error;
+  return data || [];
+}
+
+/* Lo cobrado se compara contra el total de cada operación. No hay una
+   columna "saldo" a propósito: sería un número copiado que se desincroniza
+   con los pagos apenas alguien registre uno a mano. */
+async function pendientesDeCobro(empresaId, desde) {
+  const { data, error } = await supabase
+    .from("operaciones")
+    .select("id, total, cliente_id, fecha, pagos(monto)")
+    .eq("empresa_id", empresaId)
+    .in("tipo", ["venta", "comanda"])
+    .eq("estado", "confirmada")
+    .gte("fecha", desde.toISOString())
+    .limit(2000);
+  if (error) throw error;
+
+  const deudas = (data || [])
+    .map((o) => ({ ...o, falta: Number(o.total || 0) - suma(o.pagos || [], (p) => p.monto) }))
+    .filter((o) => o.falta > 1);   // el 1 evita arrastrar centavos de redondeo
+
+  return {
+    monto: suma(deudas, (o) => o.falta),
+    clientes: new Set(deudas.map((o) => o.cliente_id).filter(Boolean)).size,
+    operaciones: deudas.length,
+  };
+}
+
+/* ------------------------------------------------------------
+   El tablero
+   ------------------------------------------------------------ */
+
+export async function cargarTablero({ empresaId, demo = false }) {
+  const ahora = new Date();
+  const hoy = alArrancarElDia(ahora);
+  const ayer = new Date(hoy.getTime() - dia);
+  const mes = new Date(ahora.getFullYear(), ahora.getMonth(), 1);
+  const mesPrevio = new Date(ahora.getFullYear(), ahora.getMonth() - 1, 1);
+  const hace90 = new Date(hoy.getTime() - 90 * dia);
+
+  const [ops, lineas, nuevos, pendiente] = await Promise.all([
+    operacionesDesde(empresaId, mesPrevio),
+    lineasDelMes(empresaId, mes),
+    clientesNuevos(empresaId),
+    pendientesDeCobro(empresaId, hace90),
+  ]);
+
+  const deHoy = ops.filter((o) => new Date(o.fecha) >= hoy);
+  const deAyer = ops.filter((o) => { const f = new Date(o.fecha); return f >= ayer && f < hoy; });
+  const delMes = ops.filter((o) => new Date(o.fecha) >= mes);
+  const delPrevio = ops.filter((o) => { const f = new Date(o.fecha); return f >= mesPrevio && f < mes; });
+
+  const totalHoy = suma(deHoy, (o) => o.total);
+  const totalAyer = suma(deAyer, (o) => o.total);
+  const totalMes = suma(delMes, (o) => o.total);
+  const totalPrevio = suma(delPrevio, (o) => o.total);
+  const ticket = delMes.length ? totalMes / delMes.length : 0;
+  const ticketPrevio = delPrevio.length ? totalPrevio / delPrevio.length : 0;
+
+  /* Sin base contra la que comparar no hay variación. Un "+100%" contra
+     cero no informa nada y encima alarma. */
+  const variacion = (hoy_, antes) => (antes > 0 ? hoy_ / antes - 1 : null);
+
+  const porArea = new Map();
+  const porServicio = new Map();
+  for (const l of lineas) {
+    const area = (l.items && l.items.categoria) || "Otros";
+    porArea.set(area, (porArea.get(area) || 0) + Number(l.total || 0));
+    const k = l.descripcion;
+    const s = porServicio.get(k) || { nombre: k, cantidad: 0, total: 0 };
+    s.cantidad += Number(l.cantidad || 0);
+    s.total += Number(l.total || 0);
+    porServicio.set(k, s);
+  }
+
+  const base = {
+    facturacionHoy: dato(totalHoy, { delta: variacion(totalHoy, totalAyer), serie: serieDiaria(ops, 14, ahora), operaciones: deHoy.length }),
+    ingresosMes: dato(totalMes, { delta: variacion(totalMes, totalPrevio), serie: serieDiaria(delMes, 14, ahora) }),
+    ticketPromedio: dato(Math.round(ticket), { delta: variacion(ticket, ticketPrevio) }),
+    ingresosPorArea: dato([...porArea.entries()]
+      .map(([nombre, total]) => ({ nombre, total }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 5)),
+    topServicios: dato([...porServicio.values()].sort((a, b) => b.total - a.total).slice(0, 5)),
+    clientesNuevos: dato(nuevos.map((c) => ({ id: c.id, nombre: c.razon_social, alta: c.creado_en ? new Date(c.creado_en) : null }))),
+    pagosPendientes: dato(pendiente.monto, { clientes: pendiente.clientes, operaciones: pendiente.operaciones }),
+
+    /* Lo que todavía no tiene tabla. En un comercio real se muestran en
+       cero y el estado vacío lo dice; en uno de demostración los completa
+       el generador de abajo. */
+    turnosHoy: dato(0),
+    asistenciaHoy: dato(0, { sobre: 0 }),
+    proximosTurnos: dato(0),
+    huecos: dato(0),
+    listaEspera: dato(0),
+    abonosPorVencer: dato(0),
+    agendaHoy: dato([]),
+    utilizacionSalas: dato([]),
+    turnosPorEstado: dato([]),
+    rendimiento: dato({ ingresos: totalMes, asistencia: null, conversion: null }),
+    acciones: dato([]),
+    alertas: dato([]),
+  };
+
+  return demo ? await completarConEjemplos(base, empresaId, ahora) : base;
+}
+
+/* ------------------------------------------------------------
+   Los ejemplos
+
+   Se arman con el catálogo y las salas de verdad del comercio, no con
+   nombres inventados: así el tablero de demostración muestra las mismas
+   prestaciones que están cargadas, y el día que aparezcan los turnos
+   reales el salto es menos brusco.
+
+   El azar va sembrado con la fecha para que los números no bailen en cada
+   pestañeo de la pantalla: dentro del mismo día son siempre los mismos.
+   ------------------------------------------------------------ */
+
+const NOMBRES = [
+  "Florencia Silva", "Martina López", "Agustín Pérez", "Belén Acosta",
+  "Julieta Román", "Camila Torres", "Valentina Rojas", "Lucía Fernández",
+];
+
+async function completarConEjemplos(base, empresaId, ahora) {
+  const [{ data: items }, { data: salas }] = await Promise.all([
+    supabase.from("items").select("nombre, duracion_min, precio, categoria")
+      .eq("empresa_id", empresaId).eq("tipo", "servicio").eq("activo", true).limit(20),
+    supabase.from("recursos").select("nombre, capacidad")
+      .eq("empresa_id", empresaId).eq("activo", true).order("orden").limit(10),
+  ]);
+
+  const servicios = items && items.length ? items : [{ nombre: "Turno", duracion_min: 60, precio: 0, categoria: "Servicios" }];
+  const espacios = salas && salas.length ? salas : [{ nombre: "Sala", capacidad: 1 }];
+
+  const r = mulberry32(Number(`${ahora.getFullYear()}${ahora.getMonth() + 1}${ahora.getDate()}`));
+  const ri = (a, b) => a + Math.floor(r() * (b - a + 1));
+  const elegir = (xs) => xs[Math.floor(r() * xs.length)];
+
+  const turnos = ri(18, 28);
+  const asistieron = Math.round(turnos * (0.7 + r() * 0.15));
+  const ausentes = ri(1, 3);
+  const noShow = ri(0, 2);
+  const cancelados = ri(1, 4);
+  const confirmados = Math.max(0, turnos - asistieron - ausentes - noShow - cancelados);
+
+  const agenda = [];
+  for (let i = 0; i < 6; i++) {
+    const s = elegir(servicios);
+    const e = elegir(espacios);
+    const cupo = Math.max(1, e.capacidad || 1);
+    const hora = 9 + i * 2;
+    agenda.push({
+      hora: `${String(hora).padStart(2, "0")}:00`,
+      servicio: s.nombre,
+      sala: e.nombre,
+      persona: elegir(NOMBRES),
+      estado: hora <= ahora.getHours() && hora + 1 > ahora.getHours() ? "en curso" : "confirmado",
+      ocupados: cupo === 1 ? 1 : ri(Math.ceil(cupo / 2), cupo),
+      cupo,
+    });
+  }
+
+  const utilizacion = espacios.slice(0, 5).map((e) => ({ nombre: e.nombre, pct: ri(58, 92) / 100 }));
+  const huecos = ri(2, 5);
+  const espera = ri(6, 16);
+  const abonos = ri(1, 4);
+
+  return {
+    ...base,
+    turnosHoy: ejemplo(turnos, { delta: (ri(-8, 20)) / 100 }),
+    asistenciaHoy: ejemplo(asistieron, { sobre: turnos }),
+    proximosTurnos: ejemplo(ri(3, 8)),
+    huecos: ejemplo(huecos),
+    listaEspera: ejemplo(espera),
+    abonosPorVencer: ejemplo(abonos),
+    agendaHoy: ejemplo(agenda),
+    utilizacionSalas: ejemplo(utilizacion),
+    turnosPorEstado: ejemplo([
+      { k: "confirmados", n: "Confirmados", v: confirmados, tono: "info" },
+      { k: "asistieron", n: "Asistieron", v: asistieron, tono: "bien" },
+      { k: "ausentes", n: "Ausentes", v: ausentes, tono: "ojo" },
+      { k: "noshow", n: "No show", v: noShow, tono: "mal" },
+      { k: "cancelados", n: "Cancelados", v: cancelados, tono: "tenue" },
+    ]),
+    rendimiento: ejemplo({
+      ingresos: base.ingresosMes.valor,
+      asistencia: asistieron / Math.max(1, turnos),
+      conversion: ri(38, 62) / 100,
+    }),
+    acciones: ejemplo([
+      { k: "inactivos", n: "Contactar clientes inactivos", d: `${ri(3, 9)} hace más de 30 días que no vienen.`, accion: "Ver clientes", tab: "clientes" },
+      { k: "huecos", n: "Ofrecer huecos disponibles", d: `${huecos} lugares libres hoy que podés ofrecer.`, accion: "Enviar ofertas", tab: null },
+      { k: "abonos", n: "Recordar abonos por vencer", d: `${abonos} vencen esta semana.`, accion: "Enviar recordatorios", tab: null },
+      { k: "espera", n: "Mover la lista de espera", d: `${espera} personas esperando un lugar.`, accion: "Ver lista", tab: null },
+    ]),
+    alertas: ejemplo([
+      { k: "abonos", n: `${abonos} abonos por vencer`, d: "Vencen en los próximos 7 días.", accion: "Ver abonos", tab: null, tono: "ojo" },
+      { k: "noshow", n: `${noShow} no show hoy`, d: "Impacta en el consumo de abonos.", accion: "Ver asistencia", tab: null, tono: "mal" },
+      { k: "cobros", n: "Pagos pendientes", d: `${base.pagosPendientes.clientes || ri(2, 6)} clientes con saldo.`, accion: "Ver caja", tab: "caja", tono: "info" },
+    ]),
+  };
+}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -34,6 +34,7 @@ import { Compras, Picking } from "../modulos/Compras.jsx";
 import { Clientes } from "../modulos/Clientes.jsx";
 import { Equipo } from "../modulos/Equipo.jsx";
 import { Agenda } from "../modulos/Agenda.jsx";
+import { Ventas } from "../modulos/Ventas.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
@@ -66,6 +67,7 @@ const MODULOS = [
   { k: "clientes", n: "Clientes", d: "Facturación A, B y C" },
   { k: "equipo", n: "Equipo", d: "Quién trabaja, qué hace y cuándo" },
   { k: "agenda", n: "Agenda", d: "Turnos, clases y disponibilidad" },
+  { k: "ventas", n: "Ventas", d: "Abonos, packs y planes" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
@@ -83,12 +85,12 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "reportes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
     k: "cajero", n: "Cajero", d: "Cobra, sin ver costos ni ganancias",
-    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda"],
+    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda", "ventas"],
     permisos: { verCostos: false, descuentos: false, anular: false, cerrarCaja: false, cambiarPrecios: false, ajustes: false },
   },
   {
@@ -1713,6 +1715,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
           {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "agenda" && <Agenda empresaId={empresaId} sucursalId={null} permisos={permisos} clientes={clientes} toast={toast} ir={ir} />}
+          {tab === "ventas" && <Ventas empresaId={empresaId} sucursalId={null} clientes={clientes} ajustes={ajustes} caja={caja} permisos={permisos} toast={toast} ir={ir} />}
           {tab === "productos" && (cargandoProductos
             ? <Vacio>Cargando catálogo…</Vacio>
             : <Productos key={foco || "todos"} productos={productos}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -14,6 +14,7 @@ import { entrar as autenticar, pedirRecuperacion, cambiarClave } from "../datos/
 import { MEDIOS_INICIALES, FISCAL_INICIAL, LISTAS_INICIALES, money, nf, hora, numeroALetras } from "../utils/helpers.js";
 import { cargarProductos, guardarProducto, crearProducto } from "../datos/items.js";
 import { cargarClientes, crearCliente, guardarCliente } from "../datos/clientes.js";
+import { cargarRubro } from "../datos/rubros.js";
 import { armarVenta, registrarVenta, siguienteNumero, ponerNumeradorAlDia, resumenDelDia } from "../datos/ventas.js";
 import { encolar, quitar, cuantasPendientes, vigilarCola } from "../datos/cola.js";
 import { ajustesDe, guardarAjustes } from "../datos/ajustes.js";
@@ -753,43 +754,53 @@ function Login({ onEntrar, imagenFondo, errorInicial }) {
   );
 }
 
-const NAV = [
-  { k: "inicio", n: "Inicio", i: LayoutDashboard },
-  { k: "comandas", n: "Salón", i: UtensilsCrossed },
-  /* El mostrador no está acá a propósito: vive adentro de la pantalla de
-     comanda, con su propia barra lateral. Ponerlo también como pestaña del
-     panel dejaba una ventana adentro de otra, con dos barras laterales
-     compitiendo por el mismo trabajo.
+/* El menú ya no está escrito acá: sale de `rubros`, una fila por tipo de
+   negocio. Lo que queda en el código es lo que una fila no puede guardar.
 
-     La cocina sí es una pestaña: es una pantalla colgada en la pared que
-     nadie toca, y no comparte nada con el flujo de tomar pedidos.
-     Ojo con la clave: `pedidos` ya es el picking del minimercado. */
-  { k: "cocina", n: "Cocina", i: ChefHat },
-  { k: "pedidos", n: "Pedidos", i: ClipboardList },
-  { k: "clientes", n: "Clientes", i: Users },
-  { k: "productos", n: "Productos", i: Package },
-  { k: "stock", n: "Stock", i: Boxes },
-  { k: "compras", n: "Compras", i: Truck },
-  { k: "caja", n: "Caja", i: Wallet },
-  { k: "reportes", n: "Informes", i: BarChart3 },
-  { k: "asistente", n: "Asistente", i: Sparkles },
-  { k: "ajustes", n: "Ajustes", i: Settings },
-];
-
-const TITULOS = {
-  inicio: ["Inicio", "Cómo viene el negocio hoy"],
-  comandas: ["Salón", "Qué mesa está ocupada, qué lleva y cuánto hace que espera"],
-  cocina: ["Cocina", "Lo que hay que preparar, en el orden en que se pidió"],
-  pedidos: ["Pedidos", "Preparación con pistola y control de faltantes"],
-  clientes: ["Clientes", "Para emitir facturas A, B o C según corresponda"],
-  productos: ["Productos", "Costos, precios y margen de todo tu catálogo"],
-  stock: ["Stock", "Qué reponer, qué vence y qué no se mueve"],
-  compras: ["Compras", "Cargar remitos, pedidos sugeridos y proveedores"],
-  caja: ["Caja", "Ingresos, egresos y arqueo del día"],
-  reportes: ["Informes", "Qué se vende, qué deja plata y qué cambió"],
-  asistente: ["Asistente", "Tus datos explicados y qué conviene hacer"],
-  ajustes: ["Ajustes", "Configuración del negocio y del sistema"],
+   El ícono viaja como nombre porque la base no sabe de React. Un nombre
+   que no esté en esta tabla cae en uno neutro: un módulo con el ícono
+   equivocado se usa igual, una pantalla que revienta no. */
+const ICONOS = {
+  panel: LayoutDashboard, planilla: ClipboardList, gente: Users,
+  caja: Package, cajas: Boxes, camion: Truck, billetera: Wallet,
+  barras: BarChart3, chispas: Sparkles, tuerca: Settings,
+  cubiertos: UtensilsCrossed, cocina: ChefHat, agenda: CalendarDays,
 };
+const iconoDe = (n) => ICONOS[n] || Store;
+
+/* El respaldo, para cuando el rubro no carga: sin conexión, o un comercio
+   con un rubro que nadie dio de alta. Sin esto una consulta fallida deja a
+   alguien sin manera de moverse por el sistema.
+
+   Va todo adentro y en un solo grupo sin rótulo, que es como se veía el
+   menú antes de este cambio. Lo que el comercio no contrató lo filtra
+   `puedeVer` igual.
+
+   El mostrador no está acá a propósito: vive adentro de la pantalla de
+   comanda, con su propia barra lateral. Ponerlo también como pestaña del
+   panel dejaba una ventana adentro de otra, con dos barras laterales
+   compitiendo por el mismo trabajo.
+
+   La cocina sí es una pestaña: es una pantalla colgada en la pared que
+   nadie toca, y no comparte nada con el flujo de tomar pedidos.
+   Ojo con la clave: `pedidos` ya es el picking del minimercado. */
+const MENU_POR_DEFECTO = [{
+  clave: "todo", nombre: null,
+  modulos: [
+    { k: "inicio", n: "Inicio", i: "panel", d: "Cómo viene el negocio hoy" },
+    { k: "comandas", n: "Salón", i: "cubiertos", d: "Qué mesa está ocupada, qué lleva y cuánto hace que espera" },
+    { k: "cocina", n: "Cocina", i: "cocina", d: "Lo que hay que preparar, en el orden en que se pidió" },
+    { k: "pedidos", n: "Pedidos", i: "planilla", d: "Preparación con pistola y control de faltantes" },
+    { k: "clientes", n: "Clientes", i: "gente", d: "Para emitir facturas A, B o C según corresponda" },
+    { k: "productos", n: "Productos", i: "caja", d: "Costos, precios y margen de todo tu catálogo" },
+    { k: "stock", n: "Stock", i: "cajas", d: "Qué reponer, qué vence y qué no se mueve" },
+    { k: "compras", n: "Compras", i: "camion", d: "Cargar remitos, pedidos sugeridos y proveedores" },
+    { k: "caja", n: "Caja", i: "billetera", d: "Ingresos, egresos y arqueo del día" },
+    { k: "reportes", n: "Informes", i: "barras", d: "Qué se vende, qué deja plata y qué cambió" },
+    { k: "asistente", n: "Asistente", i: "chispas", d: "Tus datos explicados y qué conviene hacer" },
+    { k: "ajustes", n: "Ajustes", i: "tuerca", d: "Configuración del negocio y del sistema" },
+  ],
+}];
 
 /* Los formularios entregan texto y la base espera números: una cadena
    vacía en una columna numérica la rechaza el servidor, no el navegador. */
@@ -849,6 +860,7 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
   const [pedidosCli, setPedidosCli] = useState(PEDIDOS_INICIALES);
   const [provs, setProvs] = useState(PROV_INFO);
   const [clientes, setClientes] = useState([]);
+  const [rubro, setRubro] = useState(null);
   const [altaProd, setAltaProd] = useState(null);
   /* Sale de la empresa, no del código. Antes cualquier comercio arrancaba
      con el nombre y el CUIT de Super 25, así que imprimía comprobantes a
@@ -933,6 +945,17 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
         setClientes([]);
         toast(e.message || "No pudimos cargar los clientes.", "mal");
       });
+    return () => { vigente = false; };
+  }, [empresaId]);
+
+  /* La forma del menú también sale de la base. Si falla no se avisa nada:
+     queda el menú de respaldo, el sistema se usa igual, y un cartel rojo
+     sobre algo que el usuario no puede arreglar solo asusta al pedo. */
+  useEffect(() => {
+    let vigente = true;
+    cargarRubro(sesion.comercio && sesion.comercio.rubro)
+      .then((r) => { if (vigente) setRubro(r); })
+      .catch((e) => console.error("No se pudo cargar el rubro:", e));
     return () => { vigente = false; };
   }, [empresaId]);
 
@@ -1287,7 +1310,24 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
 
   const ventasHoy = resumenDia.total;
   const ticketsHoy = resumenDia.tickets;
-  const [titulo, bajada] = TITULOS[tab];
+  /* El menú que se dibuja: los grupos del rubro, con los módulos que el
+     comercio contrató y el rol habilita. Un grupo que se queda sin ningún
+     módulo no se dibuja — si no, una estética vería el rótulo "Finanzas"
+     con nada abajo. */
+  const grupos = useMemo(() => {
+    const base = rubro && rubro.grupos.length ? rubro.grupos : MENU_POR_DEFECTO;
+    return base
+      .map((g) => ({ ...g, modulos: (g.modulos || []).filter((m) => puedeVer(m.k)) }))
+      .filter((g) => g.modulos.length > 0);
+  }, [rubro, modulos, config.cocinaEnPantalla]);
+
+  /* El título de la pantalla sale del mismo lugar que su renglón del menú.
+     Antes eran dos listas separadas que había que acordarse de actualizar
+     juntas. */
+  const items = useMemo(() => grupos.flatMap((g) => g.modulos), [grupos]);
+  const actual = items.find((m) => m.k === tab);
+  const titulo = actual ? actual.n : "";
+  const bajada = actual ? actual.d : "";
   const alertasAltas = ins.filter((i) => i.sev === "alta").length;
 
   useEffect(() => {
@@ -1465,18 +1505,34 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
             {vender === "comandas" ? <ClipboardList size={17} /> : <Barcode size={17} />} {rotuloVender}
             <kbd className="f-m text-[10px] border border-borde-fuerte rounded px-1 py-0.5">F10</kbd>
           </Boton>
+          {/* Un grupo sin nombre se dibuja como lista pelada: así se ve el
+              menú de un comercio o un bar, igual que antes de que esto
+              fuera configurable. El rótulo aparece solo donde el rubro lo
+              definió. */}
           <nav className="mt-3 space-y-0.5">
-            {NAV.filter((n) => puedeVer(n.k)).map((n) => (
-              <button key={n.k} onClick={() => ir(n.k)}
-                className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-sm font-medium transition-colors ${tab === n.k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
-                <n.i size={16} className={tab === n.k ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
-                {n.k === "compras" && k.criticos.filter((x) => x.cobertura < 4).length > 0 && (
-                  <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{k.criticos.filter((x) => x.cobertura < 4).length}</span>
+            {grupos.map((g) => (
+              <div key={g.clave} className={g.nombre ? "pt-3" : ""}>
+                {g.nombre && (
+                  <div className="px-2.5 pb-1 text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">{g.nombre}</div>
                 )}
-                {n.k === "pedidos" && pedidosCli.filter((p) => p.estado !== "entregado").length > 0 && (
-                  <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{pedidosCli.filter((p) => p.estado !== "entregado").length}</span>
-                )}
-              </button>
+                <div className="space-y-0.5">
+                  {g.modulos.map((n) => {
+                    const Icono = iconoDe(n.i);
+                    return (
+                      <button key={n.k} onClick={() => ir(n.k)}
+                        className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-sm font-medium transition-colors ${tab === n.k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+                        <Icono size={16} className={tab === n.k ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
+                        {n.k === "compras" && k.criticos.filter((x) => x.cobertura < 4).length > 0 && (
+                          <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{k.criticos.filter((x) => x.cobertura < 4).length}</span>
+                        )}
+                        {n.k === "pedidos" && pedidosCli.filter((p) => p.estado !== "entregado").length > 0 && (
+                          <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{pedidosCli.filter((p) => p.estado !== "entregado").length}</span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
             ))}
           </nav>
           <div className="mt-auto px-2.5 py-3 border-t border-borde">
@@ -1492,12 +1548,18 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
             <button onClick={cobrar_} className="flex flex-col items-center gap-0.5 px-3.5 py-2 text-[10px] font-semibold shrink-0 text-sobre-acento bg-acento">
               {vender === "comandas" ? <ClipboardList size={17} /> : <Barcode size={17} />} {rotuloVender}
             </button>
-            {NAV.filter((n) => puedeVer(n.k)).map((n) => (
-              <button key={n.k} onClick={() => ir(n.k)}
-                className={`flex flex-col items-center gap-0.5 px-3.5 py-2 text-[10px] font-semibold shrink-0 ${tab === n.k ? "text-acento" : "text-texto-tenue"}`}>
-                <n.i size={17} /> {n.n}
-              </button>
-            ))}
+            {/* En el celular los grupos se aplanan a propósito: es una tira
+                que se desliza, y meterle rótulos adentro la haría más larga
+                sin ordenar nada. */}
+            {items.map((n) => {
+              const Icono = iconoDe(n.i);
+              return (
+                <button key={n.k} onClick={() => ir(n.k)}
+                  className={`flex flex-col items-center gap-0.5 px-3.5 py-2 text-[10px] font-semibold shrink-0 ${tab === n.k ? "text-acento" : "text-texto-tenue"}`}>
+                  <Icono size={17} /> {n.n}
+                </button>
+              );
+            })}
           </div>
         </div>
 

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -1380,7 +1380,10 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
 
   useEffect(() => {
     const h = (e) => {
-      if (e.key === "F10" && vista === "panel") { e.preventDefault(); cobrar_(); }
+      /* El atajo sigue a la acción del rubro: si el rubro no tiene una,
+         F10 no abre nada. Dejarlo vivo mientras se le saca el botón sería
+         dejar una puerta escondida a una pantalla que no corresponde. */
+      if (e.key === "F10" && vista === "panel" && accion) { e.preventDefault(); cobrar_(); }
     };
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -7,14 +7,15 @@ import {
   LayoutDashboard, Barcode, Package, Boxes, Truck, Wallet, BarChart3,
   Sparkles, Settings, Plus, Check, AlertTriangle, ChevronLeft, Upload,
   ArrowRight, Store, CalendarDays, ClipboardList, Users, Sun, Moon, LogOut, ZapOff,
-  Eye, EyeOff, Mail, KeyRound, UtensilsCrossed, ChefHat, ShoppingBag
+  Eye, EyeOff, Mail, KeyRound, UtensilsCrossed, ChefHat, ShoppingBag,
+  Heart, MessageSquare
 } from "lucide-react";
 import { mulberry32, uid, HOY, DATA, PEDIDOS_INICIALES, PROV_INFO, fdatel } from "../datos/generador.js";
 import { entrar as autenticar, pedirRecuperacion, cambiarClave } from "../datos/sesion.js";
 import { MEDIOS_INICIALES, FISCAL_INICIAL, LISTAS_INICIALES, money, nf, hora, numeroALetras } from "../utils/helpers.js";
 import { cargarProductos, guardarProducto, crearProducto } from "../datos/items.js";
 import { cargarClientes, crearCliente, guardarCliente } from "../datos/clientes.js";
-import { cargarRubro } from "../datos/rubros.js";
+import { cargarTablero, tableroVacio } from "../datos/tablero.js";
 import { armarVenta, registrarVenta, siguienteNumero, ponerNumeradorAlDia, resumenDelDia } from "../datos/ventas.js";
 import { encolar, quitar, cuantasPendientes, vigilarCola } from "../datos/cola.js";
 import { ajustesDe, guardarAjustes } from "../datos/ajustes.js";
@@ -23,7 +24,7 @@ import {
   abrirCaja as abrirCajaEnBase, cerrarCaja as cerrarCajaEnBase,
 } from "../datos/caja.js";
 import { calcular, insights } from "../utils/diagnostico.js";
-import { ScanCtx, useScanner, beep, campanita, hablar, Boton, Modal, Vacio } from "../ui/Base.jsx";
+import { ScanCtx, useScanner, beep, campanita, hablar, Boton, Modal, Vacio, Apagado } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 import { Inicio } from "../modulos/Inicio.jsx";
 import { POS, FormProducto } from "../modulos/Vender.jsx";
@@ -765,6 +766,7 @@ const ICONOS = {
   caja: Package, cajas: Boxes, camion: Truck, billetera: Wallet,
   barras: BarChart3, chispas: Sparkles, tuerca: Settings,
   cubiertos: UtensilsCrossed, cocina: ChefHat, agenda: CalendarDays,
+  barcode: Barcode, bolsa: ShoppingBag, corazon: Heart, mensaje: MessageSquare,
 };
 const iconoDe = (n) => ICONOS[n] || Store;
 
@@ -822,7 +824,7 @@ function aDatosDeBase(d) {
   };
 }
 
-function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
+function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
   const { modulos, permisos, esPlataforma } = permisosDe(sesion);
 
   /* La configuración del comercio se lee directo de la sesión. `ajustes`
@@ -845,7 +847,22 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
   /* Cada forma de vender tiene su pantalla a pantalla completa: el POS para
      el que cobra en un mostrador, la de comandas para el que atiende un
      salón. El panel es a dónde se va a mirar el negocio, no a trabajar. */
-  const [vista, setVista] = useState(vender === "comandas" ? "comanda" : vender === "cobro" ? "cobro" : "panel");
+  /* Por dónde abre el sistema lo decide el rubro y ya no lo que se
+     contrató. El criterio viejo era "si tenés cobro, abrís en la caja
+     registradora", y con eso una estética arrancaba en un lector de
+     códigos de barras con el carrito vacío, cuando el 95% de su día es
+     agendar y vender es la excepción.
+
+     Un rubro igual puede pedir abrir en una pantalla que este comercio no
+     contrató. Ahí manda lo que el comercio tiene: abrir en una pantalla
+     vacía es peor que abrir en otra. */
+  const entradaPorDefecto = vender === "comandas" ? "comanda" : vender === "cobro" ? "cobro" : "panel";
+  const entradaPedida = rubro && rubro.entrada;
+  const entrada =
+    entradaPedida === "comanda" && vender !== "comandas" ? entradaPorDefecto :
+    entradaPedida === "cobro" && !vender ? entradaPorDefecto :
+    entradaPedida || entradaPorDefecto;
+  const [vista, setVista] = useState(entrada);
   const [tab, setTab] = useState("inicio");
   const [foco, setFoco] = useState(null);
   const [productos, setProductos] = useState([]);
@@ -860,7 +877,7 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
   const [pedidosCli, setPedidosCli] = useState(PEDIDOS_INICIALES);
   const [provs, setProvs] = useState(PROV_INFO);
   const [clientes, setClientes] = useState([]);
-  const [rubro, setRubro] = useState(null);
+  const [tablero, setTablero] = useState(null);
   const [altaProd, setAltaProd] = useState(null);
   /* Sale de la empresa, no del código. Antes cualquier comercio arrancaba
      con el nombre y el CUIT de Super 25, así que imprimía comprobantes a
@@ -948,16 +965,26 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
     return () => { vigente = false; };
   }, [empresaId]);
 
-  /* La forma del menú también sale de la base. Si falla no se avisa nada:
-     queda el menú de respaldo, el sistema se usa igual, y un cartel rojo
-     sobre algo que el usuario no puede arreglar solo asusta al pedo. */
+  /* El tablero se pide una sola vez y solo donde se usa: el de comercio se
+     calcula en el navegador sobre el catálogo y no necesita nada de esto.
+
+     Si falla no se rompe la pantalla ni se avisa con un cartel rojo: queda
+     el tablero en su estado vacío, que ya dice lo que corresponde. */
+  const esTableroDeServicios = !!rubro && rubro.inicio === "servicios";
   useEffect(() => {
+    if (!esTableroDeServicios) return;
     let vigente = true;
-    cargarRubro(sesion.comercio && sesion.comercio.rubro)
-      .then((r) => { if (vigente) setRubro(r); })
-      .catch((e) => console.error("No se pudo cargar el rubro:", e));
+    cargarTablero({ empresaId, demo: config.demo === true })
+      .then((t) => { if (vigente) setTablero(t); })
+      .catch((e) => {
+        /* Con el tablero vacío la pantalla se dibuja igual y cada bloque
+           dice que no tiene datos. Dejarlo en null la colgaba mostrando el
+           esqueleto de carga para siempre, que es la peor de las dos. */
+        console.error("No se pudo armar el tablero:", e);
+        if (vigente) setTablero(tableroVacio());
+      });
     return () => { vigente = false; };
-  }, [empresaId]);
+  }, [empresaId, esTableroDeServicios]);
 
   /* El cierre guarda el saldo de apertura y lo que se contó, pero no lo que
      el sistema esperaba: eso es la suma de los movimientos de esa sesión y se
@@ -1296,7 +1323,16 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
   /* El botón dice qué se va a hacer, no dónde: desde ahí se comanda,
      sea para una mesa o para el mostrador. "Salón" ya está en el menú
      de la izquierda y repetirlo no agregaba nada. */
-  const rotuloVender = vender === "comandas" ? "Comanda" : "Cobrar";
+  /* La acción principal también es del rubro. `destacada` es lo que decide
+     si va como el botón grande de arriba —cobrar en un minimercado, tomar
+     la comanda en un bar— o como un renglón más del menú, que es lo que
+     corresponde donde vender existe pero es la excepción. */
+  const accion = (rubro && rubro.accion) || (vender
+    ? { k: "cobro", n: vender === "comandas" ? "Comanda" : "Cobrar",
+        i: vender === "comandas" ? "planilla" : "barcode", destacada: true }
+    : null);
+  const rotuloVender = accion ? accion.n : "Cobrar";
+  const IconoAccion = iconoDe(accion ? accion.i : "barcode");
 
   // Un único lector para todo el sistema: si la pantalla activa sabe qué hacer
   // con el código, se lo queda; si no, abre la ficha rápida del producto.
@@ -1318,13 +1354,25 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
     const base = rubro && rubro.grupos.length ? rubro.grupos : MENU_POR_DEFECTO;
     return base
       .map((g) => ({ ...g, modulos: (g.modulos || []).filter((m) => puedeVer(m.k)) }))
-      .filter((g) => g.modulos.length > 0);
+      /* Una sección se queda si tiene algo que mostrar, o si está marcada
+         como próxima: esas se dibujan apagadas para que se vea a dónde va
+         el sistema. Lo que el comercio simplemente no contrató desaparece,
+         como siempre — un módulo no contratado no lo ve ni el dueño. */
+      .filter((g) => g.modulos.length > 0 || g.proximo);
   }, [rubro, modulos, config.cocinaEnPantalla]);
 
-  /* El título de la pantalla sale del mismo lugar que su renglón del menú.
-     Antes eran dos listas separadas que había que acordarse de actualizar
-     juntas. */
-  const items = useMemo(() => grupos.flatMap((g) => g.modulos), [grupos]);
+  /* Una sección con un solo módulo se dibuja con el nombre de la sección y
+     no con el del módulo: "Clientes y equipo" es un renglón, no un rótulo
+     con "Clientes" colgando abajo. Cuando una sección junte dos o más, ahí
+     van a hacer falta las pestañas internas.
+
+     El título de la pantalla sale de acá también. Antes eran dos listas
+     separadas que había que acordarse de actualizar juntas. */
+  const items = useMemo(() => grupos.flatMap((g) => (
+    g.modulos.length === 1 && g.nombre
+      ? [{ ...g.modulos[0], n: g.nombre, i: g.i || g.modulos[0].i }]
+      : g.modulos
+  )), [grupos]);
   const actual = items.find((m) => m.k === tab);
   const titulo = actual ? actual.n : "";
   const bajada = actual ? actual.d : "";
@@ -1501,39 +1549,71 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
               <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">1 caja · {nf.format(productos.length)} art.</div>
             </div>
           </div>
-          <Boton className="w-full mt-2" size="lg" onClick={cobrar_}>
-            {vender === "comandas" ? <ClipboardList size={17} /> : <Barcode size={17} />} {rotuloVender}
-            <kbd className="f-m text-[10px] border border-borde-fuerte rounded px-1 py-0.5">F10</kbd>
-          </Boton>
+          {accion && accion.destacada && (
+            <Boton className="w-full mt-2" size="lg" onClick={cobrar_}>
+              <IconoAccion size={17} /> {rotuloVender}
+              <kbd className="f-m text-[10px] border border-borde-fuerte rounded px-1 py-0.5">F10</kbd>
+            </Boton>
+          )}
+          {/* Sin destacar queda como un renglón más, arriba del menú: se
+              llega igual y con el mismo atajo, pero deja de ser lo más
+              grande de una pantalla donde no es lo que más se hace. */}
+          {accion && !accion.destacada && (
+            <button onClick={cobrar_}
+              className="w-full mt-3 flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-sm font-medium text-texto-suave hover:bg-superficie-2 transition-colors">
+              <IconoAccion size={16} className="text-texto-tenue" /> {rotuloVender}
+              <kbd className="f-m text-[10px] border border-borde rounded px-1 py-0.5 ml-auto text-texto-tenue">F10</kbd>
+            </button>
+          )}
           {/* Un grupo sin nombre se dibuja como lista pelada: así se ve el
               menú de un comercio o un bar, igual que antes de que esto
               fuera configurable. El rótulo aparece solo donde el rubro lo
               definió. */}
           <nav className="mt-3 space-y-0.5">
-            {grupos.map((g) => (
-              <div key={g.clave} className={g.nombre ? "pt-3" : ""}>
-                {g.nombre && (
-                  <div className="px-2.5 pb-1 text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">{g.nombre}</div>
-                )}
-                <div className="space-y-0.5">
-                  {g.modulos.map((n) => {
-                    const Icono = iconoDe(n.i);
-                    return (
-                      <button key={n.k} onClick={() => ir(n.k)}
-                        className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-sm font-medium transition-colors ${tab === n.k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
-                        <Icono size={16} className={tab === n.k ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
-                        {n.k === "compras" && k.criticos.filter((x) => x.cobertura < 4).length > 0 && (
-                          <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{k.criticos.filter((x) => x.cobertura < 4).length}</span>
-                        )}
-                        {n.k === "pedidos" && pedidosCli.filter((p) => p.estado !== "entregado").length > 0 && (
-                          <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{pedidosCli.filter((p) => p.estado !== "entregado").length}</span>
-                        )}
-                      </button>
-                    );
-                  })}
+            {grupos.map((g) => {
+              const fila = "w-full flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-sm font-medium transition-colors";
+
+              /* Sección que va a existir y todavía no: se ve, no se toca. */
+              if (g.modulos.length === 0) {
+                const Icono = iconoDe(g.i);
+                return (
+                  <Apagado key={g.clave} motivo={g.nombre} className={`${fila} !justify-start text-texto-suave`}>
+                    <Icono size={16} className="text-texto-tenue" /> {g.nombre}
+                  </Apagado>
+                );
+              }
+
+              /* Con un solo módulo, la sección es el renglón. */
+              const sola = g.modulos.length === 1 && g.nombre;
+              const visibles = sola
+                ? [{ ...g.modulos[0], n: g.nombre, i: g.i || g.modulos[0].i }]
+                : g.modulos;
+
+              return (
+                <div key={g.clave} className={g.nombre && !sola ? "pt-3" : ""}>
+                  {g.nombre && !sola && (
+                    <div className="px-2.5 pb-1 text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">{g.nombre}</div>
+                  )}
+                  <div className="space-y-0.5">
+                    {visibles.map((n) => {
+                      const Icono = iconoDe(n.i);
+                      return (
+                        <button key={n.k} onClick={() => ir(n.k)}
+                          className={`${fila} ${tab === n.k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+                          <Icono size={16} className={tab === n.k ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
+                          {n.k === "compras" && k.criticos.filter((x) => x.cobertura < 4).length > 0 && (
+                            <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{k.criticos.filter((x) => x.cobertura < 4).length}</span>
+                          )}
+                          {n.k === "pedidos" && pedidosCli.filter((p) => p.estado !== "entregado").length > 0 && (
+                            <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{pedidosCli.filter((p) => p.estado !== "entregado").length}</span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </nav>
           <div className="mt-auto px-2.5 py-3 border-t border-borde">
             <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">Caja</div>
@@ -1545,9 +1625,13 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
         {/* Navegación móvil */}
         <div className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-superficie border-t border-borde overflow-x-auto seguro-abajo">
           <div className="flex">
-            <button onClick={cobrar_} className="flex flex-col items-center gap-0.5 px-3.5 py-2 text-[10px] font-semibold shrink-0 text-sobre-acento bg-acento">
-              {vender === "comandas" ? <ClipboardList size={17} /> : <Barcode size={17} />} {rotuloVender}
-            </button>
+            {accion && (
+              <button onClick={cobrar_}
+                className={`flex flex-col items-center gap-0.5 px-3.5 py-2 text-[10px] font-semibold shrink-0 ${
+                  accion.destacada ? "text-sobre-acento bg-acento" : "text-texto-tenue"}`}>
+                <IconoAccion size={17} /> {rotuloVender}
+              </button>
+            )}
             {/* En el celular los grupos se aplanan a propósito: es una tira
                 que se desliza, y meterle rótulos adentro la haría más larga
                 sin ordenar nada. */}
@@ -1574,14 +1658,22 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
               <span className="text-texto-tenue">·</span>
               <span className="f-m">{money(ventasHoy)} hoy</span>
               <BotonTema tema={tema} setTema={setTema} />
-              <Boton size="sm" variant="dark" className="md:hidden" onClick={cobrar_}>
-                {vender === "comandas" ? <ClipboardList size={14} /> : <Barcode size={14} />} {rotuloVender}
-              </Boton>
+              {accion && (
+                <Boton size="sm" variant="dark" className="md:hidden" onClick={cobrar_}>
+                  <IconoAccion size={14} /> {rotuloVender}
+                </Boton>
+              )}
               <Sesion sesion={sesion} onSalir={onSalir} />
             </div>
           </header>
 
-          {tab === "inicio" && <Inicio k={k} ins={ins} ventasHoy={ventasHoy} ticketsHoy={ticketsHoy} ir={ir} negocio={ajustes.negocio} aCobrar={cobrar_} />}
+          {tab === "inicio" && (
+            <Inicio tablero={rubro ? rubro.inicio : "comercio"}
+              k={k} ins={ins} ventasHoy={ventasHoy} ticketsHoy={ticketsHoy}
+              datos={tablero} cargando={esTableroDeServicios && !tablero}
+              usuario={sesion.nombre} puedeVer={puedeVer}
+              ir={ir} negocio={ajustes.negocio} aCobrar={cobrar_} />
+          )}
           {tab === "comandas" && (
             <Comandas empresaId={empresaId} config={config} ajustes={ajustes}
               caja={caja} permisos={permisos} sesion={sesion} toast={toast} />

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -33,6 +33,7 @@ import { Stock } from "../modulos/Stock.jsx";
 import { Compras, Picking } from "../modulos/Compras.jsx";
 import { Clientes } from "../modulos/Clientes.jsx";
 import { Equipo } from "../modulos/Equipo.jsx";
+import { Agenda } from "../modulos/Agenda.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
@@ -64,6 +65,7 @@ const MODULOS = [
   { k: "pedidos", n: "Pedidos", d: "Preparación con pistola" },
   { k: "clientes", n: "Clientes", d: "Facturación A, B y C" },
   { k: "equipo", n: "Equipo", d: "Quién trabaja, qué hace y cuándo" },
+  { k: "agenda", n: "Agenda", d: "Turnos, clases y disponibilidad" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
@@ -81,12 +83,12 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "reportes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
     k: "cajero", n: "Cajero", d: "Cobra, sin ver costos ni ganancias",
-    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo"],
+    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda"],
     permisos: { verCostos: false, descuentos: false, anular: false, cerrarCaja: false, cambiarPrecios: false, ajustes: false },
   },
   {
@@ -1710,6 +1712,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "pedidos" && <Picking pedidos={pedidosCli} setPedidos={setPedidosCli} productos={productos} setProductos={setProductos} cobrar={cobrar} ajustes={ajustes} toast={toast} />}
           {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
           {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
+          {tab === "agenda" && <Agenda empresaId={empresaId} sucursalId={null} permisos={permisos} clientes={clientes} toast={toast} ir={ir} />}
           {tab === "productos" && (cargandoProductos
             ? <Vacio>Cargando catálogo…</Vacio>
             : <Productos key={foco || "todos"} productos={productos}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -35,6 +35,7 @@ import { Clientes } from "../modulos/Clientes.jsx";
 import { Equipo } from "../modulos/Equipo.jsx";
 import { Agenda } from "../modulos/Agenda.jsx";
 import { Ventas } from "../modulos/Ventas.jsx";
+import { Finanzas } from "../modulos/Finanzas.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
@@ -68,6 +69,7 @@ const MODULOS = [
   { k: "equipo", n: "Equipo", d: "Quién trabaja, qué hace y cuándo" },
   { k: "agenda", n: "Agenda", d: "Turnos, clases y disponibilidad" },
   { k: "ventas", n: "Ventas", d: "Abonos, packs y planes" },
+  { k: "finanzas", n: "Finanzas", d: "Caja, ingresos, egresos y sueldos" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
@@ -85,12 +87,12 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "reportes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
     k: "cajero", n: "Cajero", d: "Cobra, sin ver costos ni ganancias",
-    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda", "ventas"],
+    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas"],
     permisos: { verCostos: false, descuentos: false, anular: false, cerrarCaja: false, cambiarPrecios: false, ajustes: false },
   },
   {
@@ -1715,6 +1717,11 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
           {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "agenda" && <Agenda empresaId={empresaId} sucursalId={null} permisos={permisos} clientes={clientes} toast={toast} ir={ir} />}
+          {tab === "finanzas" && (
+            <Finanzas empresaId={empresaId} caja={caja} movCaja={movCaja} ajustes={ajustes}
+              abrirCaja={abrirCajaDelDia} cerrarCaja={cerrarCajaDelDia}
+              permisos={permisos} toast={toast} />
+          )}
           {tab === "ventas" && <Ventas empresaId={empresaId} sucursalId={null} clientes={clientes} ajustes={ajustes} caja={caja} permisos={permisos} toast={toast} ir={ir} />}
           {tab === "productos" && (cargandoProductos
             ? <Vacio>Cargando catálogo…</Vacio>

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -24,7 +24,7 @@ import {
   abrirCaja as abrirCajaEnBase, cerrarCaja as cerrarCajaEnBase,
 } from "../datos/caja.js";
 import { calcular, insights } from "../utils/diagnostico.js";
-import { ScanCtx, useScanner, beep, campanita, hablar, Boton, Modal, Vacio, Apagado } from "../ui/Base.jsx";
+import { ScanCtx, useScanner, beep, campanita, hablar, Boton, Modal, Vacio, Apagado, Tabs } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 import { Inicio } from "../modulos/Inicio.jsx";
 import { POS, FormProducto } from "../modulos/Vender.jsx";
@@ -32,6 +32,7 @@ import { Productos } from "../modulos/Productos.jsx";
 import { Stock } from "../modulos/Stock.jsx";
 import { Compras, Picking } from "../modulos/Compras.jsx";
 import { Clientes } from "../modulos/Clientes.jsx";
+import { Equipo } from "../modulos/Equipo.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
@@ -62,6 +63,7 @@ const MODULOS = [
   { k: "compras", n: "Compras", d: "Remitos, costos y proveedores" },
   { k: "pedidos", n: "Pedidos", d: "Preparación con pistola" },
   { k: "clientes", n: "Clientes", d: "Facturación A, B y C" },
+  { k: "equipo", n: "Equipo", d: "Quién trabaja, qué hace y cuándo" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
@@ -79,12 +81,12 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "reportes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
     k: "cajero", n: "Cajero", d: "Cobra, sin ver costos ni ganancias",
-    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes"],
+    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo"],
     permisos: { verCostos: false, descuentos: false, anular: false, cerrarCaja: false, cambiarPrecios: false, ajustes: false },
   },
   {
@@ -1368,14 +1370,27 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
 
      El título de la pantalla sale de acá también. Antes eran dos listas
      separadas que había que acordarse de actualizar juntas. */
+  /* Una sección con nombre es un solo renglón del menú, tenga uno o cinco
+     módulos adentro: "Clientes y equipo" es una fila, no un rótulo con
+     "Clientes" y "Equipo" colgando. Los de adentro se eligen con pestañas
+     arriba del contenido, que es a donde va la arquitectura de diez
+     secciones.
+
+     Las secciones sin nombre —comercio, gastronomía— siguen desplegando
+     sus módulos como una lista plana, igual que siempre. */
   const items = useMemo(() => grupos.flatMap((g) => (
-    g.modulos.length === 1 && g.nombre
+    g.nombre && g.modulos.length
       ? [{ ...g.modulos[0], n: g.nombre, i: g.i || g.modulos[0].i }]
       : g.modulos
   )), [grupos]);
-  const actual = items.find((m) => m.k === tab);
-  const titulo = actual ? actual.n : "";
-  const bajada = actual ? actual.d : "";
+
+  const seccion = grupos.find((g) => g.modulos.some((m) => m.k === tab)) || null;
+  const moduloActual = seccion ? seccion.modulos.find((m) => m.k === tab) : null;
+  /* El título es el de la sección y la bajada la del módulo: así el
+     encabezado y las pestañas dicen cosas distintas y no se repiten. */
+  const titulo = seccion && seccion.nombre ? seccion.nombre : moduloActual ? moduloActual.n : "";
+  const bajada = moduloActual ? moduloActual.d : "";
+  const pestanas = seccion && seccion.nombre && seccion.modulos.length > 1 ? seccion.modulos : null;
   const alertasAltas = ins.filter((i) => i.sev === "alta").length;
 
   useEffect(() => {
@@ -1586,24 +1601,24 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
                 );
               }
 
-              /* Con un solo módulo, la sección es el renglón. */
-              const sola = g.modulos.length === 1 && g.nombre;
-              const visibles = sola
-                ? [{ ...g.modulos[0], n: g.nombre, i: g.i || g.modulos[0].i }]
+              /* La sección con nombre es el renglón, tenga los módulos que
+                 tenga; los de adentro se eligen con las pestañas de
+                 arriba. Queda activa mientras se esté en cualquiera de
+                 ellos. */
+              const visibles = g.nombre
+                ? [{ ...g.modulos[0], n: g.nombre, i: g.i || g.modulos[0].i, claves: g.modulos.map((m) => m.k) }]
                 : g.modulos;
 
               return (
-                <div key={g.clave} className={g.nombre && !sola ? "pt-3" : ""}>
-                  {g.nombre && !sola && (
-                    <div className="px-2.5 pb-1 text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">{g.nombre}</div>
-                  )}
+                <div key={g.clave}>
                   <div className="space-y-0.5">
                     {visibles.map((n) => {
                       const Icono = iconoDe(n.i);
+                      const aca = (n.claves || [n.k]).includes(tab);
                       return (
                         <button key={n.k} onClick={() => ir(n.k)}
-                          className={`${fila} ${tab === n.k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
-                          <Icono size={16} className={tab === n.k ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
+                          className={`${fila} ${aca ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+                          <Icono size={16} className={aca ? "text-acento-vivo" : "text-texto-tenue"} /> {n.n}
                           {n.k === "compras" && k.criticos.filter((x) => x.cobertura < 4).length > 0 && (
                             <span className="ml-auto text-[10px] font-bold bg-acento text-sobre-acento rounded-full px-1.5">{k.criticos.filter((x) => x.cobertura < 4).length}</span>
                           )}
@@ -1670,6 +1685,16 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
             </div>
           </header>
 
+          {/* Los módulos de una sección se eligen acá y no en la barra
+              lateral: es lo que permite que el menú sean diez renglones y
+              no quince. Aparecen solo cuando la sección tiene más de uno,
+              porque una pestaña sola no es una elección. */}
+          {pestanas && (
+            <div className="-mt-2 mb-5">
+              <Tabs value={tab} onChange={ir} items={pestanas.map((m) => ({ k: m.k, n: m.n }))} />
+            </div>
+          )}
+
           {tab === "inicio" && (
             <Inicio tablero={rubro ? rubro.inicio : "comercio"}
               k={k} ins={ins} ventasHoy={ventasHoy} ticketsHoy={ticketsHoy}
@@ -1684,6 +1709,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "cocina" && <Cocina empresaId={empresaId} config={config} toast={toast} />}
           {tab === "pedidos" && <Picking pedidos={pedidosCli} setPedidos={setPedidosCli} productos={productos} setProductos={setProductos} cobrar={cobrar} ajustes={ajustes} toast={toast} />}
           {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
+          {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "productos" && (cargandoProductos
             ? <Vacio>Cargando catálogo…</Vacio>
             : <Productos key={foco || "todos"} productos={productos}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -939,7 +939,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
   useEffect(() => {
     let vigente = true;
     setCargandoProductos(true);
-    cargarProductos()
+    cargarProductos(empresaId)
       .then((ps) => { if (vigente) setProductos(ps); })
       .catch((e) => {
         if (!vigente) return;
@@ -955,7 +955,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
      impreso en un comprobante. */
   useEffect(() => {
     let vigente = true;
-    cargarClientes()
+    cargarClientes(empresaId)
       .then((cs) => { if (vigente) setClientes(cs); })
       .catch((e) => {
         if (!vigente) return;
@@ -1037,11 +1037,11 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
     } catch (e) {
       toast(e.message || "No se pudo guardar el producto.", "mal");
       try {
-        const ps = await cargarProductos();
+        const ps = await cargarProductos(empresaId);
         setProductos(ps);
       } catch { /* el error ya se avisó; el catálogo queda como estaba */ }
     }
-  }, []);
+  }, [empresaId]);
 
   const agregarProducto = useCallback(async (datos, msg) => {
     try {

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -11,8 +11,9 @@ import {
 } from "lucide-react";
 import { mulberry32, uid, HOY, DATA, PEDIDOS_INICIALES, PROV_INFO, fdatel } from "../datos/generador.js";
 import { entrar as autenticar, pedirRecuperacion, cambiarClave } from "../datos/sesion.js";
-import { CLIENTES_INICIALES, MEDIOS_INICIALES, FISCAL_INICIAL, LISTAS_INICIALES, money, nf, hora, numeroALetras } from "../utils/helpers.js";
+import { MEDIOS_INICIALES, FISCAL_INICIAL, LISTAS_INICIALES, money, nf, hora, numeroALetras } from "../utils/helpers.js";
 import { cargarProductos, guardarProducto, crearProducto } from "../datos/items.js";
+import { cargarClientes, crearCliente, guardarCliente } from "../datos/clientes.js";
 import { armarVenta, registrarVenta, siguienteNumero, ponerNumeradorAlDia, resumenDelDia } from "../datos/ventas.js";
 import { encolar, quitar, cuantasPendientes, vigilarCola } from "../datos/cola.js";
 import { ajustesDe, guardarAjustes } from "../datos/ajustes.js";
@@ -847,7 +848,7 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
   const [pedidos, setPedidos] = useState([]);
   const [pedidosCli, setPedidosCli] = useState(PEDIDOS_INICIALES);
   const [provs, setProvs] = useState(PROV_INFO);
-  const [clientes, setClientes] = useState(CLIENTES_INICIALES);
+  const [clientes, setClientes] = useState([]);
   const [altaProd, setAltaProd] = useState(null);
   /* Sale de la empresa, no del código. Antes cualquier comercio arrancaba
      con el nombre y el CUIT de Super 25, así que imprimía comprobantes a
@@ -920,6 +921,21 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
     return () => { vigente = false; };
   }, [empresaId]);
 
+  /* Los clientes tampoco vienen del generador. Si la carga falla se queda la
+     lista vacía y se avisa: un cliente inventado en pantalla terminaría
+     impreso en un comprobante. */
+  useEffect(() => {
+    let vigente = true;
+    cargarClientes()
+      .then((cs) => { if (vigente) setClientes(cs); })
+      .catch((e) => {
+        if (!vigente) return;
+        setClientes([]);
+        toast(e.message || "No pudimos cargar los clientes.", "mal");
+      });
+    return () => { vigente = false; };
+  }, [empresaId]);
+
   /* El cierre guarda el saldo de apertura y lo que se contó, pero no lo que
      el sistema esperaba: eso es la suma de los movimientos de esa sesión y se
      recalcula al leerlo. Guardarlo aparte sería un número copiado a mano que
@@ -986,6 +1002,31 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
       return p;
     } catch (e) {
       toast(e.message || "No se pudo crear el producto.", "mal");
+      return null;
+    }
+  }, [empresaId]);
+
+  /* Un solo camino para el alta y la edición: quien llama pasa el cliente
+     entero y el id decide cuál de las dos es. Devuelve el cliente guardado
+     porque el POS lo necesita para seleccionarlo enseguida.
+
+     Acá no se cambia la pantalla primero, al revés que con los productos: un
+     cliente se guarda de a uno y el id lo genera la base, así que mostrarlo
+     antes de tenerlo obligaría a inventarle uno y después reemplazarlo. */
+  const guardarClienteEn = useCallback(async (datos) => {
+    try {
+      if (datos.id) {
+        const c = await guardarCliente(datos.id, datos);
+        if (c) setClientes((cs) => cs.map((x) => (x.id === c.id ? c : x)));
+        toast(`${datos.razonSocial} guardado.`);
+        return c;
+      }
+      const c = await crearCliente(empresaId, datos);
+      setClientes((cs) => [...cs, c].sort((a, b) => a.razonSocial.localeCompare(b.razonSocial, "es")));
+      toast(`${c.razonSocial} agregado.`);
+      return c;
+    } catch (e) {
+      toast(e.message || "No se pudo guardar el cliente.", "mal");
       return null;
     }
   }, [empresaId]);
@@ -1338,7 +1379,7 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
             {caja.abierta ? (
               <POS productos={productos} setProductos={setProductos} cobrar={cobrar} ajustes={ajustes}
                 toast={toast} ir={ir} pendiente={pendientePOS} setPendiente={setPendientePOS}
-                aPanel={() => { setVista("panel"); setTab("inicio"); }} clientes={clientes} setClientes={setClientes} permisos={permisos} />
+                aPanel={() => { setVista("panel"); setTab("inicio"); }} clientes={clientes} guardarCliente={guardarClienteEn} permisos={permisos} />
             ) : (
               <div className="py-8">
                 <CajaCerrada caja={caja} abrirCaja={abrirCajaDelDia}
@@ -1485,7 +1526,7 @@ function Sistema({ sesion, onSalir, setComercios, tema, setTema }) {
           )}
           {tab === "cocina" && <Cocina empresaId={empresaId} config={config} toast={toast} />}
           {tab === "pedidos" && <Picking pedidos={pedidosCli} setPedidos={setPedidosCli} productos={productos} setProductos={setProductos} cobrar={cobrar} ajustes={ajustes} toast={toast} />}
-          {tab === "clientes" && <Clientes clientes={clientes} setClientes={setClientes} tickets={tickets} ajustes={ajustes} toast={toast} />}
+          {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
           {tab === "productos" && (cargandoProductos
             ? <Vacio>Cargando catálogo…</Vacio>
             : <Productos key={foco || "todos"} productos={productos}

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -12,8 +12,10 @@
    última palabra la tiene el servidor: dos personas agendando al mismo
    tiempo desde dos dispositivos solo se resuelven ahí.
 
-   Las clases grupales, la lista de espera y la recurrencia todavía no
-   tienen base, así que sus pestañas están apagadas. Ninguna finge andar.
+   Las clases grupales y la lista de espera ya funcionan: una clase es
+   una reserva con cupo y las inscripciones cuelgan de ella. La
+   recurrencia y los abonos todavía no tienen base, así que lo que los
+   necesita está apagado. Nada finge andar.
    ============================================================ */
 
 import React, { useState, useEffect, useMemo, useCallback } from "react";
@@ -24,10 +26,12 @@ import {
 import {
   cargarTurnos, agendarTurno, moverTurno, cambiarEstado, guardarNotas,
   escucharTurnos, ESTADOS, estadoDe, franjasDelDia, minutosDe, aReloj, OCUPAN,
+  crearClase, inscribir, cargarInscriptos, cargarEspera, anotarEnEspera,
+  marcarEspera, bloquear, MOTIVOS_BLOQUEO,
 } from "../datos/agenda.js";
 import { cargarEquipo, cargarServicios } from "../datos/equipo.js";
 import { cargarRecursos } from "../datos/comandas.js";
-import { money, nf } from "../utils/helpers.js";
+import { money } from "../utils/helpers.js";
 import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado, Apagado } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 import { Drawer } from "../ui/Drawer.jsx";
@@ -126,10 +130,40 @@ function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, onGua
   return (
     <Modal open onClose={onCerrar} ancho="max-w-xl">
       <div className="p-5">
-        <h3 className="f-d text-lg">{d.id ? "Editar turno" : "Nuevo turno"}</h3>
+        <h3 className="f-d text-lg">
+          {d.id ? "Reprogramar" : d.tipo === "clase" ? "Nueva clase" : "Nuevo turno"}
+        </h3>
+
+        {/* Un turno es para una persona; una clase abre lugares y la gente
+            se anota después. Se elige acá y no en dos botones distintos
+            porque el 90% del formulario es el mismo. */}
+        {!d.id && (
+          <div className="flex rounded-lg border border-borde overflow-hidden mt-3 w-fit">
+            {[["turno", "Turno individual"], ["clase", "Clase grupal"]].map(([k, n]) => (
+              <button key={k} onClick={() => setD((x) => ({ ...x, tipo: k }))}
+                className={`px-3 py-1.5 text-sm font-semibold ${(d.tipo || "turno") === k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+                {n}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="space-y-3 mt-4">
-          {/* Quién viene */}
+          {/* Una clase no tiene cliente: tiene lugares, y la gente se
+              anota después desde el detalle. */}
+          {d.tipo === "clase" ? (
+            <div className="grid grid-cols-2 gap-3">
+              <Campo label="Nombre de la clase">
+                <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)}
+                  placeholder="Reformer intermedio" className={inputCls} />
+              </Campo>
+              <Campo label="Cupo">
+                <input type="number" min="1" value={d.cupo || 1}
+                  onChange={(e) => set("cupo", Number(e.target.value))} className={inputCls} />
+              </Campo>
+            </div>
+          ) : (
+          /* Quién viene */
           <Campo label="Cliente">
             {cliente ? (
               <div className="flex items-center gap-2 mt-1">
@@ -170,6 +204,7 @@ function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, onGua
               </>
             )}
           </Campo>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <Campo label="Servicio">
@@ -267,6 +302,9 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
   const [error, setError] = useState("");
   const [alta, setAlta] = useState(null);
   const [abierto, setAbierto] = useState(null);
+  const [inscriptos, setInscriptos] = useState([]);
+  const [espera, setEspera] = useState([]);
+  const [bloqueo, setBloqueo] = useState(null);
   const [filtro, setFiltro] = useState({ personalId: "", recursoId: "", estado: "" });
 
   const ventana = useMemo(() => (
@@ -318,6 +356,18 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
     return cortar;
   }, [empresaId, releer]);
 
+  /* Los anotados y la lista de espera de una clase se piden al abrir su
+     detalle y cada vez que algo cambia: si otro anota a alguien mientras
+     este panel está abierto, el cupo que se ve tiene que ser el de verdad. */
+  useEffect(() => {
+    if (!abierto || abierto.forma !== "clase") { setInscriptos([]); setEspera([]); return; }
+    let vigente = true;
+    Promise.all([cargarInscriptos(empresaId, abierto.id), cargarEspera(empresaId, abierto.id)])
+      .then(([i, e]) => { if (vigente) { setInscriptos(i); setEspera(e); } })
+      .catch((e) => { if (vigente) toast(e.message || "No pudimos cargar los anotados.", "mal"); });
+    return () => { vigente = false; };
+  }, [abierto, empresaId, turnos]);
+
   const profesionales = useMemo(() => equipo.filter((p) => p.tipo === "profesional"), [equipo]);
 
   /* Las columnas del calendario. En el día son las personas o las salas;
@@ -346,30 +396,45 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
       .map((p) => ({ k: p.id, n: p.nombre, sub: p.especialidad, franjas: franjasDelDia(p, fecha) }));
   }, [vista, agrupar, salas, profesionales, equipo, fecha, ventana.desde, filtro.personalId]);
 
-  const bloques = useMemo(() => turnos.map((t) => ({
+  /* Las inscripciones no se dibujan: viven adentro de la clase, y
+     dibujarlas sería pintar seis bloques encima del mismo reformer. */
+  const visibles = useMemo(() => turnos.filter((t) => t.forma !== "inscripcion"), [turnos]);
+
+  const bloques = useMemo(() => visibles.map((t) => ({
     id: t.id,
     columna: vista === "semana" ? paraInput(t.desde) : (agrupar === "sala" ? t.recursoId : t.personalId),
     desde: minutosDe(t.desde),
     hasta: minutosDe(t.desde) + t.duracion,
     turno: t,
-  })), [turnos, vista, agrupar]);
+  })), [visibles, vista, agrupar]);
 
   /* El rango de horas que se dibuja sale de los horarios cargados, no de
      un 8 a 20 fijo: un negocio que abre a las 7 no tiene por qué
      desplazar la pantalla para ver su primer turno. */
   const [desdeHora, hastaHora] = useMemo(() => {
     const fs = columnas.flatMap((c) => c.franjas || []).filter((f) => f.hasta - f.desde < 1440);
-    const conTurnos = turnos.map((t) => minutosDe(t.desde));
+    const conTurnos = visibles.map((t) => minutosDe(t.desde));
     const min = Math.min(...[...fs.map((f) => f.desde), ...conTurnos, 9 * 60]);
-    const max = Math.max(...[...fs.map((f) => f.hasta), ...turnos.map((t) => minutosDe(t.desde) + t.duracion), 18 * 60]);
+    const max = Math.max(...[...fs.map((f) => f.hasta), ...visibles.map((t) => minutosDe(t.desde) + t.duracion), 18 * 60]);
     return [Math.max(0, Math.floor(min / 60) - 1), Math.min(24, Math.ceil(max / 60) + 1)];
-  }, [columnas, turnos]);
+  }, [columnas, visibles]);
 
   async function guardar(d) {
     const desde = conHora(new Date(`${d.fecha}T12:00:00`), d.hora);
     try {
       if (d.id) {
         await moverTurno(d.id, desde, Number(d.duracion));
+      } else if (d.tipo === "clase") {
+        await crearClase({
+          empresaId, sucursalId,
+          personalId: d.personalId || null,
+          recursoId: d.recursoId || null,
+          itemId: d.itemId || null,
+          nombre: d.nombre || "Clase",
+          desde, duracion: Number(d.duracion),
+          cupo: Number(d.cupo) || 1,
+          notas: d.notas,
+        });
       } else {
         await agendarTurno({
           empresaId, sucursalId,
@@ -406,7 +471,7 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
 
   const pestanas = [
     { k: "calendario", n: "Calendario" },
-    { k: "lista", n: "Lista", badge: turnos.length || null },
+    { k: "lista", n: "Lista", badge: visibles.length || null },
   ];
 
   return (
@@ -467,14 +532,19 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
           {ESTADOS.map((e) => <option key={e.k} value={e.k}>{e.n}</option>)}
         </select>
 
-        <Boton size="sm" className="ml-auto" onClick={() => setAlta({ fecha: paraInput(fecha) })}>
-          <Plus size={14} /> Nuevo turno
-        </Boton>
+        <div className="ml-auto flex items-center gap-2">
+          <Boton size="sm" variant="ghost" onClick={() => setBloqueo({ fecha: paraInput(fecha) })}>
+            <Trash2 size={14} /> Bloquear
+          </Boton>
+          <Boton size="sm" onClick={() => setAlta({ fecha: paraInput(fecha) })}>
+            <Plus size={14} /> Nuevo turno
+          </Boton>
+        </div>
       </div>
 
       <Tabs value={pestana} onChange={setPestana} items={pestanas} />
       <div className="flex flex-wrap gap-3 -mt-2">
-        {["Clases", "Lista de espera", "Asistencia"].map((n) => (
+        {["Asistencia", "Recurrencia"].map((n) => (
           <Apagado key={n} motivo={n} className="text-sm font-semibold py-2">{n}</Apagado>
         ))}
       </div>
@@ -486,11 +556,11 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
         ) : cargando ? (
           <Cargando>Buscando los turnos…</Cargando>
         ) : pestana === "lista" ? (
-          turnos.length === 0 ? (
+          visibles.length === 0 ? (
             <Vacio>No hay turnos {vista === "dia" ? "para este día" : "en esta semana"}.</Vacio>
           ) : (
             <ul className="divide-y divide-borde">
-              {turnos.map((t) => (
+              {visibles.map((t) => (
                 <li key={t.id}>
                   <button onClick={() => setAbierto(t)} className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
                     <span className="f-m text-sm text-texto w-24 shrink-0">
@@ -539,12 +609,23 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
               }[e.tono];
               return (
                 <span className={`block h-full rounded-lg border px-2 py-1 overflow-hidden ${tono}`}>
-                  <span className="block text-[11px] font-semibold text-texto truncate">
-                    {t.servicio || t.cliente}
+                  <span className="flex items-baseline gap-1.5">
+                    <span className="flex-1 text-[11px] font-semibold text-texto truncate">
+                      {t.forma === "clase" ? t.cliente : (t.servicio || t.cliente)}
+                    </span>
+                    {/* En una clase lo que hay que ver de lejos es cuánto
+                        lugar queda, no quién viene. */}
+                    {t.forma === "clase" && (
+                      <span className={`f-m text-[10px] shrink-0 ${t.lugares <= 0 ? "text-mal" : ""}`}>
+                        {t.anotados}/{t.cupo}
+                      </span>
+                    )}
                   </span>
                   {alto > 34 && (
                     <span className="block text-[10px] truncate opacity-80">
-                      {soloHora(t.desde)} · {t.servicio ? t.cliente : t.profesional}
+                      {soloHora(t.desde)} · {t.forma === "clase"
+                        ? (t.profesional || t.sala || "sin asignar")
+                        : (t.servicio ? t.cliente : t.profesional)}
                     </span>
                   )}
                 </span>
@@ -560,25 +641,38 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
         subtitulo={abierto ? `${fechaLarga(abierto.desde)} · ${soloHora(abierto.desde)}` : ""}
         acciones={abierto && (
           <div className="flex flex-wrap gap-2">
-            {abierto.estado === "pendiente" && (
+            {/* La asistencia de una clase es de cada anotado, no de la
+                clase: uno vino y otro no. Por eso acá no van. */}
+            {abierto.forma === "clase" && abierto.estado !== "cancelada" && (
+              <button onClick={() => mover(abierto, "cancelada")}
+                className="text-xs font-semibold text-mal hover:underline px-2">Cancelar la clase</button>
+            )}
+            {abierto.forma !== "clase" && abierto.estado === "pendiente" && (
               <Boton size="sm" onClick={() => mover(abierto, "confirmada")}><Check size={14} /> Confirmar</Boton>
             )}
-            {OCUPAN.includes(abierto.estado) && abierto.estado !== "cumplida" && (
+            {abierto.forma !== "clase" && OCUPAN.includes(abierto.estado) && abierto.estado !== "cumplida" && (
               <Boton size="sm" variant="ghost" onClick={() => mover(abierto, "cumplida")}>Asistió</Boton>
             )}
-            {abierto.estado !== "cumplida" && (
+            {abierto.forma !== "clase" && abierto.estado !== "cumplida" && (
               <Boton size="sm" variant="ghost" onClick={() => mover(abierto, "ausente")}>No vino</Boton>
             )}
             <Boton size="sm" variant="ghost" onClick={() => { setAlta({ ...aFormulario(abierto) }); setAbierto(null); }}>
               <RotateCcw size={14} /> Reprogramar
             </Boton>
-            {abierto.estado !== "cancelada" && (
+            {abierto.forma !== "clase" && abierto.estado !== "cancelada" && (
               <button onClick={() => mover(abierto, "cancelada")}
                 className="text-xs font-semibold text-mal hover:underline px-2">Cancelar turno</button>
             )}
           </div>
         )}>
-        {abierto && (
+        {abierto && abierto.forma === "clase" && (
+          <PanelClase clase={abierto} inscriptos={inscriptos} espera={espera}
+            clientes={clientes} empresaId={empresaId} toast={toast}
+            onCambio={async () => { await releer(); }}
+            onMover={mover} />
+        )}
+
+        {abierto && abierto.forma !== "clase" && (
           <div className="space-y-4">
             <Sello tono={estadoDe(abierto.estado).tono}>{estadoDe(abierto.estado).n}</Sello>
 
@@ -631,6 +725,27 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
 
       <FormTurno abierto={!!alta} inicial={alta} equipo={equipo} servicios={servicios}
         salas={salas} clientes={clientes} onGuardar={guardar} onCerrar={() => setAlta(null)} />
+
+      <FormBloqueo abierto={!!bloqueo} inicial={bloqueo} equipo={equipo}
+        onCerrar={() => setBloqueo(null)}
+        onGuardar={async (b) => {
+          try {
+            const dia = new Date(`${b.fecha}T12:00:00`);
+            await bloquear({
+              empresaId,
+              personalId: b.personalId || null,
+              desde: conHora(dia, b.desde),
+              hasta: conHora(dia, b.hasta),
+              motivo: b.motivo,
+              nota: b.nota,
+            });
+            await releer();
+            toast("Bloqueo guardado.");
+            return null;
+          } catch (e) {
+            return e.message || "No se pudo bloquear.";
+          }
+        }} />
     </div>
   );
 }
@@ -660,4 +775,267 @@ function unir(franjas) {
     else salida.push({ ...f });
   }
   return salida;
+}
+
+/* ------------------------------------------------------------
+   El detalle de una clase
+
+   Una clase no tiene un cliente: tiene lugares y gente adentro. La
+   asistencia es de cada anotado —uno vino y otro no— así que se marca
+   persona por persona y no sobre la clase.
+
+   La lista de espera no se promueve sola. Liberar un lugar y meter a
+   alguien sin avisarle es peor que el problema: se entera cuando ya no
+   puede ir.
+   ------------------------------------------------------------ */
+function PanelClase({ clase, inscriptos, espera, clientes, empresaId, toast, onCambio, onMover }) {
+  const [q, setQ] = useState("");
+  const [trabajando, setTrabajando] = useState(false);
+
+  const vivos = inscriptos.filter((i) => !["cancelada", "ausente"].includes(i.estado));
+  const lugares = clase.cupo - vivos.length;
+  const llena = lugares <= 0;
+
+  const norm = (t) => String(t || "").toLowerCase();
+  const candidatos = q.trim().length >= 1
+    ? clientes.filter((c) => norm(c.razonSocial).includes(norm(q))).slice(0, 5)
+    : [];
+
+  async function anotar({ clienteId, nombre }) {
+    setTrabajando(true);
+    try {
+      if (llena) {
+        await anotarEnEspera({ empresaId, claseId: clase.id, clienteId, nombre });
+        toast(`${nombre} quedó en lista de espera.`);
+      } else {
+        await inscribir({ claseId: clase.id, clienteId, nombre });
+        toast(`${nombre} anotado.`);
+      }
+      setQ("");
+      await onCambio();
+    } catch (e) {
+      toast(e.message || "No se pudo anotar.", "mal");
+    }
+    setTrabajando(false);
+  }
+
+  async function cambiar(inscripcion, estado) {
+    try {
+      await cambiarEstado(inscripcion.id, estado);
+      await onCambio();
+    } catch (e) {
+      toast(e.message || "No se pudo cambiar.", "mal");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Sello tono={estadoDe(clase.estado).tono}>{estadoDe(clase.estado).n}</Sello>
+        <Sello tono={llena ? "mal" : "bien"}>
+          {vivos.length} de {clase.cupo}{llena ? " · completa" : ` · ${lugares} ${lugares === 1 ? "lugar" : "lugares"}`}
+        </Sello>
+      </div>
+
+      <dl className="space-y-2.5 text-sm">
+        {[
+          [Clock, "Duración", `${clase.duracion} minutos`],
+          [User, "Profesional", clase.profesional || "sin asignar"],
+          [MapPin, "Sala", clase.sala || "sin sala"],
+        ].map(([Ico, rot, val]) => (
+          <div key={rot} className="flex items-start gap-2.5">
+            <Ico size={15} className="text-texto-tenue mt-0.5 shrink-0" />
+            <dt className="text-texto-tenue w-24 shrink-0">{rot}</dt>
+            <dd className="text-texto min-w-0 flex-1">{val}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Anotar */}
+      {clase.estado !== "cancelada" && (
+        <div className="rounded-xl border border-borde p-3">
+          <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold">
+            {llena ? "Sumar a la lista de espera" : "Anotar a alguien"}
+          </div>
+          <div className="relative mt-2">
+            <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-texto-tenue" />
+            <input value={q} onChange={(e) => setQ(e.target.value)}
+              placeholder={clientes.length ? "Buscar un cliente o escribir un nombre" : "Escribir un nombre"}
+              className={`${inputCls} pl-8`} />
+          </div>
+          {candidatos.length > 0 && (
+            <ul className="mt-1 border border-borde rounded-lg divide-y divide-borde">
+              {candidatos.map((c) => (
+                <li key={c.id}>
+                  <button disabled={trabajando}
+                    onClick={() => anotar({ clienteId: c.id, nombre: c.razonSocial })}
+                    className="w-full text-left px-2.5 py-1.5 text-sm hover:bg-superficie-2 disabled:opacity-50">
+                    {c.razonSocial}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {q.trim().length >= 2 && (
+            <Boton size="sm" variant="ghost" className="mt-2" disabled={trabajando}
+              onClick={() => anotar({ clienteId: null, nombre: q.trim() })}>
+              <Plus size={14} /> {llena ? "A la espera" : "Anotar"} a “{q.trim()}”
+            </Boton>
+          )}
+        </div>
+      )}
+
+      {/* Los anotados */}
+      <div>
+        <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-2">
+          Anotados ({vivos.length})
+        </div>
+        {inscriptos.length === 0 ? (
+          <Vacio>Todavía no se anotó nadie.</Vacio>
+        ) : (
+          <ul className="space-y-1.5">
+            {inscriptos.map((i) => (
+              <li key={i.id} className="flex items-center gap-2 text-sm">
+                <span className="truncate flex-1 text-texto">{i.cliente}</span>
+                <Sello tono={estadoDe(i.estado).tono}>{estadoDe(i.estado).n}</Sello>
+                {!["cumplida", "cancelada"].includes(i.estado) && (
+                  <>
+                    <button onClick={() => cambiar(i, "cumplida")} title="Vino"
+                      className="p-1.5 rounded-lg text-texto-tenue hover:text-bien hover:bg-superficie-2">
+                      <Check size={14} />
+                    </button>
+                    <button onClick={() => cambiar(i, "ausente")} title="No vino"
+                      className="p-1.5 rounded-lg text-texto-tenue hover:text-mal hover:bg-superficie-2">
+                      <X size={14} />
+                    </button>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* La espera */}
+      {espera.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-2">
+            Esperando un lugar ({espera.length})
+          </div>
+          <ul className="space-y-1.5">
+            {espera.map((e, i) => (
+              <li key={e.id} className="flex items-center gap-2 text-sm">
+                <span className="f-m text-xs text-texto-tenue w-5 shrink-0">{i + 1}</span>
+                <span className="truncate flex-1 text-texto">{e.nombre}</span>
+                {!llena ? (
+                  <Boton size="sm" variant="ghost" disabled={trabajando} onClick={async () => {
+                    setTrabajando(true);
+                    try {
+                      await inscribir({ claseId: clase.id, clienteId: e.cliente_id, nombre: e.nombre });
+                      await marcarEspera(e.id, "entro");
+                      toast(`${e.nombre} entró a la clase.`);
+                      await onCambio();
+                    } catch (err) {
+                      toast(err.message || "No se pudo.", "mal");
+                    }
+                    setTrabajando(false);
+                  }}>Meterlo</Boton>
+                ) : (
+                  <button onClick={async () => { await marcarEspera(e.id, "baja"); await onCambio(); }}
+                    className="text-xs text-texto-tenue hover:text-mal">Sacar</button>
+                )}
+              </li>
+            ))}
+          </ul>
+          {!llena && (
+            <p className="text-xs text-texto-suave mt-2">
+              Se liberó un lugar. Nadie entra solo: avisale primero y después metelo.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------
+   Bloquear un rato
+
+   Vacaciones, una ausencia, un feriado o simplemente "hoy no atiendo de
+   dos a cuatro". Va contra `excepciones`, que desde la 0032 guarda horas
+   y no días enteros. Sin profesional, el bloqueo es de todo el comercio:
+   eso es un feriado.
+   ------------------------------------------------------------ */
+function FormBloqueo({ abierto, inicial, equipo, onGuardar, onCerrar }) {
+  const [d, setD] = useState({});
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!abierto) return;
+    setD({ desde: "14:00", hasta: "16:00", motivo: "ausencia", nota: "", ...(inicial || {}) });
+    setError("");
+  }, [abierto, inicial]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+  const falta = !d.fecha || !d.desde || !d.hasta || d.hasta <= d.desde;
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-md">
+      <div className="p-5">
+        <h3 className="f-d text-lg">Bloquear un rato</h3>
+        <p className="text-xs text-texto-suave mt-1">
+          Mientras esté bloqueado no se puede agendar nada ahí, ni a mano ni desde afuera.
+        </p>
+
+        <div className="space-y-3 mt-4">
+          <Campo label="Quién">
+            <select value={d.personalId || ""} onChange={(e) => set("personalId", e.target.value || null)} className={inputCls}>
+              <option value="">Todo el local</option>
+              {equipo.map((p) => <option key={p.id} value={p.id}>{p.nombre}</option>)}
+            </select>
+          </Campo>
+
+          <div className="grid grid-cols-3 gap-3">
+            <Campo label="Día">
+              <input type="date" value={d.fecha} onChange={(e) => set("fecha", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Desde">
+              <input type="time" value={d.desde} onChange={(e) => set("desde", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Hasta">
+              <input type="time" value={d.hasta} onChange={(e) => set("hasta", e.target.value)} className={inputCls} />
+            </Campo>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Motivo">
+              <select value={d.motivo} onChange={(e) => set("motivo", e.target.value)} className={inputCls}>
+                {MOTIVOS_BLOQUEO.map((m) => <option key={m.k} value={m.k}>{m.n}</option>)}
+              </select>
+            </Campo>
+            <Campo label="Nota">
+              <input value={d.nota || ""} onChange={(e) => set("nota", e.target.value)}
+                placeholder="Turno médico…" className={inputCls} />
+            </Campo>
+          </div>
+
+          {error && <p className="text-sm text-mal">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={falta || guardando} onClick={async () => {
+            setGuardando(true);
+            const problema = await onGuardar(d);
+            setGuardando(false);
+            if (problema) setError(problema); else onCerrar();
+          }}>
+            <Check size={15} /> {guardando ? "Guardando…" : "Bloquear"}
+          </Boton>
+        </div>
+      </div>
+    </Modal>
+  );
 }

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -12,10 +12,11 @@
    última palabra la tiene el servidor: dos personas agendando al mismo
    tiempo desde dos dispositivos solo se resuelven ahí.
 
-   Las clases grupales y la lista de espera ya funcionan: una clase es
-   una reserva con cupo y las inscripciones cuelgan de ella. La
-   recurrencia y los abonos todavía no tienen base, así que lo que los
-   necesita está apagado. Nada finge andar.
+   Las clases grupales, la lista de espera y los abonos ya funcionan.
+   Una clase es una reserva con cupo y las inscripciones cuelgan de ella;
+   el crédito de un abono se descuenta al reservar y no al asistir, que es
+   lo que hace que el tope semanal se pueda hacer cumplir. La recurrencia
+   todavía no tiene base y por eso está apagada. Nada finge andar.
    ============================================================ */
 
 import React, { useState, useEffect, useMemo, useCallback } from "react";
@@ -30,6 +31,7 @@ import {
   marcarEspera, bloquear, MOTIVOS_BLOQUEO,
 } from "../datos/agenda.js";
 import { cargarEquipo, cargarServicios } from "../datos/equipo.js";
+import { cargarAbonos } from "../datos/abonos.js";
 import { cargarRecursos } from "../datos/comandas.js";
 import { money } from "../utils/helpers.js";
 import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado, Apagado } from "../ui/Base.jsx";
@@ -75,11 +77,24 @@ const paraInput = (d) => {
    El formulario de un turno
    ------------------------------------------------------------ */
 
-function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, onGuardar, onCerrar }) {
+function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, empresaId, onGuardar, onCerrar }) {
   const [d, setD] = useState({});
   const [buscando, setBuscando] = useState("");
   const [guardando, setGuardando] = useState(false);
   const [error, setError] = useState("");
+  const [abonos, setAbonos] = useState([]);
+
+  /* Los abonos del cliente elegido. Se piden al elegirlo y no antes: si se
+     trajeran todos los del comercio, un negocio con mil clientes cargaría
+     mil abonos para mostrar dos. */
+  useEffect(() => {
+    if (!abierto || !d.clienteId) { setAbonos([]); return; }
+    let vigente = true;
+    cargarAbonos(empresaId, { clienteId: d.clienteId, soloActivos: true })
+      .then((xs) => { if (vigente) setAbonos(xs); })
+      .catch(() => { if (vigente) setAbonos([]); });
+    return () => { vigente = false; };
+  }, [abierto, d.clienteId, empresaId]);
 
   useEffect(() => {
     if (!abierto) return;
@@ -256,6 +271,23 @@ function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, onGua
                   : `${persona.nombre} no trabaja ese día.`;
               })()}
             </p>
+          )}
+
+          {/* El crédito se descuenta al reservar, no al venir: es lo que
+              hace que el tope semanal se pueda hacer cumplir. Solo aparece
+              si la persona tiene algo con qué pagar. */}
+          {d.tipo !== "clase" && abonos.length > 0 && (
+            <Campo label="Descontar de un abono">
+              <select value={d.abonoId || ""} onChange={(e) => set("abonoId", e.target.value || null)} className={inputCls}>
+                <option value="">No, se paga aparte</option>
+                {abonos.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.nombre} — {a.clases === null ? "libre" : `${a.restantes} ${a.restantes === 1 ? "clase" : "clases"}`}
+                    {a.vence ? ` · vence ${a.vence.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit" })}` : ""}
+                  </option>
+                ))}
+              </select>
+            </Campo>
           )}
 
           <Campo label="Observaciones">
@@ -442,6 +474,7 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
           personalId: d.personalId || null,
           recursoId: d.recursoId || null,
           itemId: d.itemId || null,
+          abonoId: d.abonoId || null,
           nombre: d.nombre || (clientes.find((c) => c.id === d.clienteId) || {}).razonSocial || "Sin nombre",
           telefono: d.telefono || null,
           desde, duracion: Number(d.duracion), notas: d.notas, estado: d.estado,
@@ -724,7 +757,8 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
       </Drawer>
 
       <FormTurno abierto={!!alta} inicial={alta} equipo={equipo} servicios={servicios}
-        salas={salas} clientes={clientes} onGuardar={guardar} onCerrar={() => setAlta(null)} />
+        salas={salas} clientes={clientes} empresaId={empresaId}
+        onGuardar={guardar} onCerrar={() => setAlta(null)} />
 
       <FormBloqueo abierto={!!bloqueo} inicial={bloqueo} equipo={equipo}
         onCerrar={() => setBloqueo(null)}

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -1,0 +1,663 @@
+/* ============================================================
+   17. AGENDA
+   ============================================================
+
+   La pantalla donde este negocio pasa el día. Todo lo que se ve acá sale
+   de la base: los turnos, los profesionales, sus horarios, las salas y
+   las prestaciones con su duración y su precio. Nada inventado.
+
+   Lo que impide un turno lo decide la base —`agendar_turno` valida
+   choques de sala, de persona, de horario y de ausencias en la misma
+   transacción—. Acá se avisa antes para no hacer perder el viaje, pero la
+   última palabra la tiene el servidor: dos personas agendando al mismo
+   tiempo desde dos dispositivos solo se resuelven ahí.
+
+   Las clases grupales, la lista de espera y la recurrencia todavía no
+   tienen base, así que sus pestañas están apagadas. Ninguna finge andar.
+   ============================================================ */
+
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  Plus, ChevronLeft, ChevronRight, Search, Check, X, CalendarDays,
+  Clock, User, MapPin, Trash2, RotateCcw,
+} from "lucide-react";
+import {
+  cargarTurnos, agendarTurno, moverTurno, cambiarEstado, guardarNotas,
+  escucharTurnos, ESTADOS, estadoDe, franjasDelDia, minutosDe, aReloj, OCUPAN,
+} from "../datos/agenda.js";
+import { cargarEquipo, cargarServicios } from "../datos/equipo.js";
+import { cargarRecursos } from "../datos/comandas.js";
+import { money, nf } from "../utils/helpers.js";
+import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado, Apagado } from "../ui/Base.jsx";
+import { Campo, inputCls } from "../ui/Campos.jsx";
+import { Drawer } from "../ui/Drawer.jsx";
+import { Calendario } from "../ui/Calendario.jsx";
+
+const DIA_MS = 86400000;
+
+const alArrancar = (d) => { const x = new Date(d); x.setHours(0, 0, 0, 0); return x; };
+const sumarDias = (d, n) => new Date(d.getTime() + n * DIA_MS);
+
+/* El lunes de la semana de esa fecha. Domingo es 0 en JavaScript, así que
+   hay que correrlo seis días para atrás y no uno. */
+function lunesDe(d) {
+  const x = alArrancar(d);
+  const dow = x.getDay();
+  return sumarDias(x, dow === 0 ? -6 : 1 - dow);
+}
+
+const fechaLarga = (d) => {
+  const t = d.toLocaleDateString("es-AR", { weekday: "long", day: "numeric", month: "long" });
+  return t.charAt(0).toUpperCase() + t.slice(1);
+};
+
+const soloHora = (d) => d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+/* De una fecha y "09:30" a un instante. Se arma con el constructor local
+   para que la hora escrita sea la hora del negocio y no UTC. */
+function conHora(fecha, hhmm) {
+  const [h, m] = String(hhmm || "09:00").split(":").map(Number);
+  const x = new Date(fecha);
+  x.setHours(h, m || 0, 0, 0);
+  return x;
+}
+
+const paraInput = (d) => {
+  const p = (n) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+};
+
+/* ------------------------------------------------------------
+   El formulario de un turno
+   ------------------------------------------------------------ */
+
+function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, onGuardar, onCerrar }) {
+  const [d, setD] = useState({});
+  const [buscando, setBuscando] = useState("");
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!abierto) return;
+    setD({
+      fecha: paraInput(new Date()), hora: "09:00", duracion: 60,
+      personas: 1, notas: "", estado: "pendiente", ...(inicial || {}),
+    });
+    setBuscando("");
+    setError("");
+  }, [abierto, inicial]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+
+  const servicio = servicios.find((s) => s.id === d.itemId) || null;
+
+  /* Al elegir el servicio se filtran los profesionales que lo dan. Un
+     sistema que te deja poner a la esteticista a dar reformer te hace
+     descubrir el error el día del turno. */
+  const habilitados = d.itemId
+    ? equipo.filter((p) => p.servicios.includes(d.itemId))
+    : equipo.filter((p) => p.tipo === "profesional");
+
+  const persona = equipo.find((p) => p.id === d.personalId) || null;
+
+  function elegirServicio(id) {
+    const s = servicios.find((x) => x.id === id);
+    setD((x) => ({
+      ...x,
+      itemId: id || null,
+      duracion: s && s.duracion ? s.duracion : x.duracion,
+      /* Si el profesional elegido no da ese servicio, se suelta: es
+         preferible que quede vacío a que quede una combinación inválida
+         que el servidor va a rechazar. */
+      personalId: id && x.personalId && !equipo.find((p) => p.id === x.personalId && p.servicios.includes(id))
+        ? null : x.personalId,
+    }));
+  }
+
+  const cliente = clientes.find((c) => c.id === d.clienteId) || null;
+  const norm = (t) => String(t || "").toLowerCase();
+  const coincidencias = buscando.trim().length >= 1
+    ? clientes.filter((c) => norm(c.razonSocial).includes(norm(buscando))).slice(0, 6)
+    : [];
+
+  const falta = !d.fecha || !d.hora || !d.duracion || (!d.clienteId && !d.nombre);
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-xl">
+      <div className="p-5">
+        <h3 className="f-d text-lg">{d.id ? "Editar turno" : "Nuevo turno"}</h3>
+
+        <div className="space-y-3 mt-4">
+          {/* Quién viene */}
+          <Campo label="Cliente">
+            {cliente ? (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="flex-1 text-sm text-texto border border-borde rounded-lg px-2.5 py-1.5 truncate">
+                  {cliente.razonSocial}
+                </span>
+                <button onClick={() => setD((x) => ({ ...x, clienteId: null }))}
+                  className="p-2 rounded-lg text-texto-tenue hover:text-mal hover:bg-superficie-2" title="Quitar">
+                  <X size={15} />
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="relative">
+                  <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-texto-tenue" />
+                  <input value={buscando} onChange={(e) => setBuscando(e.target.value)}
+                    placeholder={clientes.length ? "Buscar un cliente cargado" : "Todavía no hay clientes cargados"}
+                    className={`${inputCls} pl-8`} />
+                </div>
+                {coincidencias.length > 0 && (
+                  <ul className="mt-1 border border-borde rounded-lg divide-y divide-borde max-h-40 overflow-auto">
+                    {coincidencias.map((c) => (
+                      <li key={c.id}>
+                        <button onClick={() => { setD((x) => ({ ...x, clienteId: c.id, nombre: c.razonSocial })); setBuscando(""); }}
+                          className="w-full text-left px-2.5 py-1.5 text-sm hover:bg-superficie-2">
+                          {c.razonSocial}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <div className="grid grid-cols-2 gap-3 mt-2">
+                  <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)}
+                    placeholder="…o anotar un nombre suelto" className={inputCls} />
+                  <input value={d.telefono || ""} onChange={(e) => set("telefono", e.target.value)}
+                    placeholder="Teléfono" className={inputCls} />
+                </div>
+              </>
+            )}
+          </Campo>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Servicio">
+              <select value={d.itemId || ""} onChange={(e) => elegirServicio(e.target.value || null)} className={inputCls}>
+                <option value="">Sin especificar</option>
+                {servicios.map((s) => <option key={s.id} value={s.id}>{s.nombre}</option>)}
+              </select>
+            </Campo>
+            <Campo label="Profesional">
+              <select value={d.personalId || ""} onChange={(e) => set("personalId", e.target.value || null)} className={inputCls}>
+                <option value="">Sin asignar</option>
+                {habilitados.map((p) => <option key={p.id} value={p.id}>{p.nombre}</option>)}
+              </select>
+            </Campo>
+          </div>
+
+          {servicio && (
+            <p className="text-xs text-texto-suave -mt-1">
+              {servicio.duracion} min · {money(servicio.precio)}
+              {d.itemId && habilitados.length === 0 && " · nadie del equipo tiene habilitado este servicio"}
+            </p>
+          )}
+
+          <div className="grid grid-cols-4 gap-3">
+            <Campo label="Sala o recurso">
+              <select value={d.recursoId || ""} onChange={(e) => set("recursoId", e.target.value || null)} className={inputCls}>
+                <option value="">Sin sala</option>
+                {salas.map((s) => <option key={s.id} value={s.id}>{s.nombre}</option>)}
+              </select>
+            </Campo>
+            <Campo label="Fecha">
+              <input type="date" value={d.fecha} onChange={(e) => set("fecha", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Hora">
+              <input type="time" value={d.hora} onChange={(e) => set("hora", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Duración">
+              <input type="number" step="5" min="5" value={d.duracion}
+                onChange={(e) => set("duracion", Number(e.target.value))} className={inputCls} />
+            </Campo>
+          </div>
+
+          {persona && persona.horarios.length > 0 && d.fecha && (
+            <p className="text-xs text-texto-tenue -mt-1">
+              {(() => {
+                const fr = franjasDelDia(persona, new Date(`${d.fecha}T12:00:00`));
+                return fr.length
+                  ? `${persona.nombre} trabaja ${fr.map((f) => `${aReloj(f.desde)} a ${aReloj(f.hasta)}`).join(" y ")}.`
+                  : `${persona.nombre} no trabaja ese día.`;
+              })()}
+            </p>
+          )}
+
+          <Campo label="Observaciones">
+            <input value={d.notas || ""} onChange={(e) => set("notas", e.target.value)}
+              placeholder="Traer toalla, primera vez, alergia…" className={inputCls} />
+          </Campo>
+
+          {error && <p className="text-sm text-mal">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={falta || guardando} onClick={async () => {
+            setGuardando(true);
+            setError("");
+            const problema = await onGuardar(d);
+            setGuardando(false);
+            if (problema) setError(problema); else onCerrar();
+          }}>
+            <Check size={15} /> {guardando ? "Guardando…" : "Guardar turno"}
+          </Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   La pantalla
+   ------------------------------------------------------------ */
+
+export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir }) {
+  const [vista, setVista] = useState("dia");
+  const [agrupar, setAgrupar] = useState("profesional");
+  const [pestana, setPestana] = useState("calendario");
+  const [fecha, setFecha] = useState(() => alArrancar(new Date()));
+
+  const [equipo, setEquipo] = useState([]);
+  const [servicios, setServicios] = useState([]);
+  const [salas, setSalas] = useState([]);
+  const [turnos, setTurnos] = useState([]);
+
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [alta, setAlta] = useState(null);
+  const [abierto, setAbierto] = useState(null);
+  const [filtro, setFiltro] = useState({ personalId: "", recursoId: "", estado: "" });
+
+  const ventana = useMemo(() => (
+    vista === "dia"
+      ? { desde: fecha, hasta: sumarDias(fecha, 1) }
+      : { desde: lunesDe(fecha), hasta: sumarDias(lunesDe(fecha), 7) }
+  ), [vista, fecha]);
+
+  /* El catálogo del rubro se pide una vez; los turnos, cada vez que
+     cambia la ventana o un filtro. */
+  useEffect(() => {
+    let vigente = true;
+    Promise.all([cargarEquipo(empresaId), cargarServicios(empresaId), cargarRecursos(empresaId)])
+      .then(([e, s, r]) => {
+        if (!vigente) return;
+        setEquipo(e);
+        setServicios(s);
+        setSalas((r || []).filter((x) => x.activo));
+      })
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar el equipo."); });
+    return () => { vigente = false; };
+  }, [empresaId]);
+
+  const releer = useCallback(async () => {
+    const xs = await cargarTurnos(empresaId, {
+      desde: ventana.desde,
+      hasta: ventana.hasta,
+      personalId: filtro.personalId || null,
+      recursoId: filtro.recursoId || null,
+      estado: filtro.estado || null,
+    });
+    setTurnos(xs);
+  }, [empresaId, ventana, filtro]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar los turnos."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  /* Recepción y el profesional tienen que ver lo mismo. `reservas` ya
+     estaba publicada en tiempo real, así que esto salió gratis. */
+  useEffect(() => {
+    const cortar = escucharTurnos(empresaId, () => { releer().catch(() => {}); });
+    return cortar;
+  }, [empresaId, releer]);
+
+  const profesionales = useMemo(() => equipo.filter((p) => p.tipo === "profesional"), [equipo]);
+
+  /* Las columnas del calendario. En el día son las personas o las salas;
+     en la semana, los siete días. */
+  const columnas = useMemo(() => {
+    if (vista === "semana") {
+      const persona = filtro.personalId ? equipo.find((p) => p.id === filtro.personalId) : null;
+      return Array.from({ length: 7 }, (_, i) => {
+        const d = sumarDias(ventana.desde, i);
+        const franjas = persona
+          ? franjasDelDia(persona, d)
+          : unir(profesionales.flatMap((p) => franjasDelDia(p, d)));
+        return {
+          k: paraInput(d),
+          n: d.toLocaleDateString("es-AR", { weekday: "short" }).replace(/^\w/, (c) => c.toUpperCase()),
+          sub: `${d.getDate()}/${d.getMonth() + 1}`,
+          franjas,
+        };
+      });
+    }
+    if (agrupar === "sala") {
+      return salas.map((s) => ({ k: s.id, n: s.nombre, sub: s.sector || "", franjas: [{ desde: 0, hasta: 1440 }] }));
+    }
+    return profesionales
+      .filter((p) => !filtro.personalId || p.id === filtro.personalId)
+      .map((p) => ({ k: p.id, n: p.nombre, sub: p.especialidad, franjas: franjasDelDia(p, fecha) }));
+  }, [vista, agrupar, salas, profesionales, equipo, fecha, ventana.desde, filtro.personalId]);
+
+  const bloques = useMemo(() => turnos.map((t) => ({
+    id: t.id,
+    columna: vista === "semana" ? paraInput(t.desde) : (agrupar === "sala" ? t.recursoId : t.personalId),
+    desde: minutosDe(t.desde),
+    hasta: minutosDe(t.desde) + t.duracion,
+    turno: t,
+  })), [turnos, vista, agrupar]);
+
+  /* El rango de horas que se dibuja sale de los horarios cargados, no de
+     un 8 a 20 fijo: un negocio que abre a las 7 no tiene por qué
+     desplazar la pantalla para ver su primer turno. */
+  const [desdeHora, hastaHora] = useMemo(() => {
+    const fs = columnas.flatMap((c) => c.franjas || []).filter((f) => f.hasta - f.desde < 1440);
+    const conTurnos = turnos.map((t) => minutosDe(t.desde));
+    const min = Math.min(...[...fs.map((f) => f.desde), ...conTurnos, 9 * 60]);
+    const max = Math.max(...[...fs.map((f) => f.hasta), ...turnos.map((t) => minutosDe(t.desde) + t.duracion), 18 * 60]);
+    return [Math.max(0, Math.floor(min / 60) - 1), Math.min(24, Math.ceil(max / 60) + 1)];
+  }, [columnas, turnos]);
+
+  async function guardar(d) {
+    const desde = conHora(new Date(`${d.fecha}T12:00:00`), d.hora);
+    try {
+      if (d.id) {
+        await moverTurno(d.id, desde, Number(d.duracion));
+      } else {
+        await agendarTurno({
+          empresaId, sucursalId,
+          clienteId: d.clienteId || null,
+          personalId: d.personalId || null,
+          recursoId: d.recursoId || null,
+          itemId: d.itemId || null,
+          nombre: d.nombre || (clientes.find((c) => c.id === d.clienteId) || {}).razonSocial || "Sin nombre",
+          telefono: d.telefono || null,
+          desde, duracion: Number(d.duracion), notas: d.notas, estado: d.estado,
+        });
+      }
+      await releer();
+      toast("Turno guardado.");
+      return null;
+    } catch (e) {
+      return e.message || "No se pudo guardar el turno.";
+    }
+  }
+
+  async function mover(t, estado) {
+    try {
+      await cambiarEstado(t.id, estado);
+      await releer();
+      setAbierto((a) => (a && a.id === t.id ? { ...a, estado } : a));
+      toast(`Turno marcado como ${estadoDe(estado).n.toLowerCase()}.`);
+    } catch (e) {
+      toast(e.message || "No se pudo cambiar el estado.", "mal");
+    }
+  }
+
+  const hoy = alArrancar(new Date());
+  const esHoy = fecha.getTime() === hoy.getTime();
+
+  const pestanas = [
+    { k: "calendario", n: "Calendario" },
+    { k: "lista", n: "Lista", badge: turnos.length || null },
+  ];
+
+  return (
+    <div className="space-y-4">
+      {/* ---------- Barra de control ---------- */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1">
+          <button onClick={() => setFecha((f) => sumarDias(f, vista === "dia" ? -1 : -7))}
+            className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2" title="Anterior">
+            <ChevronLeft size={15} />
+          </button>
+          <button onClick={() => setFecha(hoy)}
+            className={`px-3 py-2 rounded-lg border text-sm font-semibold ${esHoy && vista === "dia" ? "border-acento text-acento" : "border-borde text-texto-suave hover:bg-superficie-2"}`}>
+            Hoy
+          </button>
+          <button onClick={() => setFecha((f) => sumarDias(f, vista === "dia" ? 1 : 7))}
+            className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2" title="Siguiente">
+            <ChevronRight size={15} />
+          </button>
+        </div>
+
+        <div className="f-d text-base min-w-[190px]">
+          {vista === "dia"
+            ? fechaLarga(fecha)
+            : `${ventana.desde.getDate()}/${ventana.desde.getMonth() + 1} al ${sumarDias(ventana.hasta, -1).getDate()}/${sumarDias(ventana.hasta, -1).getMonth() + 1}`}
+        </div>
+
+        <div className="flex rounded-lg border border-borde overflow-hidden">
+          {[["dia", "Día"], ["semana", "Semana"]].map(([k, n]) => (
+            <button key={k} onClick={() => setVista(k)}
+              className={`px-3 py-1.5 text-sm font-semibold ${vista === k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+              {n}
+            </button>
+          ))}
+          <Apagado motivo="La vista de mes" className="px-3 py-1.5 text-sm font-semibold">Mes</Apagado>
+        </div>
+
+        {vista === "dia" && (
+          <div className="flex rounded-lg border border-borde overflow-hidden">
+            {[["profesional", "Por profesional"], ["sala", "Por sala"]].map(([k, n]) => (
+              <button key={k} onClick={() => setAgrupar(k)}
+                className={`px-3 py-1.5 text-sm font-semibold ${agrupar === k ? "bg-superficie-3 text-texto" : "text-texto-suave hover:bg-superficie-2"}`}>
+                {n}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <select value={filtro.personalId} onChange={(e) => setFiltro((f) => ({ ...f, personalId: e.target.value }))}
+          className="text-sm border border-borde rounded-lg px-2.5 py-2 bg-superficie outline-none focus:border-acento">
+          <option value="">Todos los profesionales</option>
+          {profesionales.map((p) => <option key={p.id} value={p.id}>{p.nombre}</option>)}
+        </select>
+
+        <select value={filtro.estado} onChange={(e) => setFiltro((f) => ({ ...f, estado: e.target.value }))}
+          className="text-sm border border-borde rounded-lg px-2.5 py-2 bg-superficie outline-none focus:border-acento">
+          <option value="">Todos los estados</option>
+          {ESTADOS.map((e) => <option key={e.k} value={e.k}>{e.n}</option>)}
+        </select>
+
+        <Boton size="sm" className="ml-auto" onClick={() => setAlta({ fecha: paraInput(fecha) })}>
+          <Plus size={14} /> Nuevo turno
+        </Boton>
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={pestanas} />
+      <div className="flex flex-wrap gap-3 -mt-2">
+        {["Clases", "Lista de espera", "Asistencia"].map((n) => (
+          <Apagado key={n} motivo={n} className="text-sm font-semibold py-2">{n}</Apagado>
+        ))}
+      </div>
+
+      {/* ---------- Contenido ---------- */}
+      <Card className="overflow-hidden">
+        {error ? (
+          <ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado>
+        ) : cargando ? (
+          <Cargando>Buscando los turnos…</Cargando>
+        ) : pestana === "lista" ? (
+          turnos.length === 0 ? (
+            <Vacio>No hay turnos {vista === "dia" ? "para este día" : "en esta semana"}.</Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {turnos.map((t) => (
+                <li key={t.id}>
+                  <button onClick={() => setAbierto(t)} className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                    <span className="f-m text-sm text-texto w-24 shrink-0">
+                      {vista === "semana" && <span className="text-texto-tenue">{t.desde.getDate()}/{t.desde.getMonth() + 1} </span>}
+                      {soloHora(t.desde)}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-texto truncate">{t.cliente}</div>
+                      <div className="text-[11px] text-texto-tenue truncate">
+                        {[t.servicio, t.profesional, t.sala].filter(Boolean).join(" · ") || "sin detalle"}
+                      </div>
+                    </div>
+                    <span className="f-m text-[11px] text-texto-tenue shrink-0">{t.duracion} min</span>
+                    <Sello tono={estadoDe(t.estado).tono}>{estadoDe(t.estado).n}</Sello>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : (
+          <Calendario
+            columnas={columnas}
+            bloques={bloques}
+            desdeHora={desdeHora}
+            hastaHora={hastaHora}
+            onBloque={(b) => setAbierto(b.turno)}
+            onVacio={(columnaK, min) => {
+              const base = vista === "semana" ? new Date(`${columnaK}T12:00:00`) : fecha;
+              setAlta({
+                fecha: paraInput(base),
+                hora: aReloj(min),
+                personalId: vista === "dia" && agrupar === "profesional" ? columnaK : "",
+                recursoId: vista === "dia" && agrupar === "sala" ? columnaK : "",
+              });
+            }}
+            dibujarBloque={(b, alto) => {
+              const t = b.turno;
+              const e = estadoDe(t.estado);
+              const tono = {
+                bien: "border-bien bg-bien-suave text-bien",
+                ojo: "border-ojo bg-ojo-suave text-ojo",
+                mal: "border-mal bg-mal-suave text-mal",
+                info: "border-info bg-info-suave text-info",
+                acento: "border-acento bg-acento-suave text-acento",
+                tenue: "border-borde bg-superficie-2 text-texto-tenue",
+              }[e.tono];
+              return (
+                <span className={`block h-full rounded-lg border px-2 py-1 overflow-hidden ${tono}`}>
+                  <span className="block text-[11px] font-semibold text-texto truncate">
+                    {t.servicio || t.cliente}
+                  </span>
+                  {alto > 34 && (
+                    <span className="block text-[10px] truncate opacity-80">
+                      {soloHora(t.desde)} · {t.servicio ? t.cliente : t.profesional}
+                    </span>
+                  )}
+                </span>
+              );
+            }}
+          />
+        )}
+      </Card>
+
+      {/* ---------- El detalle ---------- */}
+      <Drawer open={!!abierto} onClose={() => setAbierto(null)}
+        titulo={abierto ? abierto.cliente : ""}
+        subtitulo={abierto ? `${fechaLarga(abierto.desde)} · ${soloHora(abierto.desde)}` : ""}
+        acciones={abierto && (
+          <div className="flex flex-wrap gap-2">
+            {abierto.estado === "pendiente" && (
+              <Boton size="sm" onClick={() => mover(abierto, "confirmada")}><Check size={14} /> Confirmar</Boton>
+            )}
+            {OCUPAN.includes(abierto.estado) && abierto.estado !== "cumplida" && (
+              <Boton size="sm" variant="ghost" onClick={() => mover(abierto, "cumplida")}>Asistió</Boton>
+            )}
+            {abierto.estado !== "cumplida" && (
+              <Boton size="sm" variant="ghost" onClick={() => mover(abierto, "ausente")}>No vino</Boton>
+            )}
+            <Boton size="sm" variant="ghost" onClick={() => { setAlta({ ...aFormulario(abierto) }); setAbierto(null); }}>
+              <RotateCcw size={14} /> Reprogramar
+            </Boton>
+            {abierto.estado !== "cancelada" && (
+              <button onClick={() => mover(abierto, "cancelada")}
+                className="text-xs font-semibold text-mal hover:underline px-2">Cancelar turno</button>
+            )}
+          </div>
+        )}>
+        {abierto && (
+          <div className="space-y-4">
+            <Sello tono={estadoDe(abierto.estado).tono}>{estadoDe(abierto.estado).n}</Sello>
+
+            <dl className="space-y-2.5 text-sm">
+              {[
+                [CalendarDays, "Cuándo", `${fechaLarga(abierto.desde)}, ${soloHora(abierto.desde)} a ${soloHora(abierto.hasta)}`],
+                [Clock, "Duración", `${abierto.duracion} minutos`],
+                [User, "Profesional", abierto.profesional || "sin asignar"],
+                [MapPin, "Sala", abierto.sala || "sin sala"],
+              ].map(([Ico, rot, val]) => (
+                <div key={rot} className="flex items-start gap-2.5">
+                  <Ico size={15} className="text-texto-tenue mt-0.5 shrink-0" />
+                  <dt className="text-texto-tenue w-24 shrink-0">{rot}</dt>
+                  <dd className="text-texto min-w-0 flex-1">{val}</dd>
+                </div>
+              ))}
+            </dl>
+
+            {abierto.servicio && (
+              <div className="rounded-xl border border-borde p-3">
+                <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold">Servicio</div>
+                <div className="text-sm text-texto mt-1">{abierto.servicio}</div>
+                <div className="f-m text-sm text-texto-suave mt-0.5">{money(abierto.precio)}</div>
+                {abierto.pagado > 0 && (
+                  <div className="f-m text-xs text-bien mt-1">Cobrado {money(abierto.pagado)}</div>
+                )}
+              </div>
+            )}
+
+            {abierto.telefono && (
+              <a href={`https://wa.me/${abierto.telefono.replace(/\D/g, "")}`} target="_blank" rel="noreferrer"
+                className="block text-sm text-acento hover:underline">Escribirle por WhatsApp</a>
+            )}
+
+            <Campo label="Observaciones">
+              <textarea defaultValue={abierto.notas} rows={3} className={inputCls}
+                onBlur={async (e) => {
+                  if (e.target.value === abierto.notas) return;
+                  try { await guardarNotas(abierto.id, e.target.value); await releer(); }
+                  catch (err) { toast(err.message || "No se pudo guardar la nota.", "mal"); }
+                }} />
+            </Campo>
+
+            <p className="text-xs text-texto-tenue">
+              Cobrar el turno y descontarlo de un abono todavía no está: llega con el módulo de Ventas.
+            </p>
+          </div>
+        )}
+      </Drawer>
+
+      <FormTurno abierto={!!alta} inicial={alta} equipo={equipo} servicios={servicios}
+        salas={salas} clientes={clientes} onGuardar={guardar} onCerrar={() => setAlta(null)} />
+    </div>
+  );
+}
+
+/* Del turno al formulario, para reprogramar sin volver a cargar todo. */
+function aFormulario(t) {
+  return {
+    id: t.id,
+    fecha: `${t.desde.getFullYear()}-${String(t.desde.getMonth() + 1).padStart(2, "0")}-${String(t.desde.getDate()).padStart(2, "0")}`,
+    hora: `${String(t.desde.getHours()).padStart(2, "0")}:${String(t.desde.getMinutes()).padStart(2, "0")}`,
+    duracion: t.duracion,
+    clienteId: t.clienteId, nombre: t.cliente, telefono: t.telefono,
+    personalId: t.personalId, itemId: t.itemId, recursoId: t.recursoId,
+    notas: t.notas, estado: t.estado,
+  };
+}
+
+/* Junta franjas que se tocan o se pisan. Sin esto, el fondo del horario
+   se dibuja varias veces encima de sí mismo y queda más claro donde se
+   superponen dos personas, que no significa nada. */
+function unir(franjas) {
+  const orden = [...franjas].sort((a, b) => a.desde - b.desde);
+  const salida = [];
+  for (const f of orden) {
+    const ultima = salida[salida.length - 1];
+    if (ultima && f.desde <= ultima.hasta) ultima.hasta = Math.max(ultima.hasta, f.hasta);
+    else salida.push({ ...f });
+  }
+  return salida;
+}

--- a/src/modulos/Clientes.jsx
+++ b/src/modulos/Clientes.jsx
@@ -4,8 +4,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Search, Plus, Check } from "lucide-react";
-import { uid } from "../datos/generador.js";
-import { CONDICIONES, FISCAL_INICIAL, condicionNombre, money, letraComprobante, CLIENTES_INICIALES } from "../utils/helpers.js";
+import { CONDICIONES, FISCAL_INICIAL, condicionNombre, money, letraComprobante } from "../utils/helpers.js";
 import { Modal, Boton, Card, Vacio } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 
@@ -64,7 +63,7 @@ export function FormCliente({ abierto, inicial, onGuardar, onCerrar }) {
   );
 }
 
-export function Clientes({ clientes, setClientes, tickets, ajustes, toast }) {
+export function Clientes({ clientes, guardarCliente, tickets, ajustes }) {
   const [q, setQ] = useState("");
   const [alta, setAlta] = useState(null);
   const norm = (t) => String(t || "").toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
@@ -121,12 +120,13 @@ export function Clientes({ clientes, setClientes, tickets, ajustes, toast }) {
         Se cambia en Ajustes, en Datos fiscales.
       </p>
 
+      {/* El modal se cierra recién cuando la base confirmó. Cerrarlo antes
+          dejaba al usuario creyendo que había guardado cuando el alta podía
+          fallar, y el aviso de error aparecía sobre la lista sin el cliente. */}
       <FormCliente abierto={!!alta} inicial={alta} onCerrar={() => setAlta(null)}
-        onGuardar={(d) => {
-          if (d.id) setClientes((cs) => cs.map((c) => (c.id === d.id ? { ...c, ...d } : c)));
-          else setClientes((cs) => [...cs, { ...d, id: "c" + uid() }]);
-          setAlta(null);
-          toast(`${d.razonSocial} guardado.`);
+        onGuardar={async (d) => {
+          const c = await guardarCliente(d);
+          if (c) setAlta(null);
         }} />
     </div>
   );

--- a/src/modulos/Equipo.jsx
+++ b/src/modulos/Equipo.jsx
@@ -1,0 +1,407 @@
+/* ============================================================
+   16. EQUIPO
+   ============================================================
+
+   Quién trabaja, qué hace cada uno y cuándo está. Es la pantalla que la
+   agenda necesita antes de existir: sin horarios cargados no se puede
+   ofrecer un turno ni siquiera a mano.
+
+   Se carga sola desde la base, como la comanda, en vez de recibir todo por
+   props: es un módulo nuevo y nadie más necesita estos datos.
+
+   Lo que se le paga solo lo ve quien puede ver costos. Recepción usa esta
+   pantalla todos los días para saber quién cubre; no tiene por qué ver el
+   sueldo de sus compañeros.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Plus, Check, Search, Clock, Trash2, UserCog } from "lucide-react";
+import {
+  cargarEquipo, cargarServicios, crearPersona, guardarPersona,
+  desactivarPersona, guardarHorarios, guardarServicios,
+  DIAS, MODALIDADES, TIPOS,
+} from "../datos/equipo.js";
+import { money, nf } from "../utils/helpers.js";
+import { Card, Boton, Modal, Vacio, Tabs } from "../ui/Base.jsx";
+import { Campo, inputCls } from "../ui/Campos.jsx";
+
+const iniciales = (nombre) =>
+  String(nombre || "?").trim().split(/\s+/).map((p) => p[0]).slice(0, 2).join("").toUpperCase();
+
+const nombreDia = (d) => (DIAS.find((x) => x.d === d) || { corto: "?" }).corto;
+
+/* "8 hs" y no "8.00 hs". Media hora se escribe 8.5, que es como la gente
+   la dice, y no 8:30, que se confunde con una hora del día. */
+const horas = (h) => `${Number(h) % 1 === 0 ? Math.round(h) : Number(h).toFixed(1)} hs`;
+
+const modalidadN = (k) => (MODALIDADES.find((m) => m.k === k) || { n: k }).n;
+
+/* Cómo se le paga, en una línea. La comisión no muestra un monto porque no
+   lo tiene: depende de lo que facture. */
+function loQueCobra(p) {
+  if (p.modalidad === "comision") return `${nf.format(p.comision)}% de comisión`;
+  if (p.modalidad === "fijo") return `${money(p.valor)} por mes`;
+  if (p.modalidad === "clase") return `${money(p.valor)} por clase`;
+  return `${money(p.valor)} la hora`;
+}
+
+/* ------------------------------------------------------------
+   El formulario
+   ------------------------------------------------------------ */
+
+function FormPersona({ abierto, inicial, servicios, permisos, onGuardar, onCerrar, onBaja }) {
+  const [d, setD] = useState({});
+  const [franjas, setFranjas] = useState([]);
+  const [habilitados, setHabilitados] = useState([]);
+  const [pestana, setPestana] = useState("datos");
+  const [guardando, setGuardando] = useState(false);
+
+  useEffect(() => {
+    if (!abierto) return;
+    const base = inicial || {};
+    setD({ tipo: "profesional", modalidad: "hora", valor: 0, comision: 0, ...base });
+    setFranjas((base.horarios || []).map((h) => ({ ...h })));
+    setHabilitados([...(base.servicios || [])]);
+    setPestana("datos");
+  }, [abierto, inicial]);
+
+  if (!abierto) return null;
+
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+  const esNueva = !d.id;
+
+  const porCategoria = servicios.reduce((m, s) => {
+    (m[s.categoria] = m[s.categoria] || []).push(s);
+    return m;
+  }, {});
+
+  const totalHoras = franjas.reduce((s, f) => {
+    if (!f.desde || !f.hasta || f.hasta <= f.desde) return s;
+    const [hd, md] = f.desde.split(":").map(Number);
+    const [hh, mh] = f.hasta.split(":").map(Number);
+    return s + (hh * 60 + mh - hd * 60 - md) / 60;
+  }, 0);
+
+  const solapadas = franjas.some((a, i) =>
+    franjas.some((b, j) => j > i && a.dia === b.dia && a.desde < b.hasta && b.desde < a.hasta));
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-2xl">
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="f-d text-lg">{esNueva ? "Sumar a alguien al equipo" : d.nombre}</h3>
+          {!esNueva && (
+            <button onClick={() => onBaja(d)} title="Dar de baja"
+              className="text-xs font-semibold text-mal hover:underline shrink-0">Dar de baja</button>
+          )}
+        </div>
+
+        <div className="mt-4">
+          <Tabs value={pestana} onChange={setPestana} items={[
+            { k: "datos", n: "Datos" },
+            { k: "horarios", n: "Horarios", badge: franjas.length || null },
+            { k: "servicios", n: "Qué hace", badge: habilitados.length || null },
+          ]} />
+        </div>
+
+        <div className="mt-4 min-h-[280px]">
+          {pestana === "datos" && (
+            <div className="space-y-3">
+              <Campo label="Nombre">
+                <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)} autoFocus className={inputCls} />
+              </Campo>
+              <div className="grid grid-cols-2 gap-3">
+                <Campo label="Rol">
+                  <select value={d.tipo} onChange={(e) => set("tipo", e.target.value)} className={inputCls}>
+                    {TIPOS.map((t) => <option key={t.k} value={t.k}>{t.n}</option>)}
+                  </select>
+                </Campo>
+                <Campo label="Especialidad">
+                  <input value={d.especialidad || ""} onChange={(e) => set("especialidad", e.target.value)}
+                    placeholder="Pilates, estética…" className={inputCls} />
+                </Campo>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <Campo label="Teléfono">
+                  <input value={d.tel || ""} onChange={(e) => set("tel", e.target.value)} className={inputCls} />
+                </Campo>
+                <Campo label="Correo">
+                  <input value={d.email || ""} onChange={(e) => set("email", e.target.value)} className={inputCls} />
+                </Campo>
+              </div>
+
+              {permisos.verCostos && (
+                <div className="pt-3 border-t border-borde space-y-3">
+                  <div className="grid grid-cols-2 gap-3">
+                    <Campo label="Cómo se le paga">
+                      <select value={d.modalidad} onChange={(e) => set("modalidad", e.target.value)} className={inputCls}>
+                        {MODALIDADES.map((m) => <option key={m.k} value={m.k}>{m.n}</option>)}
+                      </select>
+                    </Campo>
+                    {d.modalidad === "comision" ? (
+                      <Campo label="Porcentaje">
+                        <input type="number" value={d.comision} onChange={(e) => set("comision", e.target.value)} className={inputCls} />
+                      </Campo>
+                    ) : (
+                      <Campo label={d.modalidad === "fijo" ? "Sueldo mensual" : d.modalidad === "clase" ? "Por clase" : "Valor hora"}>
+                        <input type="number" value={d.valor} onChange={(e) => set("valor", e.target.value)} className={inputCls} />
+                      </Campo>
+                    )}
+                  </div>
+                  <p className="text-xs text-texto-suave">
+                    {(MODALIDADES.find((m) => m.k === d.modalidad) || {}).d}
+                  </p>
+                </div>
+              )}
+
+              {!esNueva && (
+                <p className="text-xs text-texto-tenue pt-2">
+                  {d.tieneCuenta
+                    ? "Tiene cuenta para entrar al sistema."
+                    : "No entra al sistema. Se le puede dar acceso cuando haga falta."}
+                </p>
+              )}
+            </div>
+          )}
+
+          {pestana === "horarios" && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs text-texto-suave">
+                  Las franjas se repiten todas las semanas. Las excepciones —vacaciones, un día que faltó— van aparte.
+                </p>
+                <span className="f-m text-sm text-texto shrink-0">{horas(totalHoras)}/semana</span>
+              </div>
+
+              {franjas.length === 0 && <Vacio>Sin horarios cargados. Sin esto no se le puede agendar nada.</Vacio>}
+
+              <ul className="space-y-2">
+                {franjas.map((f, i) => (
+                  <li key={i} className="flex items-center gap-2">
+                    <select value={f.dia} className={`${inputCls} w-36`}
+                      onChange={(e) => setFranjas((xs) => xs.map((x, j) => j === i ? { ...x, dia: Number(e.target.value) } : x))}>
+                      {DIAS.map((x) => <option key={x.d} value={x.d}>{x.n}</option>)}
+                    </select>
+                    <input type="time" value={f.desde} className={`${inputCls} w-28`}
+                      onChange={(e) => setFranjas((xs) => xs.map((x, j) => j === i ? { ...x, desde: e.target.value } : x))} />
+                    <span className="text-texto-tenue text-sm">a</span>
+                    <input type="time" value={f.hasta} className={`${inputCls} w-28`}
+                      onChange={(e) => setFranjas((xs) => xs.map((x, j) => j === i ? { ...x, hasta: e.target.value } : x))} />
+                    <button onClick={() => setFranjas((xs) => xs.filter((_, j) => j !== i))}
+                      title="Quitar" className="ml-auto p-2 rounded-lg text-texto-tenue hover:text-mal hover:bg-superficie-2">
+                      <Trash2 size={15} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+
+              <Boton size="sm" variant="ghost"
+                onClick={() => setFranjas((xs) => [...xs, { dia: 1, desde: "09:00", hasta: "13:00" }])}>
+                <Plus size={14} /> Agregar franja
+              </Boton>
+
+              {solapadas && (
+                <p className="text-xs text-mal">
+                  Hay dos franjas del mismo día que se pisan. Se puede guardar igual, pero la agenda va a ofrecer ese rato dos veces.
+                </p>
+              )}
+            </div>
+          )}
+
+          {pestana === "servicios" && (
+            <div className="space-y-4">
+              <p className="text-xs text-texto-suave">
+                Lo que esta persona puede dar. La agenda usa esto para no ofrecer a alguien para algo que no hace.
+              </p>
+              {servicios.length === 0 && <Vacio>Todavía no hay prestaciones cargadas en el catálogo.</Vacio>}
+              {Object.entries(porCategoria).map(([cat, lista]) => (
+                <div key={cat}>
+                  <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-1.5">{cat}</div>
+                  <div className="grid sm:grid-cols-2 gap-1">
+                    {lista.map((s) => {
+                      const puesto = habilitados.includes(s.id);
+                      return (
+                        <label key={s.id} className="flex items-center gap-2 text-sm py-1.5 px-2 rounded-lg hover:bg-superficie-2 cursor-pointer">
+                          <input type="checkbox" checked={puesto}
+                            onChange={() => setHabilitados((xs) => puesto ? xs.filter((x) => x !== s.id) : [...xs, s.id])} />
+                          <span className="truncate flex-1 text-texto">{s.nombre}</span>
+                          <span className="f-m text-[11px] text-texto-tenue shrink-0">{s.duracion} min</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={!d.nombre || guardando}
+            onClick={async () => {
+              setGuardando(true);
+              const ok = await onGuardar(d, franjas, habilitados);
+              setGuardando(false);
+              if (ok) onCerrar();
+            }}>
+            <Check size={15} /> {guardando ? "Guardando…" : "Guardar"}
+          </Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   La pantalla
+   ------------------------------------------------------------ */
+
+export function Equipo({ empresaId, permisos, toast }) {
+  const [gente, setGente] = useState([]);
+  const [servicios, setServicios] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [q, setQ] = useState("");
+  const [editando, setEditando] = useState(null);
+
+  const releer = useCallback(async () => {
+    const [g, s] = await Promise.all([cargarEquipo(empresaId), cargarServicios(empresaId)]);
+    setGente(g);
+    setServicios(s);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    releer()
+      .catch((e) => { if (vigente) toast(e.message || "No pudimos cargar el equipo.", "mal"); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  const norm = (t) => String(t || "").toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  const lista = useMemo(() => (
+    q.trim().length >= 2
+      ? gente.filter((p) => norm(p.nombre).includes(norm(q)) || norm(p.especialidad).includes(norm(q)))
+      : gente
+  ), [gente, q]);
+
+  const sinHorario = gente.filter((p) => p.horarios.length === 0).length;
+
+  /* Se guarda la persona, sus horarios y sus servicios en ese orden: los
+     dos últimos necesitan el id, que recién existe después del alta. */
+  async function guardar(d, franjas, habilitados) {
+    try {
+      const id = d.id || await crearPersona(empresaId, d);
+      if (d.id) await guardarPersona(d.id, d);
+      await Promise.all([
+        guardarHorarios(empresaId, id, franjas),
+        guardarServicios(empresaId, id, habilitados),
+      ]);
+      await releer();
+      toast(`${d.nombre} guardado.`);
+      return true;
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.", "mal");
+      return false;
+    }
+  }
+
+  async function darDeBaja(p) {
+    try {
+      await desactivarPersona(p.id);
+      await releer();
+      setEditando(null);
+      toast(`${p.nombre} ya no está en el equipo.`);
+    } catch (e) {
+      toast(e.message || "No se pudo dar de baja.", "mal");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[220px]">
+          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-texto-tenue" />
+          <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Buscar por nombre o especialidad"
+            className="w-full pl-9 pr-3 py-2 text-sm border border-borde rounded-xl outline-none focus:border-acento bg-superficie" />
+        </div>
+        <Boton size="sm" onClick={() => setEditando({})}><Plus size={14} /> Sumar a alguien</Boton>
+      </div>
+
+      {sinHorario > 0 && (
+        <Card className="p-3.5 flex items-center gap-3">
+          <Clock size={16} className="text-ojo shrink-0" />
+          <p className="text-sm text-texto-suave">
+            {sinHorario === 1 ? "Hay una persona sin horario cargado." : `Hay ${sinHorario} personas sin horario cargado.`}{" "}
+            Hasta que lo tengan, la agenda no les va a poder asignar nada.
+          </p>
+        </Card>
+      )}
+
+      <Card className="overflow-hidden">
+        {cargando ? (
+          <div className="p-8 text-center text-sm text-texto-tenue">Cargando…</div>
+        ) : lista.length === 0 ? (
+          <Vacio>
+            {gente.length === 0
+              ? "Todavía no hay nadie en el equipo. Empezá por acá: la agenda necesita saber quién trabaja y cuándo."
+              : "Nadie coincide con esa búsqueda."}
+          </Vacio>
+        ) : (
+          <ul className="divide-y divide-borde">
+            {lista.map((p) => (
+              <li key={p.id}>
+                <button onClick={() => setEditando(p)}
+                  className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                  <span className="w-9 h-9 shrink-0 rounded-full bg-superficie-2 flex items-center justify-center text-xs font-bold text-texto-suave">
+                    {iniciales(p.nombre)}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium text-texto flex items-center gap-2">
+                      {p.nombre}
+                      {p.tipo !== "profesional" && (
+                        <span className="text-[10px] uppercase tracking-wider font-bold px-1.5 py-0.5 rounded border border-borde bg-superficie-2 text-texto-suave">
+                          {(TIPOS.find((t) => t.k === p.tipo) || {}).n}
+                        </span>
+                      )}
+                      {p.tieneCuenta && <UserCog size={13} className="text-texto-tenue" title="Entra al sistema" />}
+                    </div>
+                    <div className="f-m text-[11px] text-texto-tenue">
+                      {p.especialidad || "sin especialidad"}
+                      {p.servicios.length > 0 && ` · ${p.servicios.length} servicios`}
+                    </div>
+                  </div>
+
+                  <div className="text-right shrink-0">
+                    {p.horarios.length === 0 ? (
+                      <span className="text-xs text-ojo font-semibold">sin horario</span>
+                    ) : (
+                      <>
+                        <div className="f-m text-sm text-texto">{horas(p.horasSemana)}</div>
+                        <div className="text-[11px] text-texto-tenue">
+                          {[...p.horarios]
+                            .sort((a, b) => (a.dia === 0 ? 7 : a.dia) - (b.dia === 0 ? 7 : b.dia))
+                            .map((h) => nombreDia(h.dia))
+                            .filter((v, i, xs) => xs.indexOf(v) === i)
+                            .join(" ")}
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {permisos.verCostos && (
+                    <div className="f-m text-sm text-texto-suave shrink-0 w-36 text-right">{loQueCobra(p)}</div>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <FormPersona abierto={!!editando} inicial={editando} servicios={servicios} permisos={permisos}
+        onCerrar={() => setEditando(null)} onGuardar={guardar} onBaja={darDeBaja} />
+    </div>
+  );
+}

--- a/src/modulos/Finanzas.jsx
+++ b/src/modulos/Finanzas.jsx
@@ -1,0 +1,539 @@
+/* ============================================================
+   19. FINANZAS
+   ============================================================
+
+   Donde cierra todo lo demás. Los abonos vendidos entran como ingreso,
+   las horas del equipo salen como sueldo, y el mes se puede mirar sin
+   depender de que la caja del día esté abierta.
+
+   La pantalla de Caja no se rehizo: es la de siempre y entra acá como una
+   pestaña. Sigue resolviendo lo suyo —apertura, arqueo, cierre— que es el
+   día, no el mes.
+
+   La liquidación vive acá y no en "Clientes y equipo" porque **pagarle a
+   alguien es un egreso**: con la liquidación colgando del módulo de
+   personal, los egresos del mes mienten.
+   ============================================================ */
+
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  Plus, Check, ArrowDownRight, ArrowUpRight, Wallet, Calendar,
+  ChevronLeft, ChevronRight, Receipt, StickyNote,
+} from "lucide-react";
+import {
+  cargarMovimientos, registrarMovimiento, resumenDelMes, cargarPendientes,
+  cargarLiquidaciones, liquidar, ajustarLiquidacion, pagarLiquidacion,
+  cargarNotas, anotar, semanaDe, nombreCategoria,
+  CATEGORIAS_EGRESO, CATEGORIAS_INGRESO,
+} from "../datos/finanzas.js";
+import { cargarEquipo } from "../datos/equipo.js";
+import { money, moneyk, pct, nf } from "../utils/helpers.js";
+import { Caja } from "./Caja.jsx";
+import { Card, Kpi, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
+import { Campo, inputCls } from "../ui/Campos.jsx";
+import { Drawer } from "../ui/Drawer.jsx";
+import { BarraDato } from "../ui/Graficos.jsx";
+
+const dia = (d) => d.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit" });
+const diaHora = (d) => `${dia(d)} ${d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false })}`;
+const mesLargo = (d) => {
+  const t = d.toLocaleDateString("es-AR", { month: "long", year: "numeric" });
+  return t.charAt(0).toUpperCase() + t.slice(1);
+};
+
+/* ------------------------------------------------------------
+   Cargar un movimiento a mano
+   ------------------------------------------------------------ */
+
+function FormMovimiento({ abierto, tipo, medios, cajaAbierta, onGuardar, onCerrar }) {
+  const [d, setD] = useState({});
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!abierto) return;
+    setD({ medio: "efectivo", categoria: tipo === "egreso" ? "otros" : "otros", monto: "" });
+    setError("");
+  }, [abierto, tipo]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+  const categorias = tipo === "egreso" ? CATEGORIAS_EGRESO : CATEGORIAS_INGRESO;
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-md">
+      <div className="p-5">
+        <h3 className="f-d text-lg">{tipo === "egreso" ? "Registrar un gasto" : "Registrar un ingreso"}</h3>
+
+        <div className="space-y-3 mt-4">
+          <Campo label="Detalle">
+            <input value={d.detalle || ""} onChange={(e) => set("detalle", e.target.value)} autoFocus
+              placeholder={tipo === "egreso" ? "Alquiler de agosto" : "Venta de una crema"} className={inputCls} />
+          </Campo>
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Monto">
+              <input type="number" value={d.monto} onChange={(e) => set("monto", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Categoría">
+              <select value={d.categoria} onChange={(e) => set("categoria", e.target.value)} className={inputCls}>
+                {categorias.map((c) => <option key={c.k} value={c.k}>{c.n}</option>)}
+              </select>
+            </Campo>
+          </div>
+          <Campo label="Medio">
+            <select value={d.medio} onChange={(e) => set("medio", e.target.value)} className={inputCls}>
+              {medios.map((m) => <option key={m.k} value={m.k}>{m.n}</option>)}
+            </select>
+          </Campo>
+
+          {/* En efectivo sí toca la caja; por transferencia no, y obligar a
+              abrirla sería inventar un arqueo que no existió. */}
+          {d.medio === "efectivo" && !cajaAbierta && (
+            <p className="text-sm text-ojo">
+              No hay caja abierta, así que esto no va a entrar en el arqueo del día. Queda como movimiento del mes.
+            </p>
+          )}
+
+          {error && <p className="text-sm text-mal">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={!d.detalle || !Number(d.monto) || guardando} onClick={async () => {
+            setGuardando(true);
+            const problema = await onGuardar({ ...d, tipo });
+            setGuardando(false);
+            if (problema) setError(problema); else onCerrar();
+          }}>
+            <Check size={15} /> Guardar
+          </Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   La pantalla
+   ------------------------------------------------------------ */
+
+export function Finanzas({ empresaId, caja, movCaja, abrirCaja, cerrarCaja, ajustes, permisos, toast }) {
+  const [pestana, setPestana] = useState("resumen");
+  const [mes, setMes] = useState(() => new Date());
+  const [semana, setSemana] = useState(() => semanaDe());
+
+  const [resumen, setResumen] = useState(null);
+  const [movimientos, setMovimientos] = useState([]);
+  const [pendientes, setPendientes] = useState([]);
+  const [liquidaciones, setLiquidaciones] = useState([]);
+  const [equipo, setEquipo] = useState([]);
+
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [cargar, setCargar] = useState(null);
+  const [abierta, setAbierta] = useState(null);
+  const [notas, setNotas] = useState([]);
+  const [nota, setNota] = useState("");
+
+  const medios = useMemo(() => (
+    ((ajustes && ajustes.medios) || []).filter((m) => m.activo !== false)
+  ), [ajustes]);
+
+  const releer = useCallback(async () => {
+    const desde = new Date(mes.getFullYear(), mes.getMonth(), 1);
+    const hasta = new Date(mes.getFullYear(), mes.getMonth() + 1, 1);
+    const [r, m, p, l, e] = await Promise.all([
+      resumenDelMes(empresaId, mes),
+      cargarMovimientos(empresaId, { desde, hasta }),
+      cargarPendientes(empresaId),
+      cargarLiquidaciones(empresaId),
+      cargarEquipo(empresaId),
+    ]);
+    setResumen(r);
+    setMovimientos(m);
+    setPendientes(p);
+    setLiquidaciones(l);
+    setEquipo(e);
+  }, [empresaId, mes]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar las finanzas."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  useEffect(() => {
+    if (!abierta) { setNotas([]); return; }
+    let vigente = true;
+    cargarNotas(empresaId, abierta.id)
+      .then((xs) => { if (vigente) setNotas(xs); })
+      .catch(() => {});
+    return () => { vigente = false; };
+  }, [abierta, empresaId]);
+
+  async function guardarMovimiento(d) {
+    try {
+      await registrarMovimiento({
+        empresaId,
+        /* Solo el efectivo toca la caja del día. Lo demás es del mes. */
+        sesionId: d.medio === "efectivo" && caja && caja.abierta ? caja.sesionId : null,
+        tipo: d.tipo, medio: d.medio, monto: Number(d.monto),
+        detalle: d.detalle, categoria: d.categoria,
+      });
+      await releer();
+      toast(d.tipo === "egreso" ? "Gasto registrado." : "Ingreso registrado.");
+      return null;
+    } catch (e) {
+      return e.message || "No se pudo registrar.";
+    }
+  }
+
+  const deLaSemana = liquidaciones.filter((l) => {
+    const iso = (f) => `${f.getFullYear()}-${String(f.getMonth() + 1).padStart(2, "0")}-${String(f.getDate()).padStart(2, "0")}`;
+    return iso(l.desde) === semana.desde;
+  });
+
+  const sinLiquidar = equipo.filter((p) => !deLaSemana.some((l) => l.personalId === p.id));
+
+  async function armar(personalId) {
+    try {
+      await liquidar(personalId, semana.desde, semana.hasta);
+      await releer();
+    } catch (e) {
+      toast(e.message || "No se pudo armar la liquidación.", "mal");
+    }
+  }
+
+  const totalPendiente = pendientes.reduce((s, p) => s + p.falta, 0);
+  const aPagarSemana = deLaSemana.filter((l) => l.estado === "borrador").reduce((s, l) => s + l.aPagar, 0);
+
+  return (
+    <div className="space-y-4">
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "resumen", n: "Resumen" },
+        { k: "caja", n: "Caja" },
+        { k: "movimientos", n: "Movimientos", badge: movimientos.length || null },
+        { k: "pendientes", n: "Pendientes", badge: pendientes.length || null },
+        { k: "liquidaciones", n: "Liquidaciones", badge: deLaSemana.length || null },
+      ]} />
+
+      {/* La caja es del día y se dibuja sola: no tiene mes ni filtros. */}
+      {pestana === "caja" ? (
+        <Caja caja={caja} movCaja={movCaja} toast={toast} ajustes={ajustes}
+          abrirCaja={abrirCaja} cerrarCaja={cerrarCaja} />
+      ) : error ? (
+        <Card><ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado></Card>
+      ) : cargando ? (
+        <Card><Cargando /></Card>
+      ) : (
+        <>
+          {/* ---------- Selector de mes ---------- */}
+          {(pestana === "resumen" || pestana === "movimientos") && (
+            <div className="flex items-center gap-1">
+              <button onClick={() => setMes((m) => new Date(m.getFullYear(), m.getMonth() - 1, 1))}
+                className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2"><ChevronLeft size={15} /></button>
+              <span className="f-d text-base px-2 min-w-[150px]">{mesLargo(mes)}</span>
+              <button onClick={() => setMes((m) => new Date(m.getFullYear(), m.getMonth() + 1, 1))}
+                className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2"><ChevronRight size={15} /></button>
+              <div className="ml-auto flex gap-2">
+                <Boton size="sm" variant="ghost" onClick={() => setCargar("ingreso")}><Plus size={14} /> Ingreso</Boton>
+                <Boton size="sm" variant="ghost" onClick={() => setCargar("egreso")}><Plus size={14} /> Gasto</Boton>
+              </div>
+            </div>
+          )}
+
+          {/* ---------- Resumen ---------- */}
+          {pestana === "resumen" && resumen && (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                <Kpi label="Ingresos del mes" icono={ArrowUpRight} valor={money(resumen.ingresos)}
+                  delta={resumen.variacion} sub="vs. mes anterior" />
+                <Kpi label="Egresos del mes" icono={ArrowDownRight} valor={money(resumen.egresos)}
+                  tono={resumen.egresos > 0 ? "mal" : "neutro"} sub={`${nf.format(resumen.movimientos)} movimientos`} />
+                <Kpi label="Resultado" icono={Wallet} valor={money(resumen.resultado)}
+                  tono={resumen.resultado >= 0 ? "bien" : "mal"}
+                  sub={`el mes pasado ${money(resumen.previo.resultado)}`} />
+                <Kpi label="Falta cobrar" icono={Receipt} valor={money(totalPendiente)}
+                  tono={totalPendiente > 0 ? "ojo" : "neutro"}
+                  sub={`${nf.format(pendientes.length)} operaciones`} />
+              </div>
+
+              <div className="grid md:grid-cols-2 gap-4">
+                <Card className="p-4">
+                  <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold mb-3">
+                    Por dónde entró
+                  </div>
+                  {resumen.porMedio.length === 0 ? <Vacio>Todavía no entró nada este mes.</Vacio> : (
+                    <div className="space-y-3">
+                      {resumen.porMedio.map((x) => (
+                        <BarraDato key={x.k} nombre={(medios.find((m) => m.k === x.k) || { n: x.k }).n}
+                          valor={x.total} total={resumen.ingresos} formato={moneyk} />
+                      ))}
+                    </div>
+                  )}
+                </Card>
+
+                <Card className="p-4">
+                  <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold mb-3">
+                    En qué se fue
+                  </div>
+                  {resumen.porCategoria.length === 0 ? <Vacio>No hubo gastos este mes.</Vacio> : (
+                    <div className="space-y-3">
+                      {resumen.porCategoria.map((x) => (
+                        <BarraDato key={x.k} nombre={nombreCategoria(x.k)}
+                          valor={x.total} total={resumen.egresos} formato={moneyk} />
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              </div>
+            </div>
+          )}
+
+          {/* ---------- Movimientos ---------- */}
+          {pestana === "movimientos" && (
+            <Card className="overflow-hidden">
+              {movimientos.length === 0 ? (
+                <Vacio>No hubo movimientos en {mesLargo(mes).toLowerCase()}.</Vacio>
+              ) : (
+                <ul className="divide-y divide-borde">
+                  {movimientos.map((m) => (
+                    <li key={m.id} className="px-4 py-2.5 flex items-center gap-3">
+                      <span className="f-m text-xs text-texto-tenue w-24 shrink-0">{diaHora(m.fecha)}</span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm text-texto truncate">{m.detalle || "Sin detalle"}</div>
+                        <div className="text-[11px] text-texto-tenue">
+                          {(medios.find((x) => x.k === m.medio) || { n: m.medio }).n}
+                          {m.categoria && ` · ${nombreCategoria(m.categoria)}`}
+                          {!m.sesionId && " · fuera de caja"}
+                        </div>
+                      </div>
+                      <span className={`f-m text-sm shrink-0 ${m.tipo === "ingreso" ? "text-bien" : "text-mal"}`}>
+                        {m.tipo === "ingreso" ? "+" : "−"}{money(m.monto)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+          )}
+
+          {/* ---------- Pendientes ---------- */}
+          {pestana === "pendientes" && (
+            <Card className="overflow-hidden">
+              {pendientes.length === 0 ? (
+                <Vacio>No hay nada pendiente de cobro.</Vacio>
+              ) : (
+                <ul className="divide-y divide-borde">
+                  {pendientes.map((p) => {
+                    const dias = Math.floor((Date.now() - p.fecha) / 86400000);
+                    return (
+                      <li key={p.id} className="px-4 py-3 flex flex-wrap items-center gap-3">
+                        <span className="f-m text-xs text-texto-tenue w-16 shrink-0">{dia(p.fecha)}</span>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm text-texto truncate">{p.cliente}</div>
+                          <div className="text-[11px] text-texto-tenue">
+                            {money(p.pagado)} de {money(p.total)}
+                            {dias > 15 && ` · ${dias} días`}
+                          </div>
+                        </div>
+                        {dias > 15 && <Sello tono="mal">Atrasado</Sello>}
+                        <span className="f-m text-sm text-texto shrink-0">{money(p.falta)}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </Card>
+          )}
+
+          {/* ---------- Liquidaciones ---------- */}
+          {pestana === "liquidaciones" && (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <button onClick={() => setSemana(semanaDe(new Date(semana.lunes.getTime() - 7 * 86400000)))}
+                  className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2"><ChevronLeft size={15} /></button>
+                <span className="f-d text-base px-1">
+                  {dia(semana.lunes)} al {dia(semana.domingo)}
+                </span>
+                <button onClick={() => setSemana(semanaDe(new Date(semana.lunes.getTime() + 7 * 86400000)))}
+                  className="p-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2"><ChevronRight size={15} /></button>
+                {aPagarSemana > 0 && (
+                  <span className="f-m text-sm text-texto-suave ml-2">{money(aPagarSemana)} por pagar</span>
+                )}
+              </div>
+
+              {sinLiquidar.length > 0 && (
+                <Card className="p-3.5">
+                  <div className="text-sm text-texto-suave mb-2">
+                    Sin liquidar esta semana: las horas salen de la agenda y después se corrigen si hace falta.
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {sinLiquidar.map((p) => (
+                      <Boton key={p.id} size="sm" variant="ghost" onClick={() => armar(p.id)}>
+                        <Plus size={14} /> {p.nombre}
+                      </Boton>
+                    ))}
+                  </div>
+                </Card>
+              )}
+
+              <Card className="overflow-hidden">
+                {deLaSemana.length === 0 ? (
+                  <Vacio>Todavía no se armó ninguna liquidación de esta semana.</Vacio>
+                ) : (
+                  <ul className="divide-y divide-borde">
+                    {deLaSemana.map((l) => (
+                      <li key={l.id}>
+                        <button onClick={() => setAbierta(l)}
+                          className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                          <div className="min-w-0 flex-1">
+                            <div className="font-medium text-texto flex items-center gap-2">
+                              {l.persona}
+                              {l.notas > 0 && <StickyNote size={13} className="text-texto-tenue" />}
+                            </div>
+                            <div className="f-m text-[11px] text-texto-tenue">
+                              {l.modalidad === "hora" ? `${l.horas} hs × ${money(l.valor)}`
+                                : l.modalidad === "clase" ? `${l.clases} clases × ${money(l.valor)}`
+                                : "sueldo fijo"}
+                              {l.ajuste !== 0 && ` · ajuste ${money(l.ajuste)}`}
+                            </div>
+                          </div>
+                          <Sello tono={l.estado === "pagada" ? "bien" : "ojo"}>
+                            {l.estado === "pagada" ? "Pagada" : "Borrador"}
+                          </Sello>
+                          <span className="f-m text-sm text-texto shrink-0 w-24 text-right">{money(l.aPagar)}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </Card>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ---------- El detalle de una liquidación ---------- */}
+      <Drawer open={!!abierta} onClose={() => setAbierta(null)}
+        titulo={abierta ? abierta.persona : ""}
+        subtitulo={abierta ? `${dia(abierta.desde)} al ${dia(abierta.hasta)}` : ""}
+        acciones={abierta && abierta.estado === "borrador" && (
+          <div className="flex flex-wrap gap-2 items-center">
+            {medios.slice(0, 3).map((m) => (
+              <Boton key={m.k} size="sm" variant={m.k === "efectivo" ? "primary" : "ghost"}
+                onClick={async () => {
+                  try {
+                    await pagarLiquidacion(abierta.id, m.k,
+                      m.k === "efectivo" && caja && caja.abierta ? caja.sesionId : null);
+                    await releer();
+                    setAbierta(null);
+                    toast(`${abierta.persona} pagado.`);
+                  } catch (e) { toast(e.message || "No se pudo pagar.", "mal"); }
+                }}>
+                Pagar por {m.n.toLowerCase()}
+              </Boton>
+            ))}
+          </div>
+        )}>
+        {abierta && (
+          <div className="space-y-4">
+            <Sello tono={abierta.estado === "pagada" ? "bien" : "ojo"}>
+              {abierta.estado === "pagada" ? `Pagada por ${abierta.medio}` : "Borrador"}
+            </Sello>
+
+            <dl className="space-y-2 text-sm">
+              {[
+                ["Modalidad", abierta.modalidad === "hora" ? "Por hora" : abierta.modalidad === "clase" ? "Por clase" : abierta.modalidad === "fijo" ? "Sueldo fijo" : "Comisión"],
+                ["Horas", `${abierta.horas} hs`],
+                ["Clases dadas", nf.format(abierta.clases)],
+                ["Valor", money(abierta.valor)],
+                ["Subtotal", money(abierta.total)],
+                ["Ajuste", money(abierta.ajuste)],
+              ].map(([rot, val]) => (
+                <div key={rot} className="flex gap-2">
+                  <dt className="text-texto-tenue w-28 shrink-0">{rot}</dt>
+                  <dd className="text-texto">{val}</dd>
+                </div>
+              ))}
+              <div className="flex gap-2 pt-2 border-t border-borde">
+                <dt className="text-texto w-28 shrink-0 font-semibold">A pagar</dt>
+                <dd className="f-m text-texto font-semibold">{money(abierta.aPagar)}</dd>
+              </div>
+            </dl>
+
+            {abierta.estado === "borrador" && (
+              <div className="grid grid-cols-2 gap-3">
+                <Campo label="Corregir horas">
+                  <input type="number" step="0.5" defaultValue={abierta.horas} className={inputCls}
+                    onBlur={async (e) => {
+                      const h = Number(e.target.value);
+                      if (h === abierta.horas) return;
+                      try {
+                        await ajustarLiquidacion(abierta.id, { horas: h });
+                        await releer();
+                        setAbierta((a) => ({ ...a, horas: h }));
+                      } catch (err) { toast(err.message || "No se pudo.", "mal"); }
+                    }} />
+                </Campo>
+                <Campo label="Ajuste (adelantos, extras)">
+                  <input type="number" defaultValue={abierta.ajuste} className={inputCls}
+                    onBlur={async (e) => {
+                      const a = Number(e.target.value);
+                      if (a === abierta.ajuste) return;
+                      try {
+                        await ajustarLiquidacion(abierta.id, { ajuste: a });
+                        await releer();
+                        setAbierta((x) => ({ ...x, ajuste: a }));
+                      } catch (err) { toast(err.message || "No se pudo.", "mal"); }
+                    }} />
+                </Campo>
+              </div>
+            )}
+
+            {/* Las notas van pegadas al período: son la explicación de por
+                qué estas horas no cierran con lo habitual. */}
+            <div>
+              <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-2">
+                Notas de la semana
+              </div>
+              {notas.length === 0 ? (
+                <p className="text-sm text-texto-tenue">Sin notas. Acá van los reemplazos y lo que haga falta explicar.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {notas.map((x) => (
+                    <li key={x.id} className="text-sm">
+                      <span className="f-m text-[11px] text-texto-tenue">{dia(x.fecha)}</span>
+                      <p className="text-texto">{x.texto}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <div className="flex gap-2 mt-3">
+                <input value={nota} onChange={(e) => setNota(e.target.value)}
+                  placeholder="Cubrió a Carla el jueves…" className={inputCls} />
+                <Boton size="sm" variant="ghost" disabled={!nota.trim()} onClick={async () => {
+                  try {
+                    await anotar(empresaId, abierta.id, nota.trim());
+                    setNota("");
+                    const xs = await cargarNotas(empresaId, abierta.id);
+                    setNotas(xs);
+                    await releer();
+                  } catch (e) { toast(e.message || "No se pudo anotar.", "mal"); }
+                }}>Anotar</Boton>
+              </div>
+            </div>
+          </div>
+        )}
+      </Drawer>
+
+      <FormMovimiento abierto={!!cargar} tipo={cargar} medios={medios}
+        cajaAbierta={!!(caja && caja.abierta)}
+        onGuardar={guardarMovimiento} onCerrar={() => setCargar(null)} />
+    </div>
+  );
+}

--- a/src/modulos/Inicio.jsx
+++ b/src/modulos/Inicio.jsx
@@ -8,8 +8,19 @@ import { ArrowRight, Truck, Wallet, Barcode } from "lucide-react";
 import { HOY, fdatel } from "../datos/generador.js";
 import { money, moneyk, pct, nf } from "../utils/helpers.js";
 import { Card, Kpi, Boton, SEV } from "../ui/Base.jsx";
+import { InicioServicios } from "./InicioServicios.jsx";
 
-export function Inicio({ k, ins, ventasHoy, ticketsHoy, ir, negocio, aCobrar }) {
+/* Qué tablero se dibuja lo decide el rubro, en la base. Acá solo está la
+   traducción de nombre a componente: un tablero es código, no configuración,
+   y pretender lo contrario termina en un armador de dashboards que nadie
+   pidió. Un nombre desconocido cae en el de comercio, que es el que había. */
+export function Inicio(props) {
+  return props.tablero === "servicios"
+    ? <InicioServicios {...props} />
+    : <InicioComercio {...props} />;
+}
+
+function InicioComercio({ k, ins, ventasHoy, ticketsHoy, ir, negocio, aCobrar }) {
   const serie = k.diario.slice(-30).map((d) => ({ ...d, ganancia: d.ventas - d.costo }));
   const ganHoy = ventasHoy * k.margen30;
   return (
@@ -116,3 +127,4 @@ export function Inicio({ k, ins, ventasHoy, ticketsHoy, ir, negocio, aCobrar }) 
     </div>
   );
 }
+

--- a/src/modulos/InicioServicios.jsx
+++ b/src/modulos/InicioServicios.jsx
@@ -1,0 +1,391 @@
+/* ============================================================
+   5 bis. INICIO · el tablero de un negocio que vende horas
+   ============================================================
+
+   No hereda nada del tablero de comercio, a propósito. Margen bruto,
+   valor del stock y "se acaban primero" no le dicen nada a una estética
+   ni a un gimnasio: no tienen góndola, y su costo está en las horas.
+
+   Y hay algo más de fondo. Acá "cuánto cobré hoy" no es la pregunta: un
+   estudio de pilates puede no facturar un peso en todo un martes y estar
+   teniendo el mejor mes del año, porque cobró los abonos en marzo. Lo que
+   esta pantalla tiene que contestar de un vistazo es qué pasa hoy con los
+   turnos y qué conviene hacer ahora.
+
+   De dónde sale cada número lo resuelve `cargarTablero`. Esta pantalla
+   recibe un objeto y dibuja: no sabe cuáles ya vienen de la base y cuáles
+   todavía son de ejemplo, y por eso no hay que tocarla cuando migren.
+   ============================================================ */
+
+import React, { useState } from "react";
+import {
+  ArrowRight, Wallet, Barcode, Users, CalendarDays, Clock, Timer,
+  UserPlus, BellRing, Receipt, DollarSign, MapPin, Zap, AlertTriangle,
+  ChevronDown, Plus, Tag,
+} from "lucide-react";
+import { fdatel } from "../datos/generador.js";
+import { money, moneyk, pct, nf } from "../utils/helpers.js";
+import { Card, Kpi, Boton, Vacio, Apagado } from "../ui/Base.jsx";
+import { Anillo, Referencia, BarraDato, Chispa } from "../ui/Graficos.jsx";
+
+const diaLargo = (d) => {
+  const t = d.toLocaleDateString("es-AR", { weekday: "long", day: "numeric", month: "long", year: "numeric" });
+  return t.charAt(0).toUpperCase() + t.slice(1);
+};
+
+const iniciales = (nombre) =>
+  String(nombre || "?").trim().split(/\s+/).map((p) => p[0]).slice(0, 2).join("").toUpperCase();
+
+/* Un renglón con su dato, su explicación y a dónde ir. Lo comparten el
+   bloque de acciones recomendadas y el de alertas: son la misma cosa con
+   distinto contenido, y tenerlos dos veces era garantía de que se fueran
+   separando solos con el tiempo. */
+function Renglon({ icono: Ico, tono = "acento", titulo, detalle, accion, ir, tab, motivo }) {
+  const color = tono === "mal" ? "text-mal" : tono === "ojo" ? "text-ojo" : tono === "info" ? "text-info" : "text-acento";
+  const pastilla = (
+    <span className="shrink-0 text-xs font-semibold px-2.5 py-1.5 rounded-lg border border-borde bg-superficie-2 whitespace-nowrap">
+      {accion}
+    </span>
+  );
+  return (
+    <li className="flex gap-3 items-start">
+      <span className="mt-0.5 w-9 h-9 shrink-0 rounded-xl bg-superficie-2 flex items-center justify-center">
+        <Ico size={16} className={color} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-semibold text-texto text-sm leading-snug">{titulo}</div>
+        <p className="text-xs text-texto-suave mt-0.5">{detalle}</p>
+      </div>
+      {accion && (tab
+        ? <button onClick={() => ir(tab)} className="shrink-0 rounded-lg hover:opacity-80 transition-opacity">{pastilla}</button>
+        : <Apagado motivo={motivo || accion}>{pastilla}</Apagado>)}
+    </li>
+  );
+}
+
+/* Una tarjeta chica del resumen del día. */
+function Mini({ icono: Ico, rotulo, valor, pie, accion, ir, tab }) {
+  return (
+    <div className="rounded-xl border border-borde bg-superficie-2/40 p-3.5 min-w-0">
+      <div className="flex items-center gap-2">
+        <span className="w-7 h-7 shrink-0 rounded-lg bg-superficie-2 flex items-center justify-center">
+          <Ico size={14} className="text-acento" />
+        </span>
+        <span className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold truncate">{rotulo}</span>
+      </div>
+      <div className="f-d text-2xl mt-1.5 tabular-nums text-texto">{valor}</div>
+      <div className="text-[11px] text-texto-tenue mt-0.5 leading-snug">{pie}</div>
+      {accion && (tab
+        ? <button onClick={() => ir(tab)} className="mt-2 text-[11px] font-semibold text-acento hover:underline inline-flex items-center gap-1">
+            {accion} <ArrowRight size={11} />
+          </button>
+        : <Apagado motivo={accion} className="mt-2 text-[11px] font-semibold gap-1">{accion} <ArrowRight size={11} /></Apagado>)}
+    </div>
+  );
+}
+
+/* Un botón de la franja de abajo. Sin `hacer` queda apagado, con el motivo
+   al pasar el mouse: se ve lo que va a existir, sin aparentar que anda. */
+function Rapida({ icono: Ico, texto, hacer }) {
+  const cuerpo = (
+    <span className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-semibold">
+      <Ico size={16} className={hacer ? "text-acento" : "text-texto-tenue"} /> {texto}
+    </span>
+  );
+  const marco = "rounded-xl border border-borde bg-superficie text-texto";
+  return hacer
+    ? <button onClick={hacer} className={`${marco} hover:bg-superficie-2 transition-colors`}>{cuerpo}</button>
+    : <Apagado motivo={texto} className={marco}>{cuerpo}</Apagado>;
+}
+
+function Bloque({ titulo, extra, children, className = "" }) {
+  return (
+    <Card className={`p-4 ${className}`}>
+      <div className="flex items-baseline justify-between gap-3 mb-3">
+        <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold">{titulo}</div>
+        {extra}
+      </div>
+      {children}
+    </Card>
+  );
+}
+
+export function InicioServicios({ datos, cargando, ir, negocio, sucursal, usuario, aCobrar, puedeVer }) {
+  const [abierto, setAbierto] = useState(false);
+
+  if (cargando || !datos) {
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <Card key={i} className="p-4 h-28 animate-pulse"><span className="sr-only">Cargando</span></Card>
+        ))}
+      </div>
+    );
+  }
+
+  const d = datos;
+  const nombrePila = String(usuario || "").trim().split(/\s+/)[0] || "";
+
+  /* Se navega solo a donde el módulo existe. Lo demás queda apagado y no
+     escondido: se ve a dónde va a llevar, sin aparentar que ya lleva. */
+  const aDonde = (k) => (puedeVer(k) ? k : null);
+  const puedeCobrar = typeof aCobrar === "function" && puedeVer("cobro");
+
+  const rapidas = [
+    { k: "turno", n: "Nuevo turno", i: CalendarDays, hacer: null },
+    { k: "venta", n: "Venta rápida", i: Barcode, hacer: puedeCobrar ? aCobrar : null },
+    { k: "pago", n: "Registrar pago", i: Receipt, hacer: aDonde("caja") ? () => ir("caja") : null },
+    { k: "cliente", n: "Nuevo cliente", i: UserPlus, hacer: aDonde("clientes") ? () => ir("clientes") : null },
+    { k: "espera", n: "Lista de espera", i: Users, hacer: null },
+    { k: "promo", n: "Nueva promoción", i: Tag, hacer: null },
+  ];
+
+  const totalArea = d.ingresosPorArea.valor.reduce((s, a) => s + a.total, 0);
+  const asistPct = d.asistenciaHoy.sobre ? d.asistenciaHoy.valor / d.asistenciaHoy.sobre : null;
+  const salas = d.utilizacionSalas.valor;
+  const estados = d.turnosPorEstado.valor;
+
+  return (
+    <div className="space-y-4">
+      {/* ---------- Saludo ---------- */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="f-d text-2xl md:text-3xl leading-tight">
+            ¡Hola{nombrePila ? `, ${nombrePila}` : ""}! <span className="align-middle">👋</span>
+          </h1>
+          <p className="text-sm text-texto-suave mt-1">{diaLargo(new Date())}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Contextual y no un selector: multi sucursal todavía no existe,
+              y un desplegable que no hace nada es peor que un texto. */}
+          <span className="inline-flex items-center gap-1.5 text-sm text-texto-suave border border-borde rounded-xl px-3 py-2">
+            <MapPin size={14} className="text-texto-tenue" /> {sucursal || negocio}
+          </span>
+          <div className="relative">
+            <Boton onClick={() => setAbierto((v) => !v)}>
+              <Zap size={16} /> Nueva acción rápida <ChevronDown size={14} />
+            </Boton>
+            {abierto && (
+              <>
+                <div className="fixed inset-0 z-30" onClick={() => setAbierto(false)} />
+                <div className="absolute right-0 mt-2 z-40 w-60 rounded-xl border border-borde bg-superficie p-1.5">
+                  {rapidas.map((a) => (
+                    <button key={a.k} disabled={!a.hacer}
+                      onClick={() => { setAbierto(false); if (a.hacer) a.hacer(); }}
+                      title={a.hacer ? "" : `${a.n} todavía no está disponible.`}
+                      className="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm text-left text-texto hover:bg-superficie-2 disabled:opacity-35 disabled:cursor-not-allowed disabled:hover:bg-transparent">
+                      <a.i size={15} className={a.hacer ? "text-acento" : "text-texto-tenue"} /> {a.n}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ---------- Los cinco de arriba ---------- */}
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
+        <Kpi label="Facturación hoy" icono={DollarSign} valor={money(d.facturacionHoy.valor)}
+          delta={d.facturacionHoy.delta} sub="vs. ayer"
+          chispa={<Chispa serie={d.facturacionHoy.serie} />} />
+        <Kpi label="Turnos hoy" icono={CalendarDays} valor={nf.format(d.turnosHoy.valor)}
+          delta={d.turnosHoy.delta} sub="vs. ayer" />
+        <Kpi label="Asistencia hoy" icono={Users} valor={nf.format(d.asistenciaHoy.valor)}
+          sub={asistPct != null ? `${pct(asistPct)} del total` : "sin turnos"} />
+        <Kpi label="Ingresos del mes" icono={Wallet} valor={money(d.ingresosMes.valor)}
+          delta={d.ingresosMes.delta} sub="vs. mes anterior"
+          chispa={<Chispa serie={d.ingresosMes.serie} />} />
+        <Kpi label="Ticket promedio" icono={Receipt} valor={money(d.ticketPromedio.valor)}
+          delta={d.ticketPromedio.delta} sub="vs. mes anterior" />
+      </div>
+
+      <div className="grid xl:grid-cols-3 gap-4 items-start">
+        {/* ---------- Columna ancha ---------- */}
+        <div className="xl:col-span-2 space-y-4">
+          <Bloque titulo="Resumen operativo del día">
+            <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-2.5">
+              <Mini icono={Clock} rotulo="Próximos turnos" valor={nf.format(d.proximosTurnos.valor)}
+                pie="en las próximas 2 hs" accion="Ver agenda" ir={ir} tab={aDonde("agenda")} />
+              <Mini icono={Timer} rotulo="Huecos disponibles" valor={nf.format(d.huecos.valor)}
+                pie="oportunidades de venta" accion="Ver huecos" ir={ir} tab={aDonde("agenda")} />
+              <Mini icono={Users} rotulo="En lista de espera" valor={nf.format(d.listaEspera.valor)}
+                pie="esperando un lugar" accion="Ver lista" ir={ir} tab={aDonde("agenda")} />
+              <Mini icono={BellRing} rotulo="Abonos por vencer" valor={nf.format(d.abonosPorVencer.valor)}
+                pie="vencen esta semana" accion="Ver abonos" ir={ir} tab={aDonde("ventas")} />
+              <Mini icono={Receipt} rotulo="Pagos pendientes" valor={money(d.pagosPendientes.valor)}
+                pie={`de ${nf.format(d.pagosPendientes.clientes || 0)} clientes`} accion="Ver pendientes" ir={ir} tab={aDonde("caja")} />
+            </div>
+          </Bloque>
+
+          <div className="grid md:grid-cols-3 gap-4">
+            <Bloque titulo="Utilización de salas">
+              {salas.length === 0 ? <Vacio>Todavía no hay uso de salas registrado.</Vacio> : (
+                <>
+                  <Anillo alto={150}
+                    datos={salas.map((s) => ({ n: s.nombre, v: Math.round(s.pct * 100) }))}
+                    centro={pct(salas.reduce((s, x) => s + x.pct, 0) / salas.length)}
+                    sub="promedio" />
+                  <div className="mt-3">
+                    <Referencia datos={salas.map((s) => ({ n: s.nombre, v: s.pct }))} formato={(x) => pct(x.v)} />
+                  </div>
+                </>
+              )}
+            </Bloque>
+
+            <Bloque titulo="Turnos por estado">
+              {estados.length === 0 ? <Vacio>Sin turnos para mostrar.</Vacio> : (
+                <>
+                  <Anillo alto={150} datos={estados}
+                    centro={nf.format(estados.reduce((s, x) => s + x.v, 0))} sub="turnos" />
+                  <div className="mt-3">
+                    <Referencia datos={estados} formato={(x) => nf.format(x.v)} />
+                  </div>
+                </>
+              )}
+            </Bloque>
+
+            <Bloque titulo="Ingresos por área" extra={
+              puedeVer("reportes")
+                ? <button onClick={() => ir("reportes")} className="text-xs font-semibold text-acento hover:underline">Ver informe</button>
+                : null
+            }>
+              {d.ingresosPorArea.valor.length === 0 ? <Vacio>Todavía no hay ingresos este mes.</Vacio> : (
+                <div className="space-y-3">
+                  {d.ingresosPorArea.valor.map((a) => (
+                    <BarraDato key={a.nombre} nombre={a.nombre} valor={a.total} total={totalArea} formato={moneyk} />
+                  ))}
+                </div>
+              )}
+            </Bloque>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-4">
+            <Bloque titulo="Acciones recomendadas para hoy">
+              {d.acciones.valor.length === 0 ? <Vacio>Nada urgente para hoy.</Vacio> : (
+                <ul className="space-y-3.5">
+                  {d.acciones.valor.map((a) => (
+                    <Renglon key={a.k} icono={AlertTriangle} titulo={a.n} detalle={a.d}
+                      accion={a.accion} ir={ir} tab={a.tab ? aDonde(a.tab) : null} />
+                  ))}
+                </ul>
+              )}
+            </Bloque>
+
+            <Bloque titulo="Últimos clientes nuevos" extra={
+              puedeVer("clientes")
+                ? <button onClick={() => ir("clientes")} className="text-xs font-semibold text-acento hover:underline">Ver todos</button>
+                : null
+            }>
+              {d.clientesNuevos.valor.length === 0 ? <Vacio>Todavía no hay clientes cargados.</Vacio> : (
+                <ul className="space-y-2.5">
+                  {d.clientesNuevos.valor.map((c) => (
+                    <li key={c.id} className="flex items-center gap-2.5 text-sm">
+                      <span className="w-8 h-8 shrink-0 rounded-full bg-superficie-2 flex items-center justify-center text-[11px] font-bold text-texto-suave">
+                        {iniciales(c.nombre)}
+                      </span>
+                      <span className="truncate flex-1 text-texto">{c.nombre}</span>
+                      <span className="f-m text-[11px] text-texto-tenue shrink-0">{c.alta ? fdatel(c.alta) : ""}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Bloque>
+
+            <Bloque titulo="Top servicios (este mes)">
+              {d.topServicios.valor.length === 0 ? <Vacio>Todavía no se vendió nada este mes.</Vacio> : (
+                <ul className="space-y-2.5">
+                  {d.topServicios.valor.map((s, i) => (
+                    <li key={s.nombre} className="flex items-center gap-2.5 text-sm">
+                      <span className="w-6 h-6 shrink-0 rounded-lg bg-superficie-2 flex items-center justify-center text-[11px] font-bold text-texto-tenue">{i + 1}</span>
+                      <span className="truncate flex-1 text-texto">{s.nombre}</span>
+                      <span className="f-m text-[11px] text-texto-tenue shrink-0">{nf.format(Math.round(s.cantidad))}</span>
+                      <span className="f-m text-xs text-texto shrink-0">{moneyk(s.total)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Bloque>
+          </div>
+        </div>
+
+        {/* ---------- Columna angosta ---------- */}
+        <div className="space-y-4">
+          <Bloque titulo="Agenda de hoy" extra={
+            aDonde("agenda")
+              ? <button onClick={() => ir("agenda")} className="text-xs font-semibold text-acento hover:underline">Ver agenda completa</button>
+              : <Apagado motivo="La agenda" className="text-xs font-semibold">Ver agenda completa</Apagado>
+          }>
+            {d.agendaHoy.valor.length === 0 ? <Vacio>No hay turnos para hoy.</Vacio> : (
+              <ul>
+                {d.agendaHoy.valor.map((t, i) => (
+                  <li key={i} className="flex gap-2.5 py-2.5 border-b border-borde last:border-0">
+                    <span className="f-m text-xs text-texto-tenue w-10 shrink-0 pt-0.5">{t.hora}</span>
+                    <span className={`w-1.5 h-1.5 rounded-full shrink-0 mt-1.5 ${t.estado === "en curso" ? "bg-acento" : "bg-bien"}`} />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-texto truncate">{t.servicio}</div>
+                      <div className="text-[11px] text-texto-suave truncate">{t.persona} · {t.sala}</div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <span className={`text-[10px] uppercase tracking-wider font-bold px-1.5 py-0.5 rounded border ${
+                        t.estado === "en curso"
+                          ? "text-acento border-acento bg-acento-suave"
+                          : "text-bien border-bien bg-bien-suave"}`}>
+                        {t.estado}
+                      </span>
+                      <div className="f-m text-[11px] text-texto-tenue mt-0.5">{t.ocupados}/{t.cupo}</div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="pt-3 mt-1 border-t border-borde">
+              <Apagado motivo="Cargar un turno" className="text-xs font-semibold gap-1">
+                <Plus size={13} /> Nuevo turno rápido
+              </Apagado>
+            </div>
+          </Bloque>
+
+          <Bloque titulo="Alertas importantes">
+            {d.alertas.valor.length === 0 ? <Vacio>Nada que requiera atención.</Vacio> : (
+              <ul className="space-y-3.5">
+                {d.alertas.valor.map((a) => (
+                  <Renglon key={a.k} icono={AlertTriangle} tono={a.tono} titulo={a.n} detalle={a.d}
+                    accion={a.accion} ir={ir} tab={a.tab ? aDonde(a.tab) : null} />
+                ))}
+              </ul>
+            )}
+          </Bloque>
+
+          <Bloque titulo="Rendimiento del mes" extra={
+            puedeVer("reportes")
+              ? <button onClick={() => ir("reportes")} className="text-xs font-semibold text-acento hover:underline">Ver informe</button>
+              : null
+          }>
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                ["Ingresos", moneyk(d.rendimiento.valor.ingresos), d.ingresosMes.serie],
+                ["Asistencia", d.rendimiento.valor.asistencia != null ? pct(d.rendimiento.valor.asistencia) : "—", null],
+                ["Conversión", d.rendimiento.valor.conversion != null ? pct(d.rendimiento.valor.conversion) : "—", null],
+              ].map(([rotulo, valor, serie]) => (
+                <div key={rotulo} className="min-w-0">
+                  <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold truncate">{rotulo}</div>
+                  <div className="f-d text-lg mt-0.5 tabular-nums text-texto truncate">{valor}</div>
+                  {serie ? <Chispa serie={serie} ancho={70} alto={22} /> : null}
+                </div>
+              ))}
+            </div>
+          </Bloque>
+        </div>
+      </div>
+
+      {/* ---------- Acciones rápidas ---------- */}
+      <div>
+        <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold mb-2">Acciones rápidas</div>
+        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2.5">
+          {rapidas.map((a) => <Rapida key={a.k} icono={a.i} texto={a.n} hacer={a.hacer} />)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modulos/Vender.jsx
+++ b/src/modulos/Vender.jsx
@@ -8,7 +8,7 @@ import {
   Minus, Plus, Trash2, Printer, FileText, MessageCircle, Mail, QrCode,
   ArrowRight, Check, X, Percent, Users, Search
 } from "lucide-react";
-import { uid, HOY } from "../datos/generador.js";
+import { HOY } from "../datos/generador.js";
 import {
   nf, money, pct, esCantidad, aNumero, precioAplicado, proximaLista,
   letraComprobante, conRecargo, mediosDe, medioPorK, FISCAL_INICIAL,
@@ -463,7 +463,7 @@ const ATAJOS = [
   ["F9", "Salón"], ["F10", "Panel"], ["F1", "Ayuda"],
 ];
 
-export function POS({ productos, setProductos, cobrar, ajustes, toast, ir, pendiente, setPendiente, aPanel, clientes, setClientes, permisos }) {
+export function POS({ productos, setProductos, cobrar, ajustes, toast, ir, pendiente, setPendiente, aPanel, clientes, guardarCliente, permisos }) {
   const [paso, setPaso] = useState("carga");     // carga → pago → monto → fin
   const [q, setQ] = useState("");
   const [sel, setSel] = useState(0);
@@ -993,7 +993,15 @@ export function POS({ productos, setProductos, cobrar, ajustes, toast, ir, pendi
       {buscarCliente && (
         <BuscarCliente clientes={clientes} onCerrar={() => setBuscarCliente(false)}
           onElegir={(c) => { setCliente(c); setBuscarCliente(false); }}
-          onCrear={(d) => { const nuevo = { ...d, id: "c" + uid() }; setClientes((cs) => [...cs, nuevo]); setCliente(nuevo); setBuscarCliente(false); toast(`${d.razonSocial} agregado.`); }} />
+          onCrear={async (d) => {
+            /* Se espera el id que devuelve la base antes de seleccionarlo:
+               el cliente va impreso en el comprobante y uno inventado acá
+               no existiría en ningún lado. */
+            const c = await guardarCliente(d);
+            if (!c) return;
+            setCliente(c);
+            setBuscarCliente(false);
+          }} />
       )}
 
       {/* ---------- Ventana 2b: efectivo ---------- */}

--- a/src/modulos/Ventas.jsx
+++ b/src/modulos/Ventas.jsx
@@ -1,0 +1,505 @@
+/* ============================================================
+   18. VENTAS · abonos, packs y planes
+   ============================================================
+
+   Un estudio de pilates cobra ocho clases en marzo y las consume hasta
+   mayo. Esta pantalla es la que hace que la caja pueda reflejar eso: sin
+   ella, un martes sin cobrar un peso parece un mal martes cuando puede
+   ser el mejor mes del año.
+
+   Los planes son items del catálogo, así que venderlos pasa por el mismo
+   camino que cualquier venta: operación, línea, pago y movimiento de
+   caja. Acá arriba solo se elige el plan y el cliente.
+
+   El crédito se descuenta al reservar, no al asistir. Se ve en la agenda,
+   no acá: esta pantalla muestra cuánto queda, no lo gasta.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Plus, Check, Search, Ticket, Calendar, X } from "lucide-react";
+import {
+  cargarAbonos, cargarPlanes, guardarPlan, venderAbono, anularAbono,
+  cargarConsumos, estadoAbono,
+} from "../datos/abonos.js";
+import { estadoDe } from "../datos/agenda.js";
+import { money, nf } from "../utils/helpers.js";
+import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
+import { Campo, inputCls } from "../ui/Campos.jsx";
+import { Drawer } from "../ui/Drawer.jsx";
+
+const fecha = (d) => (d ? d.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit", year: "2-digit" }) : "—");
+
+/* Cómo se lee un plan en una línea: "8 clases · 60 días · 2 por semana". */
+function condiciones(p) {
+  const partes = [];
+  partes.push(p.clases ? `${p.clases} ${p.clases === 1 ? "clase" : "clases"}` : "libre");
+  if (p.vigenciaDias) partes.push(`${p.vigenciaDias} días`);
+  if (p.topeSemanal) partes.push(`${p.topeSemanal} por semana`);
+  return partes.join(" · ");
+}
+
+/* ------------------------------------------------------------
+   Vender un abono
+   ------------------------------------------------------------ */
+
+function FormVenta({ abierto, planes, clientes, medios, cajaAbierta, onGuardar, onCerrar }) {
+  const [d, setD] = useState({});
+  const [buscando, setBuscando] = useState("");
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!abierto) return;
+    setD({ medio: "efectivo", cobrar: true });
+    setBuscando("");
+    setError("");
+  }, [abierto]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+
+  const plan = planes.find((p) => p.id === d.itemId) || null;
+  const cliente = clientes.find((c) => c.id === d.clienteId) || null;
+  const precio = d.precio !== undefined && d.precio !== "" ? Number(d.precio) : (plan ? plan.precio : 0);
+
+  const norm = (t) => String(t || "").toLowerCase();
+  const coincidencias = buscando.trim().length >= 1
+    ? clientes.filter((c) => norm(c.razonSocial).includes(norm(buscando))).slice(0, 6)
+    : [];
+
+  const falta = !d.clienteId || !d.itemId;
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-lg">
+      <div className="p-5">
+        <h3 className="f-d text-lg">Vender un abono</h3>
+
+        <div className="space-y-3 mt-4">
+          <Campo label="Cliente">
+            {cliente ? (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="flex-1 text-sm text-texto border border-borde rounded-lg px-2.5 py-1.5 truncate">
+                  {cliente.razonSocial}
+                </span>
+                <button onClick={() => set("clienteId", null)} title="Quitar"
+                  className="p-2 rounded-lg text-texto-tenue hover:text-mal hover:bg-superficie-2"><X size={15} /></button>
+              </div>
+            ) : (
+              <>
+                <div className="relative">
+                  <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-texto-tenue" />
+                  <input value={buscando} onChange={(e) => setBuscando(e.target.value)}
+                    placeholder={clientes.length ? "Buscar un cliente" : "Todavía no hay clientes cargados"}
+                    className={`${inputCls} pl-8`} autoFocus />
+                </div>
+                {coincidencias.length > 0 && (
+                  <ul className="mt-1 border border-borde rounded-lg divide-y divide-borde max-h-40 overflow-auto">
+                    {coincidencias.map((c) => (
+                      <li key={c.id}>
+                        <button onClick={() => { set("clienteId", c.id); setBuscando(""); }}
+                          className="w-full text-left px-2.5 py-1.5 text-sm hover:bg-superficie-2">{c.razonSocial}</button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {/* Un abono es de alguien: no hay "consumidor final" acá.
+                    Sin cliente no se sabe de quién es el crédito. */}
+                {clientes.length === 0 && (
+                  <p className="text-xs text-texto-suave mt-1">
+                    Un abono es de una persona, así que hace falta tenerla cargada en Clientes.
+                  </p>
+                )}
+              </>
+            )}
+          </Campo>
+
+          <Campo label="Plan">
+            <select value={d.itemId || ""} onChange={(e) => set("itemId", e.target.value || null)} className={inputCls}>
+              <option value="">Elegir…</option>
+              {planes.filter((p) => p.activo).map((p) => (
+                <option key={p.id} value={p.id}>{p.nombre} — {money(p.precio)}</option>
+              ))}
+            </select>
+          </Campo>
+
+          {plan && (
+            <p className="text-xs text-texto-suave -mt-1">
+              {condiciones(plan)}
+              {plan.vigenciaDias && ` · vence el ${fecha(new Date(Date.now() + plan.vigenciaDias * 86400000))}`}
+            </p>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Precio">
+              <input type="number" value={d.precio !== undefined ? d.precio : (plan ? plan.precio : "")}
+                onChange={(e) => set("precio", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Medio de pago">
+              <select value={d.medio} onChange={(e) => set("medio", e.target.value)}
+                disabled={!d.cobrar} className={inputCls}>
+                {medios.map((m) => <option key={m.k} value={m.k}>{m.n}</option>)}
+              </select>
+            </Campo>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-texto-suave">
+            <input type="checkbox" checked={d.cobrar} onChange={(e) => set("cobrar", e.target.checked)} />
+            Cobrarlo ahora
+          </label>
+          {!d.cobrar && (
+            <p className="text-xs text-texto-suave -mt-1">
+              El abono queda activo y la venta con saldo pendiente. Aparece en Finanzas como cuenta por cobrar.
+            </p>
+          )}
+
+          {d.cobrar && !cajaAbierta && (
+            <p className="text-sm text-ojo">
+              No hay caja abierta. Abrila en Caja, o destildá “cobrarlo ahora” y cobralo después.
+            </p>
+          )}
+
+          {error && <p className="text-sm text-mal">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={falta || guardando || (d.cobrar && !cajaAbierta)} onClick={async () => {
+            setGuardando(true);
+            const problema = await onGuardar({ ...d, precio });
+            setGuardando(false);
+            if (problema) setError(problema); else onCerrar();
+          }}>
+            <Check size={15} /> {guardando ? "Guardando…" : d.cobrar ? `Cobrar ${money(precio)}` : "Guardar sin cobrar"}
+          </Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   El catálogo de planes
+   ------------------------------------------------------------ */
+
+function FormPlan({ abierto, inicial, onGuardar, onCerrar }) {
+  const [d, setD] = useState({});
+  const [guardando, setGuardando] = useState(false);
+
+  useEffect(() => {
+    if (abierto) setD({ activo: true, precio: 0, ...(inicial || {}) });
+  }, [abierto, inicial]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-lg">
+      <div className="p-5">
+        <h3 className="f-d text-lg">{d.id ? "Editar plan" : "Nuevo plan"}</h3>
+
+        <div className="space-y-3 mt-4">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2">
+              <Campo label="Nombre">
+                <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)}
+                  placeholder="Pack 8 clases" autoFocus className={inputCls} />
+              </Campo>
+            </div>
+            <Campo label="Precio">
+              <input type="number" value={d.precio} onChange={(e) => set("precio", e.target.value)} className={inputCls} />
+            </Campo>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <Campo label="Clases">
+              <input type="number" min="1" value={d.clases ?? ""} onChange={(e) => set("clases", e.target.value)}
+                placeholder="vacío = libre" className={inputCls} />
+            </Campo>
+            <Campo label="Días de vigencia">
+              <input type="number" min="1" value={d.vigenciaDias ?? ""} onChange={(e) => set("vigenciaDias", e.target.value)}
+                placeholder="sin vencimiento" className={inputCls} />
+            </Campo>
+            <Campo label="Tope semanal">
+              <input type="number" min="1" value={d.topeSemanal ?? ""} onChange={(e) => set("topeSemanal", e.target.value)}
+                placeholder="sin tope" className={inputCls} />
+            </Campo>
+          </div>
+
+          <p className="text-xs text-texto-suave">
+            Sin clases es un plan libre: se paga el período y se viene lo que el tope semanal permita.
+            El tope se controla al reservar, que es cuando importa.
+          </p>
+
+          <label className="flex items-center gap-2 text-sm text-texto-suave">
+            <input type="checkbox" checked={d.activo !== false} onChange={(e) => set("activo", e.target.checked)} />
+            Se puede vender
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={!d.nombre || guardando} onClick={async () => {
+            setGuardando(true);
+            const ok = await onGuardar(d);
+            setGuardando(false);
+            if (ok) onCerrar();
+          }}><Check size={15} /> Guardar</Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   La pantalla
+   ------------------------------------------------------------ */
+
+export function Ventas({ empresaId, sucursalId, clientes, ajustes, caja, permisos, toast, ir }) {
+  const [pestana, setPestana] = useState("abonos");
+  const [abonos, setAbonos] = useState([]);
+  const [planes, setPlanes] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [q, setQ] = useState("");
+  const [vendiendo, setVendiendo] = useState(false);
+  const [editandoPlan, setEditandoPlan] = useState(null);
+  const [abierto, setAbierto] = useState(null);
+  const [consumos, setConsumos] = useState([]);
+
+  const releer = useCallback(async () => {
+    const [a, p] = await Promise.all([cargarAbonos(empresaId), cargarPlanes(empresaId)]);
+    setAbonos(a);
+    setPlanes(p);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar los abonos."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  useEffect(() => {
+    if (!abierto) { setConsumos([]); return; }
+    let vigente = true;
+    cargarConsumos(empresaId, abierto.id)
+      .then((xs) => { if (vigente) setConsumos(xs); })
+      .catch(() => {});
+    return () => { vigente = false; };
+  }, [abierto, empresaId]);
+
+  const medios = useMemo(() => (
+    ((ajustes && ajustes.medios) || []).filter((m) => m.activo !== false)
+  ), [ajustes]);
+
+  const norm = (t) => String(t || "").toLowerCase();
+  const lista = useMemo(() => (
+    q.trim().length >= 2
+      ? abonos.filter((a) => norm(a.cliente).includes(norm(q)) || norm(a.nombre).includes(norm(q)))
+      : abonos
+  ), [abonos, q]);
+
+  const activos = abonos.filter((a) => a.estado === "activo");
+  const porVencer = activos.filter((a) => a.vence && (a.vence - Date.now()) / 86400000 <= 7);
+
+  async function vender(d) {
+    try {
+      await venderAbono({
+        empresaId, sucursalId,
+        clienteId: d.clienteId,
+        itemId: d.itemId,
+        precio: Number(d.precio) || 0,
+        sesionId: d.cobrar ? (caja && caja.sesionId) || null : null,
+        pagos: d.cobrar ? [{ medio: d.medio, monto: Number(d.precio) || 0 }] : [],
+      });
+      await releer();
+      toast("Abono vendido.");
+      return null;
+    } catch (e) {
+      return e.message || "No se pudo vender.";
+    }
+  }
+
+  async function grabarPlan(d) {
+    try {
+      await guardarPlan(empresaId, d);
+      await releer();
+      toast(`${d.nombre} guardado.`);
+      return true;
+    } catch (e) {
+      toast(e.message || "No se pudo guardar el plan.", "mal");
+      return false;
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {pestana === "abonos" && (
+          <div className="relative flex-1 min-w-[220px]">
+            <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-texto-tenue" />
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Buscar por cliente o plan"
+              className="w-full pl-9 pr-3 py-2 text-sm border border-borde rounded-xl outline-none focus:border-acento bg-superficie" />
+          </div>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          {pestana === "planes"
+            ? <Boton size="sm" onClick={() => setEditandoPlan({})}><Plus size={14} /> Nuevo plan</Boton>
+            : <Boton size="sm" onClick={() => setVendiendo(true)}><Plus size={14} /> Vender un abono</Boton>}
+        </div>
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "abonos", n: "Abonos", badge: activos.length || null },
+        { k: "planes", n: "Planes", badge: planes.length || null },
+      ]} />
+
+      {porVencer.length > 0 && pestana === "abonos" && (
+        <Card className="p-3.5 flex items-center gap-3">
+          <Calendar size={16} className="text-ojo shrink-0" />
+          <p className="text-sm text-texto-suave">
+            {porVencer.length === 1
+              ? `Hay un abono que vence esta semana: ${porVencer[0].cliente}.`
+              : `Hay ${porVencer.length} abonos que vencen esta semana.`}
+          </p>
+        </Card>
+      )}
+
+      <Card className="overflow-hidden">
+        {error ? (
+          <ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado>
+        ) : cargando ? (
+          <Cargando />
+        ) : pestana === "planes" ? (
+          planes.length === 0 ? (
+            <Vacio>
+              Todavía no hay planes. Son lo que se vende: un pack de clases, una cuota mensual.
+            </Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {planes.map((p) => (
+                <li key={p.id}>
+                  <button onClick={() => setEditandoPlan(p)}
+                    className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-texto">{p.nombre}</div>
+                      <div className="f-m text-[11px] text-texto-tenue">{condiciones(p)}</div>
+                    </div>
+                    {!p.activo && <Sello tono="tenue">No se vende</Sello>}
+                    <span className="f-m text-sm text-texto shrink-0">{money(p.precio)}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : lista.length === 0 ? (
+          <Vacio>
+            {abonos.length === 0
+              ? "Todavía no se vendió ningún abono. Cargá primero los planes y después vendelos."
+              : "Ningún abono coincide con esa búsqueda."}
+          </Vacio>
+        ) : (
+          <ul className="divide-y divide-borde">
+            {lista.map((a) => {
+              const e = estadoAbono(a.estado);
+              return (
+                <li key={a.id}>
+                  <button onClick={() => setAbierto(a)}
+                    className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                    <span className="w-9 h-9 shrink-0 rounded-xl bg-superficie-2 flex items-center justify-center">
+                      <Ticket size={16} className="text-texto-suave" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-texto truncate">{a.cliente}</div>
+                      <div className="f-m text-[11px] text-texto-tenue truncate">
+                        {a.nombre}{a.vence ? ` · vence ${fecha(a.vence)}` : ""}
+                      </div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className="f-m text-sm text-texto">
+                        {a.clases === null ? "libre" : `${a.restantes} de ${a.clases}`}
+                      </div>
+                      {a.topeSemanal && (
+                        <div className="text-[11px] text-texto-tenue">{a.topeSemanal} por semana</div>
+                      )}
+                    </div>
+                    <Sello tono={e.tono}>{e.n}</Sello>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card>
+
+      <Drawer open={!!abierto} onClose={() => setAbierto(null)}
+        titulo={abierto ? abierto.cliente : ""}
+        subtitulo={abierto ? abierto.nombre : ""}
+        acciones={abierto && abierto.estado !== "anulado" && (
+          <button onClick={async () => {
+            try {
+              await anularAbono(abierto.id);
+              await releer();
+              setAbierto(null);
+              toast("Abono anulado.");
+            } catch (e) { toast(e.message || "No se pudo anular.", "mal"); }
+          }} className="text-xs font-semibold text-mal hover:underline px-2">Anular abono</button>
+        )}>
+        {abierto && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Sello tono={estadoAbono(abierto.estado).tono}>{estadoAbono(abierto.estado).n}</Sello>
+              {abierto.clases !== null && (
+                <Sello tono={abierto.restantes > 0 ? "bien" : "mal"}>
+                  {abierto.restantes} de {abierto.clases}
+                </Sello>
+              )}
+            </div>
+
+            <dl className="space-y-2 text-sm">
+              {[
+                ["Desde", fecha(abierto.desde)],
+                ["Vence", abierto.vence ? fecha(abierto.vence) : "sin vencimiento"],
+                ["Usadas", nf.format(abierto.usadas)],
+                ["Tope semanal", abierto.topeSemanal ? `${abierto.topeSemanal} por semana` : "sin tope"],
+              ].map(([rot, val]) => (
+                <div key={rot} className="flex gap-2">
+                  <dt className="text-texto-tenue w-28 shrink-0">{rot}</dt>
+                  <dd className="text-texto">{val}</dd>
+                </div>
+              ))}
+            </dl>
+
+            <div>
+              <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-2">
+                En qué se usó
+              </div>
+              {consumos.length === 0 ? (
+                <Vacio>Todavía no se tomó ningún turno con este abono.</Vacio>
+              ) : (
+                <ul className="space-y-1.5">
+                  {consumos.map((t) => (
+                    <li key={t.id} className="flex items-center gap-2 text-sm">
+                      <span className="f-m text-xs text-texto-tenue w-16 shrink-0">{fecha(t.desde)}</span>
+                      <span className="truncate flex-1 text-texto">{t.servicio || "Turno"}</span>
+                      <Sello tono={estadoDe(t.estado).tono}>{estadoDe(t.estado).n}</Sello>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </Drawer>
+
+      <FormVenta abierto={vendiendo} planes={planes} clientes={clientes} medios={medios}
+        cajaAbierta={!!(caja && caja.abierta)} onGuardar={vender} onCerrar={() => setVendiendo(false)} />
+
+      <FormPlan abierto={!!editandoPlan} inicial={editandoPlan}
+        onGuardar={grabarPlan} onCerrar={() => setEditandoPlan(null)} />
+    </div>
+  );
+}

--- a/src/ui/Base.jsx
+++ b/src/ui/Base.jsx
@@ -550,6 +550,58 @@ export function Vacio({ children }) {
   return <div className="text-center py-14 text-texto-tenue text-sm">{children}</div>;
 }
 
+/* Los otros tres estados que toda pantalla tiene y que hasta ahora cada
+   una resolvía a su manera: una decía "Cargando…", otra ponía un spinner,
+   otra no mostraba nada. Con una sola voz, el sistema se siente uno. */
+export function Cargando({ children = "Cargando…" }) {
+  return (
+    <div className="flex items-center justify-center gap-2.5 py-14 text-texto-tenue text-sm">
+      <span className="w-4 h-4 rounded-full border-2 border-borde-fuerte border-t-acento animate-spin" />
+      {children}
+    </div>
+  );
+}
+
+/* El error dice qué pasó y ofrece reintentar. Un mensaje sin salida deja
+   al usuario mirando una pantalla rota sin nada que hacer. */
+export function ErrorEstado({ children, onReintentar }) {
+  return (
+    <div className="text-center py-14">
+      <p className="text-sm text-mal">{children || "Algo salió mal."}</p>
+      {onReintentar && (
+        <button onClick={onReintentar} className="mt-3 text-xs font-semibold text-acento hover:underline">
+          Reintentar
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function SinPermiso({ children = "No tenés permiso para ver esta parte." }) {
+  return <div className="text-center py-14 text-texto-tenue text-sm">{children}</div>;
+}
+
+/* La pastilla de estado, que estaba copiada en seis pantallas con clases
+   distintas. El tono es semántico: verde está bien, rojo hay que mirarlo.
+   El fondo es el suave del mismo color y no el saturado, que es la regla
+   de DISENO.md. */
+const TONO_SELLO = {
+  bien: "text-bien border-bien bg-bien-suave",
+  ojo: "text-ojo border-ojo bg-ojo-suave",
+  mal: "text-mal border-mal bg-mal-suave",
+  info: "text-info border-info bg-info-suave",
+  acento: "text-acento border-acento bg-acento-suave",
+  tenue: "text-texto-tenue border-borde bg-superficie-2",
+};
+
+export function Sello({ tono = "tenue", children, className = "" }) {
+  return (
+    <span className={`text-[10px] uppercase tracking-wider font-bold px-1.5 py-0.5 rounded border whitespace-nowrap ${TONO_SELLO[tono] || TONO_SELLO.tenue} ${className}`}>
+      {children}
+    </span>
+  );
+}
+
 export function TablaSimple({ cols, filas, vacio }) {
   if (!filas.length) return <Vacio>{vacio}</Vacio>;
   return (

--- a/src/ui/Base.jsx
+++ b/src/ui/Base.jsx
@@ -17,11 +17,24 @@ export function Card({ children, className = "" }) {
   return <div className={`bg-superficie border border-borde rounded-2xl ${className}`}>{children}</div>;
 }
 
-export function Kpi({ label, valor, delta, sub, tono = "neutro" }) {
+/* `icono` y `chispa` son opcionales y no cambian nada si no se pasan: sin
+   ellos esta tarjeta se dibuja igual que siempre, que es lo que necesitan
+   Caja, Stock, Compras y Reportes, que la usan desde antes.
+
+   `chispa` entra como nodo y no como serie de números a propósito: así
+   esta tarjeta no depende del gráfico, y el gráfico no depende de ella. */
+export function Kpi({ label, valor, delta, sub, tono = "neutro", icono: Ico, chispa }) {
   const col = tono === "bien" ? "text-bien" : tono === "mal" ? "text-mal" : "text-texto";
   return (
     <Card className="p-4">
-      <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold">{label}</div>
+      <div className="flex items-center gap-2">
+        {Ico && (
+          <span className="w-8 h-8 shrink-0 rounded-xl bg-superficie-2 flex items-center justify-center">
+            <Ico size={15} className="text-acento" />
+          </span>
+        )}
+        <div className="text-[11px] uppercase tracking-widest text-texto-tenue font-semibold min-w-0 truncate">{label}</div>
+      </div>
       <div className={`f-d text-3xl mt-1 tabular-nums ${col}`}>{valor}</div>
       <div className="flex items-center gap-2 mt-1">
         {delta !== undefined && delta !== null && (
@@ -30,7 +43,8 @@ export function Kpi({ label, valor, delta, sub, tono = "neutro" }) {
             {pct(Math.abs(delta))}
           </span>
         )}
-        {sub && <span className="text-xs text-texto-tenue">{sub}</span>}
+        {sub && <span className="text-xs text-texto-tenue truncate">{sub}</span>}
+        {chispa && <span className="ml-auto shrink-0">{chispa}</span>}
       </div>
     </Card>
   );

--- a/src/ui/Calendario.jsx
+++ b/src/ui/Calendario.jsx
@@ -1,0 +1,165 @@
+/* ============================================================
+   CALENDARIO · la grilla de turnos
+   ============================================================
+
+   Una grilla con las horas a la izquierda y una columna por profesional
+   —o por sala, o por día si se mira la semana—. Los turnos se dibujan
+   **proporcionales a su duración**: uno de 30 minutos ocupa la mitad que
+   uno de 60. Es lo único que hace que un día se lea de un vistazo.
+
+   El horario laboral va de fondo, más claro. Lo que queda oscuro es
+   tiempo en el que no se atiende, y eso responde "¿por qué no puedo poner
+   un turno acá?" sin que nadie tenga que preguntarlo.
+
+   Este componente no sabe de reservas ni de Supabase: recibe columnas y
+   bloques y los dibuja. Por eso sirve igual para turnos, para clases o
+   para lo que venga después.
+   ============================================================ */
+
+import React, { useMemo, useRef } from "react";
+
+const MIN_POR_HORA = 60;
+
+/* Alto de una hora en píxeles. 56 entra un día de 8 a 21 en una pantalla
+   de escritorio sin desplazar, que es el caso normal. */
+const ALTO_HORA = 56;
+
+const reloj = (min) =>
+  `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
+
+/* Los que se pisan se reparten el ancho de la columna. Sin esto, dos
+   turnos a la misma hora se tapan y uno desaparece. */
+function repartir(bloques) {
+  const orden = [...bloques].sort((a, b) => a.desde - b.desde || b.hasta - a.hasta);
+  const salida = [];
+  let grupo = [];
+
+  const cerrar = () => {
+    grupo.forEach((b, i) => salida.push({ ...b, columna: i, columnas: grupo.length }));
+    grupo = [];
+  };
+
+  for (const b of orden) {
+    if (grupo.length && !grupo.some((g) => g.desde < b.hasta && g.hasta > b.desde)) cerrar();
+    grupo.push(b);
+  }
+  cerrar();
+  return salida;
+}
+
+export function Calendario({
+  columnas,          // [{ k, n, sub, franjas: [{desde, hasta}] }]  minutos desde medianoche
+  bloques,           // [{ id, columna: k, desde, hasta, ... }]     minutos desde medianoche
+  desdeHora = 7,
+  hastaHora = 22,
+  onVacio,           // (columnaK, minutos) => void
+  onBloque,          // (bloque) => void
+  dibujarBloque,     // (bloque) => nodo
+}) {
+  const ref = useRef(null);
+  const desdeMin = desdeHora * 60;
+  const hastaMin = hastaHora * 60;
+  const alto = ((hastaMin - desdeMin) / MIN_POR_HORA) * ALTO_HORA;
+
+  const horas = useMemo(() => {
+    const xs = [];
+    for (let h = desdeHora; h <= hastaHora; h++) xs.push(h);
+    return xs;
+  }, [desdeHora, hastaHora]);
+
+  const porColumna = useMemo(() => {
+    const m = new Map();
+    for (const c of columnas) m.set(c.k, []);
+    for (const b of bloques) if (m.has(b.columna)) m.get(b.columna).push(b);
+    for (const [k, xs] of m) m.set(k, repartir(xs));
+    return m;
+  }, [columnas, bloques]);
+
+  const y = (min) => ((min - desdeMin) / MIN_POR_HORA) * ALTO_HORA;
+
+  /* Al hacer clic en un hueco se redondea a la media hora de arriba: nadie
+     agenda a las 9:07, y pedirle precisión al mouse es maltratarlo. */
+  function clicEnVacio(e, columnaK) {
+    if (!onVacio) return;
+    const caja = e.currentTarget.getBoundingClientRect();
+    const min = desdeMin + ((e.clientY - caja.top) / ALTO_HORA) * MIN_POR_HORA;
+    onVacio(columnaK, Math.max(desdeMin, Math.round(min / 30) * 30));
+  }
+
+  if (columnas.length === 0) {
+    return (
+      <div className="text-center py-14 text-texto-tenue text-sm">
+        No hay a quién mostrarle la agenda todavía.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto" ref={ref}>
+      <div className="min-w-[640px]">
+        {/* Encabezado de columnas */}
+        <div className="flex sticky top-0 z-10 bg-superficie border-b border-borde">
+          <div className="w-14 shrink-0" />
+          {columnas.map((c) => (
+            <div key={c.k} className="flex-1 min-w-0 px-2 py-2.5 border-l border-borde">
+              <div className="text-sm font-semibold text-texto truncate">{c.n}</div>
+              {c.sub && <div className="text-[11px] text-texto-tenue truncate">{c.sub}</div>}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex" style={{ height: alto }}>
+          {/* Las horas */}
+          <div className="w-14 shrink-0 relative">
+            {horas.map((h) => (
+              <div key={h} className="absolute right-2 -translate-y-1/2 f-m text-[11px] text-texto-tenue"
+                style={{ top: y(h * 60) }}>
+                {String(h).padStart(2, "0")}
+              </div>
+            ))}
+          </div>
+
+          {columnas.map((c) => {
+            const franjas = c.franjas || [];
+            return (
+              <div key={c.k} className="flex-1 min-w-0 relative border-l border-borde"
+                onClick={(e) => clicEnVacio(e, c.k)}>
+
+                {/* Fuera de horario queda oscuro; el horario laboral, un
+                    poco más claro. Se dibuja el trabajo y no el hueco:
+                    son menos rectángulos y se ve igual. */}
+                {franjas.map((f, i) => (
+                  <div key={i} className="absolute inset-x-0 bg-superficie-2/50"
+                    style={{ top: y(Math.max(f.desde, desdeMin)), height: Math.max(0, y(Math.min(f.hasta, hastaMin)) - y(Math.max(f.desde, desdeMin))) }} />
+                ))}
+
+                {/* Las líneas de la hora */}
+                {horas.map((h) => (
+                  <div key={h} className="absolute inset-x-0 border-t border-borde/60" style={{ top: y(h * 60) }} />
+                ))}
+
+                {(porColumna.get(c.k) || []).map((b) => {
+                  const arriba = y(Math.max(b.desde, desdeMin));
+                  const altoB = Math.max(18, y(Math.min(b.hasta, hastaMin)) - arriba);
+                  const ancho = 100 / b.columnas;
+                  return (
+                    <button key={b.id}
+                      onClick={(e) => { e.stopPropagation(); onBloque && onBloque(b); }}
+                      className="absolute px-0.5 text-left"
+                      style={{ top: arriba, height: altoB, left: `${b.columna * ancho}%`, width: `${ancho}%` }}>
+                      {dibujarBloque ? dibujarBloque(b, altoB) : (
+                        <span className="block h-full rounded-lg border border-borde bg-superficie-2 px-2 py-1 text-xs truncate">
+                          {reloj(b.desde)}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/Drawer.jsx
+++ b/src/ui/Drawer.jsx
@@ -1,0 +1,61 @@
+/* ============================================================
+   DRAWER · el panel que se abre al costado
+   ============================================================
+
+   Hermano de `Modal`, con una diferencia que importa: el modal tapa la
+   pantalla y el drawer la deja ver. Para el detalle de un turno eso es
+   todo — se mira la ficha sin perder de vista la agenda de atrás, que es
+   justamente contra lo que se compara para decidir.
+
+   En el celular no hay costado que valga, así que sube desde abajo. Es el
+   mismo criterio que ya usa `Overlay` en el POS.
+   ============================================================ */
+
+import React, { useEffect } from "react";
+import { X } from "lucide-react";
+
+export function Drawer({ open, onClose, titulo, subtitulo, acciones, children, ancho = "max-w-md" }) {
+  /* Escape cierra, y mientras está abierto el fondo no se desplaza: si se
+     desplaza, al cerrar el drawer la agenda quedó en otro lado. */
+  useEffect(() => {
+    if (!open) return;
+    const h = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", h);
+    const antes = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", h);
+      document.body.style.overflow = antes;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Menos opaco que el del modal, a propósito: lo de atrás tiene que
+          seguir leyéndose. */}
+      <div className="absolute inset-0 bg-fondo/60" onClick={onClose} />
+
+      <aside
+        className={`relative w-full ${ancho} h-full bg-superficie border-l border-borde flex flex-col seguro-abajo`}>
+        <header className="flex items-start gap-3 p-4 border-b border-borde shrink-0">
+          <div className="min-w-0 flex-1">
+            <h3 className="f-d text-lg leading-tight truncate">{titulo}</h3>
+            {subtitulo && <p className="text-sm text-texto-suave mt-0.5 truncate">{subtitulo}</p>}
+          </div>
+          <button onClick={onClose} title="Cerrar"
+            className="shrink-0 p-1.5 rounded-lg text-texto-tenue hover:text-texto hover:bg-superficie-2">
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+
+        {acciones && (
+          <footer className="p-4 border-t border-borde shrink-0">{acciones}</footer>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/src/ui/Graficos.jsx
+++ b/src/ui/Graficos.jsx
@@ -1,0 +1,120 @@
+/* ============================================================
+   GRÁFICOS · anillos, barras y chispas
+   ============================================================
+
+   Los colores se pasan como `rgb(var(--acento))` y no como un hex: así un
+   gráfico sigue al tema igual que el resto del sistema. Un `#f97316`
+   escrito acá quedaría fijo en claro y en oscuro, que es exactamente lo
+   que sacamos de las pantallas.
+   ============================================================ */
+
+import React from "react";
+import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
+
+export const TONOS = {
+  bien: "rgb(var(--bien))",
+  ojo: "rgb(var(--ojo))",
+  mal: "rgb(var(--mal))",
+  info: "rgb(var(--info))",
+  acento: "rgb(var(--acento))",
+  tenue: "rgb(var(--texto-tenue))",
+};
+
+/* Anillo. `datos` es [{ n, v, tono }] o [{ n, v }] a secas.
+
+   Sin tono, todos los gajos van del mismo naranja en distinta intensidad y
+   no de cinco colores distintos. Un color fuerte tiene que significar algo:
+   una sala más ocupada que otra no es un estado, es una cantidad, y para
+   una cantidad alcanza con la intensidad. */
+export function Anillo({ datos, centro, sub, alto = 190 }) {
+  const total = datos.reduce((s, d) => s + (Number(d.v) || 0), 0);
+  if (!total) {
+    return (
+      <div style={{ height: alto }} className="flex items-center justify-center text-sm text-texto-tenue">
+        Sin datos todavía
+      </div>
+    );
+  }
+  return (
+    <div style={{ height: alto }} className="relative">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie data={datos} dataKey="v" nameKey="n" innerRadius="62%" outerRadius="92%"
+            paddingAngle={2} stroke="none" isAnimationActive={false}>
+            {datos.map((d, i) => (
+              <Cell key={i}
+                fill={d.tono ? TONOS[d.tono] || TONOS.acento : TONOS.acento}
+                fillOpacity={d.tono ? 1 : 1 - i * 0.16} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+        <div className="f-d text-2xl tabular-nums text-texto">{centro}</div>
+        {sub && <div className="text-[11px] text-texto-tenue">{sub}</div>}
+      </div>
+    </div>
+  );
+}
+
+/* La referencia de un anillo, al costado. Va aparte del gráfico porque en
+   pantallas angostas la leyenda baja y el anillo se queda arriba. */
+export function Referencia({ datos, formato }) {
+  return (
+    <ul className="space-y-2 min-w-0">
+      {datos.map((d, i) => (
+        <li key={d.k || d.n} className="flex items-center gap-2 text-sm">
+          <span className="w-2 h-2 rounded-full shrink-0"
+            style={{
+              background: d.tono ? TONOS[d.tono] || TONOS.acento : TONOS.acento,
+              opacity: d.tono ? 1 : 1 - i * 0.16,
+            }} />
+          <span className="truncate flex-1 text-texto-suave">{d.n}</span>
+          <span className="f-m text-xs text-texto shrink-0">{formato ? formato(d) : d.v}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/* Barra horizontal con su monto y su parte del total. La usa "ingresos por
+   área" y sirve para cualquier ranking con plata. */
+export function BarraDato({ nombre, valor, total, formato }) {
+  const parte = total > 0 ? valor / total : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-3 text-sm">
+        <span className="truncate text-texto">{nombre}</span>
+        <span className="shrink-0 flex items-baseline gap-2">
+          <span className="f-m text-texto">{formato ? formato(valor) : valor}</span>
+          <span className="f-m text-xs text-texto-tenue">{Math.round(parte * 100)}%</span>
+        </span>
+      </div>
+      <div className="h-1.5 rounded-full bg-superficie-2 overflow-hidden">
+        <div className="h-full rounded-full bg-acento" style={{ width: `${Math.max(2, parte * 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/* La chispa de las tarjetas: una línea sin ejes ni números. No es un
+   gráfico para leer valores, es para ver si sube o baja, así que se dibuja
+   a mano en vez de arrastrar un contenedor de recharts por cada tarjeta. */
+export function Chispa({ serie, alto = 28, ancho = 92 }) {
+  const xs = (serie || []).filter((n) => Number.isFinite(n));
+  if (xs.length < 2) return null;
+
+  const min = Math.min(...xs);
+  const max = Math.max(...xs);
+  const rango = max - min || 1;
+  const paso = ancho / (xs.length - 1);
+  const punto = (v, i) => `${(i * paso).toFixed(1)},${(alto - ((v - min) / rango) * (alto - 3) - 1.5).toFixed(1)}`;
+  const linea = xs.map(punto).join(" ");
+
+  return (
+    <svg width={ancho} height={alto} viewBox={`0 0 ${ancho} ${alto}`} className="overflow-visible" aria-hidden="true">
+      <polyline points={linea} fill="none" stroke="rgb(var(--acento))" strokeWidth="1.5"
+        strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -225,12 +225,6 @@ export const FISCAL_INICIAL = {
   domicilio: "Av. San Martín 1204 · Caseros",
 };
 
-export const CLIENTES_INICIALES = [
-  { id: "c1", razonSocial: "Almacén de Vicky", doc: "27-31456789-4", tipoDoc: "CUIT", condicion: "RI", domicilio: "Sarmiento 88", email: "", tel: "11 4478-9032" },
-  { id: "c2", razonSocial: "Rotisería Don Luis", doc: "20-28765432-1", tipoDoc: "CUIT", condicion: "MONOTRIBUTO", domicilio: "Belgrano 415", email: "", tel: "" },
-  { id: "c3", razonSocial: "Marta Gómez", doc: "27.345.678", tipoDoc: "DNI", condicion: "CF", domicilio: "Rivadavia 2140", email: "", tel: "11 5031-7742" },
-];
-
 export function mediosDe(ajustes) {
   const ms = (ajustes && ajustes.medios) || MEDIOS_INICIALES;
   return ms.filter((m) => m.activo !== false);

--- a/supabase/migrations/0025_rubros.sql
+++ b/supabase/migrations/0025_rubros.sql
@@ -1,0 +1,146 @@
+/* ============================================================
+   0025 · EL MENÚ ES DATO
+   ============================================================
+
+   Hasta acá el menú era una lista fija escrita en el código, pensada para
+   un minimercado. Reemplazarla por otra lista fija pensada para una
+   estética dejaba el mismo problema para el rubro siguiente: cada negocio
+   nuevo obligaba a tocar componentes.
+
+   Ahora los grupos, qué módulos caen en cada uno, en qué orden y cómo se
+   llaman salen de una fila. Agregar "Genez para gimnasios" pasa a ser un
+   insert.
+
+   Es la misma decisión que `canales` en el centro de pedidos: el flujo de
+   un pedido vive en una fila y por eso mostrador no tiene "en camino" y
+   delivery sí, sin un solo `if`.
+
+   El ícono va como nombre y no como componente, obviamente: la base no
+   sabe de React. El navegador traduce nombre → ícono, y si no lo conoce
+   usa uno neutro en vez de romper la pantalla.
+   ============================================================ */
+
+create table rubros (
+  clave    text primary key,
+  nombre   text not null,
+  /* [{ clave, nombre, modulos: [{ k, n, d, i }] }]
+     `nombre` en null es un grupo sin rótulo: se dibuja la lista pelada,
+     que es como se ve hoy. */
+  menu     jsonb   not null default '[]',
+  /* Cómo llama cada rubro a las mismas cosas: turno, clase, sesión, cita.
+     Mismo mecanismo que VOZ_MESA y VOZ_CANAL en la comanda. */
+  voces    jsonb   not null default '{}',
+  /* Con qué módulos arranca un comercio de este rubro. Sugerencia para el
+     alta, no una restricción: después se contrata lo que se quiera. */
+  modulos  text[]  not null default '{}',
+  orden    integer not null default 0,
+  activo   boolean not null default true
+);
+
+comment on column rubros.menu is
+  'Grupos del menú y sus módulos. Un módulo listado acá igual no se ve si el comercio no lo contrató o el rol no lo habilita.';
+
+alter table rubros enable row level security;
+
+/* La forma del producto no es dato de nadie: cualquiera con sesión la lee.
+   Escribirla es de plataforma. */
+create policy rubros_leer on rubros
+  for select to authenticated using (true);
+
+create policy rubros_escribir on rubros
+  for all to authenticated using (public.es_plataforma()) with check (public.es_plataforma());
+
+/* ------------------------------------------------------------
+   Los rubros que ya existen
+
+   Estos dos reproducen el menú actual **exactamente**: un solo grupo sin
+   rótulo y el mismo orden. Super 25 y el Bar Rivadavia no tienen que notar
+   que algo cambió. La agrupación de verdad la estrena el rubro nuevo.
+   ------------------------------------------------------------ */
+
+insert into rubros (clave, nombre, orden, modulos, voces, menu) values
+(
+  'minimercado', 'Comercio', 10,
+  array['cobro','caja','ajustes','productos','stock','compras','pedidos','clientes','reportes','asistente'],
+  '{"cliente": "Cliente", "clientes": "Clientes"}'::jsonb,
+  '[{
+    "clave": "todo", "nombre": null,
+    "modulos": [
+      {"k":"inicio",   "n":"Inicio",    "i":"panel",    "d":"Cómo viene el negocio hoy"},
+      {"k":"pedidos",  "n":"Pedidos",   "i":"planilla", "d":"Preparación con pistola y control de faltantes"},
+      {"k":"clientes", "n":"Clientes",  "i":"gente",    "d":"Para emitir facturas A, B o C según corresponda"},
+      {"k":"productos","n":"Productos", "i":"caja",     "d":"Costos, precios y margen de todo tu catálogo"},
+      {"k":"stock",    "n":"Stock",     "i":"cajas",    "d":"Qué reponer, qué vence y qué no se mueve"},
+      {"k":"compras",  "n":"Compras",   "i":"camion",   "d":"Cargar remitos, pedidos sugeridos y proveedores"},
+      {"k":"caja",     "n":"Caja",      "i":"billetera","d":"Ingresos, egresos y arqueo del día"},
+      {"k":"reportes", "n":"Informes",  "i":"barras",   "d":"Qué se vende, qué deja plata y qué cambió"},
+      {"k":"asistente","n":"Asistente", "i":"chispas",  "d":"Tus datos explicados y qué conviene hacer"},
+      {"k":"ajustes",  "n":"Ajustes",   "i":"tuerca",   "d":"Configuración del negocio y del sistema"}
+    ]
+  }]'::jsonb
+),
+(
+  'gastronomia', 'Gastronomía', 20,
+  array['cobro','caja','ajustes','comandas','cocina','productos','stock','compras','clientes','reportes'],
+  '{"cliente": "Cliente", "clientes": "Clientes"}'::jsonb,
+  '[{
+    "clave": "todo", "nombre": null,
+    "modulos": [
+      {"k":"inicio",   "n":"Inicio",    "i":"panel",    "d":"Cómo viene el negocio hoy"},
+      {"k":"comandas", "n":"Salón",     "i":"cubiertos","d":"Qué mesa está ocupada, qué lleva y cuánto hace que espera"},
+      {"k":"cocina",   "n":"Cocina",    "i":"cocina",   "d":"Lo que hay que preparar, en el orden en que se pidió"},
+      {"k":"clientes", "n":"Clientes",  "i":"gente",    "d":"Para emitir facturas A, B o C según corresponda"},
+      {"k":"productos","n":"Productos", "i":"caja",     "d":"Costos, precios y margen de todo tu catálogo"},
+      {"k":"stock",    "n":"Stock",     "i":"cajas",    "d":"Qué reponer, qué vence y qué no se mueve"},
+      {"k":"compras",  "n":"Compras",   "i":"camion",   "d":"Cargar remitos, pedidos sugeridos y proveedores"},
+      {"k":"caja",     "n":"Caja",      "i":"billetera","d":"Ingresos, egresos y arqueo del día"},
+      {"k":"reportes", "n":"Informes",  "i":"barras",   "d":"Qué se vende, qué deja plata y qué cambió"},
+      {"k":"asistente","n":"Asistente", "i":"chispas",  "d":"Tus datos explicados y qué conviene hacer"},
+      {"k":"ajustes",  "n":"Ajustes",   "i":"tuerca",   "d":"Configuración del negocio y del sistema"}
+    ]
+  }]'::jsonb
+),
+/* ------------------------------------------------------------
+   El rubro nuevo
+
+   Solo se listan módulos que existen hoy. A medida que se construyan la
+   agenda, el equipo, los abonos y las finanzas, se agregan filas acá y
+   aparecen solas en el menú: eso es lo que estamos comprando con este
+   cambio.
+   ------------------------------------------------------------ */
+(
+  'servicios', 'Servicios y turnos', 30,
+  array['cobro','caja','ajustes','clientes','reportes'],
+  '{"cliente": "Cliente", "clientes": "Clientes", "turno": "Turno", "turnos": "Turnos", "profesional": "Profesional", "profesionales": "Profesionales"}'::jsonb,
+  '[
+    {"clave":"inicio", "nombre": null, "modulos":[
+      {"k":"inicio","n":"Inicio","i":"panel","d":"Cómo viene el negocio hoy"}
+    ]},
+    {"clave":"gente", "nombre":"Clientes y equipo", "modulos":[
+      {"k":"clientes","n":"Clientes","i":"gente","d":"Ficha, historial y turnos de cada cliente"}
+    ]},
+    {"clave":"finanzas", "nombre":"Finanzas", "modulos":[
+      {"k":"caja","n":"Caja","i":"billetera","d":"Ingresos, egresos y arqueo del día"},
+      {"k":"reportes","n":"Informes","i":"barras","d":"Qué se vende, qué deja plata y qué cambió"}
+    ]},
+    {"clave":"config", "nombre":"Configuración", "modulos":[
+      {"k":"ajustes","n":"Ajustes","i":"tuerca","d":"Configuración del negocio y del sistema"}
+    ]}
+  ]'::jsonb
+)
+on conflict (clave) do update
+  set nombre = excluded.nombre, menu = excluded.menu,
+      voces = excluded.voces, modulos = excluded.modulos, orden = excluded.orden;
+
+/* ------------------------------------------------------------
+   Qué quedó
+   ------------------------------------------------------------ */
+
+select
+  r.clave, r.nombre,
+  jsonb_array_length(r.menu) as grupos,
+  (select count(*) from jsonb_array_elements(r.menu) g,
+          jsonb_array_elements(g -> 'modulos')) as modulos_en_el_menu,
+  (select count(*) from empresas e where e.rubro = r.clave) as comercios
+from rubros r
+order by r.orden;

--- a/supabase/migrations/0026_recursos_de_servicios.sql
+++ b/supabase/migrations/0026_recursos_de_servicios.sql
@@ -1,0 +1,22 @@
+/* ============================================================
+   0026 · RECURSOS PARA NEGOCIOS DE SERVICIOS
+   ============================================================
+
+   `recursos` ya modelaba cualquier cosa reservable —mesa, habitación,
+   sillón, bahía, cancha— pero la lista se escribió pensando en gastronomía
+   y alojamiento. Una estética reserva salas y camillas, y un estudio de
+   pilates reserva la sala del reformer.
+
+   Se agregan los dos tipos que faltaban en vez de abrir la columna a texto
+   libre: la restricción es lo que evita que mañana convivan 'sala',
+   'Sala', 'salita' y 'SALA' y que ninguna consulta agrupe bien.
+   ============================================================ */
+
+alter table recursos drop constraint recursos_tipo_valido;
+
+alter table recursos add constraint recursos_tipo_valido check (
+  tipo in ('mesa', 'habitacion', 'sillon', 'bahia', 'cancha', 'sala', 'camilla', 'otro')
+);
+
+comment on column recursos.tipo is
+  'Qué se reserva. Cambia por rubro: mesa en gastronomía, sala o camilla en servicios, cancha en un club.';

--- a/supabase/migrations/0027_entrada_del_rubro.sql
+++ b/supabase/migrations/0027_entrada_del_rubro.sql
@@ -1,0 +1,64 @@
+/* ============================================================
+   0027 · POR DÓNDE ENTRA CADA RUBRO
+   ============================================================
+
+   El menú ya salía de una fila, pero tres cosas seguían decididas por un
+   `if` en el código, y las tres estaban escritas pensando en un comercio
+   que vende cosas:
+
+   1. En qué pantalla arranca el sistema. Era: "si contrataste cobro,
+      arrancás en la caja registradora". Una estética abría con un lector
+      de códigos de barras y un carrito vacío, cuando el 95% de su día es
+      agendar turnos y vender es la excepción.
+
+   2. Qué es el botón grande de la barra lateral. Cobrar en un
+      minimercado, tomar la comanda en un bar. En un negocio de turnos,
+      cobrar existe pero no es lo que se hace todo el día, así que no
+      puede ser lo más grande de la pantalla.
+
+   3. Qué tablero muestra el Inicio. Margen bruto, valor del stock y
+      vencimientos no le dicen nada a quien vende horas.
+
+   Las tres pasan a la fila del rubro. El tablero va como nombre y no como
+   configuración: un tablero es código, no datos, y pretender lo contrario
+   termina en un armador de dashboards que nadie pidió. Lo que la fila
+   decide es cuál se muestra.
+   ============================================================ */
+
+alter table rubros add column entrada text    not null default 'panel';
+alter table rubros add column accion  jsonb;
+alter table rubros add column inicio  text    not null default 'comercio';
+
+alter table rubros add constraint rubros_entrada_valida check (
+  entrada in ('panel', 'cobro', 'comanda')
+);
+
+comment on column rubros.entrada is
+  'Pantalla en la que abre el sistema. panel es el tablero; cobro y comanda son las pantallas de venta.';
+comment on column rubros.accion is
+  'El botón principal de la barra lateral: {k, n, i, destacada}. Con destacada en false baja a un renglón más del menú. En null no hay botón.';
+comment on column rubros.inicio is
+  'Qué tablero dibuja la pantalla de Inicio. El navegador traduce nombre → componente.';
+
+update rubros set
+  entrada = 'cobro',
+  accion  = '{"k":"cobro","n":"Cobrar","i":"barcode","destacada":true}'::jsonb,
+  inicio  = 'comercio'
+where clave = 'minimercado';
+
+update rubros set
+  entrada = 'comanda',
+  accion  = '{"k":"comanda","n":"Comanda","i":"planilla","destacada":true}'::jsonb,
+  inicio  = 'comercio'
+where clave = 'gastronomia';
+
+/* Vender existe y tiene que seguir a mano —una estética vende una crema de
+   vez en cuando— pero deja de ser lo primero que se ve y lo más grande.
+   Baja a un renglón del menú, arriba de todo. */
+update rubros set
+  entrada = 'panel',
+  accion  = '{"k":"cobro","n":"Cobrar","i":"barcode","destacada":false}'::jsonb,
+  inicio  = 'servicios'
+where clave = 'servicios';
+
+select clave, entrada, inicio, accion from rubros order by orden;

--- a/supabase/migrations/0028_menu_de_diez_secciones.sql
+++ b/supabase/migrations/0028_menu_de_diez_secciones.sql
@@ -1,0 +1,71 @@
+/* ============================================================
+   0028 · EL MENÚ DEFINITIVO DE DIEZ SECCIONES
+   ============================================================
+
+   La arquitectura final de Genez son diez secciones y no quince módulos
+   sueltos. Esta migración la deja planteada para el rubro de servicios sin
+   tocar una línea de las pantallas que ya andan.
+
+   Dos reglas nuevas en la forma del menú:
+
+   `proximo` marca una sección que va a existir y todavía no. Se dibuja
+   apagada, con el motivo al pasar el mouse. Es la misma decisión que las
+   acciones rápidas del tablero: preferimos que se vea a dónde va el
+   sistema antes que esconderlo, pero sin que nada aparente funcionar.
+
+   `i` es el ícono de la sección, que hace falta justamente para poder
+   dibujarla cuando todavía no tiene ningún módulo adentro que le preste
+   el suyo.
+
+   Y una convención de dibujo, que vive en el navegador: una sección con un
+   solo módulo se dibuja como un renglón con el nombre de la sección, no
+   con el del módulo. Así "Clientes y equipo" es una fila y no un rótulo
+   con "Clientes" colgando abajo. Cuando una sección junte dos o más
+   módulos, ahí sí van a hacer falta las pestañas internas, que es el
+   siguiente paso y no este.
+
+   Comercio y gastronomía no se tocan: siguen con su grupo único sin
+   rótulo, exactamente como estaban.
+   ============================================================ */
+
+update rubros set menu = '[
+  {"clave":"inicio", "nombre": null, "i":"panel", "modulos":[
+    {"k":"inicio","n":"Inicio","i":"panel","d":"Cómo viene el negocio hoy"}
+  ]},
+
+  {"clave":"agenda", "nombre":"Agenda", "i":"agenda", "proximo": true, "modulos":[]},
+
+  {"clave":"gente", "nombre":"Clientes y equipo", "i":"gente", "modulos":[
+    {"k":"clientes","n":"Clientes","i":"gente","d":"Ficha, historial y turnos de cada cliente"}
+  ]},
+
+  {"clave":"catalogo", "nombre":"Servicios y recursos", "i":"tuerca", "proximo": true, "modulos":[]},
+
+  {"clave":"ventas", "nombre":"Ventas", "i":"bolsa", "proximo": true, "modulos":[]},
+
+  {"clave":"finanzas", "nombre":"Finanzas", "i":"billetera", "modulos":[
+    {"k":"caja","n":"Caja","i":"billetera","d":"Ingresos, egresos y arqueo del día"}
+  ]},
+
+  {"clave":"crm", "nombre":"CRM y marketing", "i":"corazon", "proximo": true, "modulos":[]},
+
+  {"clave":"comunicaciones", "nombre":"Comunicaciones", "i":"mensaje", "proximo": true, "modulos":[]},
+
+  {"clave":"reportes", "nombre":"Reportes", "i":"barras", "modulos":[
+    {"k":"reportes","n":"Informes","i":"barras","d":"Qué se vende, qué deja plata y qué cambió"}
+  ]},
+
+  {"clave":"config", "nombre":"Configuración", "i":"tuerca", "modulos":[
+    {"k":"ajustes","n":"Ajustes","i":"tuerca","d":"Configuración del negocio y del sistema"}
+  ]}
+]'::jsonb
+where clave = 'servicios';
+
+select
+  g ->> 'clave'                              as seccion,
+  coalesce(g ->> 'nombre', '(sin rótulo)')   as rotulo,
+  jsonb_array_length(g -> 'modulos')         as modulos,
+  coalesce(g ->> 'proximo', 'false')         as proximo
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios'
+order by x.orden;

--- a/supabase/migrations/0029_servicios_sin_pos.sql
+++ b/supabase/migrations/0029_servicios_sin_pos.sql
@@ -1,0 +1,22 @@
+/* ============================================================
+   0029 · UN NEGOCIO DE TURNOS NO ABRE CON UN LECTOR DE CÓDIGOS
+   ============================================================
+
+   El botón "Cobrar" del rubro servicios abría el punto de venta del
+   minimercado: buscador de artículos, lector de códigos de barras,
+   carrito. En una estética eso no tiene ningún sentido, y encima estaba
+   arriba de todo en la barra lateral.
+
+   Se le saca la acción al rubro. No se le saca el módulo `cobro`: una
+   estética vende una crema de vez en cuando y va a necesitar cobrar. Lo
+   que falta es la pantalla adecuada para eso, que es otra cosa y se diseña
+   aparte.
+
+   Mientras tanto queda sin acción principal, que es lo honesto: mejor no
+   ofrecer nada que ofrecer la pantalla equivocada.
+   ============================================================ */
+
+update rubros set accion = null where clave = 'servicios';
+
+select clave, entrada, inicio, coalesce(accion ->> 'n', '— sin acción —') as boton
+from rubros order by orden;

--- a/supabase/migrations/0030_equipo.sql
+++ b/supabase/migrations/0030_equipo.sql
@@ -1,0 +1,204 @@
+/* ============================================================
+   0030 · EL EQUIPO
+   ============================================================
+
+   Quién trabaja, qué sabe hacer y cuándo está. Es lo que le falta a la
+   base para poder ofrecer un turno: sin saber que Carla da reformer los
+   martes de 8 a 13, no hay agenda posible ni siquiera a mano.
+
+   `personal` no es `perfiles`
+   ---------------------------
+   `perfiles` son usuarios del sistema: gente que entra con una cuenta.
+   `personal` es gente del negocio, que puede no entrar nunca. Hoy en la
+   estética ningún profesor usa el sistema, y aun así hay que poder
+   agendarlos, pagarles y cubrirlos cuando faltan.
+
+   Por eso `perfil_id` es opcional. El día que un profesor quiera entrar se
+   le engancha una cuenta y nada más. Preverlo ahora cuesta una columna;
+   agregarlo después cuesta una migración de datos con turnos encima.
+
+   `personal` tampoco es `recursos`
+   --------------------------------
+   Un recurso es una cosa que se ocupa —una sala, una camilla—. Una persona
+   se ocupa también, pero además cobra, falta y tiene especialidad. Meter
+   las dos en la misma tabla obligaba a que la mitad de las columnas
+   estuvieran siempre en null.
+
+   La modalidad de pago
+   --------------------
+   Por hora, por clase, por comisión o sueldo fijo, y por persona. El
+   primer negocio paga por hora, pero ninguna de las cuatro puede estar
+   escrita en el código: es un sistema que se adapta, no que impone.
+   ============================================================ */
+
+create table personal (
+  id           uuid primary key default gen_random_uuid(),
+  empresa_id   uuid not null references empresas(id) on delete cascade,
+  sucursal_id  uuid references sucursales(id) on delete set null,
+  /* Opcional a propósito: se trabaja acá sin tener cuenta en el sistema. */
+  perfil_id    uuid references perfiles(id) on delete set null,
+
+  nombre       text not null,
+  tipo         text not null default 'profesional',
+  especialidad text,
+  tel          text,
+  email        text,
+
+  /* Sobre qué se le paga y cuánto. `valor` es el valor hora, el valor por
+     clase o el sueldo según la modalidad: un solo número, porque tres
+     columnas donde siempre hay dos vacías se desincronizan solas. */
+  modalidad    text not null default 'hora',
+  valor        numeric(14,2) not null default 0,
+  comision     numeric(5,2)  not null default 0,
+
+  orden        integer not null default 0,
+  activo       boolean not null default true,
+  campos_extra jsonb   not null default '{}',
+  creado_en    timestamptz not null default now(),
+
+  constraint personal_tipo_valido check (tipo in ('profesional', 'recepcion', 'otro')),
+  constraint personal_modalidad_valida check (modalidad in ('hora', 'clase', 'comision', 'fijo')),
+  constraint personal_nombre_unico unique (empresa_id, nombre)
+);
+
+create index on personal (empresa_id, activo);
+create index on personal (perfil_id) where perfil_id is not null;
+
+comment on column personal.perfil_id is 'Cuenta del sistema, si la tiene. La mayoría del personal no entra nunca.';
+comment on column personal.valor     is 'Valor hora, valor por clase o sueldo, según modalidad.';
+
+/* ------------------------------------------------------------
+   Qué hace cada uno
+
+   Sin esto la agenda ofrecería a la esteticista para dar reformer. Es lo
+   que después filtra qué profesional aparece al elegir un servicio.
+   ------------------------------------------------------------ */
+create table personal_servicios (
+  personal_id uuid not null references personal(id) on delete cascade,
+  item_id     uuid not null references items(id)    on delete cascade,
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  primary key (personal_id, item_id)
+);
+
+create index on personal_servicios (empresa_id);
+create index on personal_servicios (item_id);
+
+/* ------------------------------------------------------------
+   Cuándo está
+
+   Una franja semanal: "martes de 8 a 13". Se repite todas las semanas, y
+   lo que no se repite son las excepciones, que van en la tabla de abajo.
+
+   La misma tabla sirve para una persona y para una sala: un reformer
+   también tiene horario, porque la sala puede estar alquilada los sábados.
+   Una fila apunta a una cosa o a la otra, nunca a las dos.
+
+   El día va 0 a 6 con el domingo en 0, igual que `getDay()` del navegador
+   y que `extract(dow)` de Postgres. Elegir otra numeración garantizaba un
+   error de corrimiento el día que alguien cruzara los dos.
+   ------------------------------------------------------------ */
+create table horarios (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  personal_id uuid references personal(id) on delete cascade,
+  recurso_id  uuid references recursos(id) on delete cascade,
+
+  dia         smallint not null,
+  desde       time not null,
+  hasta       time not null,
+  activo      boolean not null default true,
+
+  constraint horarios_dia_valido   check (dia between 0 and 6),
+  constraint horarios_rango_valido check (hasta > desde),
+  constraint horarios_dueno_unico  check (num_nonnulls(personal_id, recurso_id) = 1)
+);
+
+create index on horarios (empresa_id, dia);
+create index on horarios (personal_id) where personal_id is not null;
+create index on horarios (recurso_id)  where recurso_id  is not null;
+
+comment on column horarios.dia is '0 domingo a 6 sábado, igual que getDay() y extract(dow).';
+
+/* ------------------------------------------------------------
+   Cuándo no está
+
+   Vacaciones, una ausencia, un feriado. Con `personal_id` en null vale
+   para todo el comercio, que es lo que hace a un feriado.
+   ------------------------------------------------------------ */
+create table excepciones (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  personal_id uuid references personal(id) on delete cascade,
+
+  desde       date not null,
+  hasta       date not null,
+  motivo      text not null default 'ausencia',
+  nota        text,
+  creado_en   timestamptz not null default now(),
+
+  constraint excepciones_rango_valido check (hasta >= desde),
+  constraint excepciones_motivo_valido check (motivo in ('ausencia', 'vacaciones', 'feriado', 'licencia'))
+);
+
+create index on excepciones (empresa_id, desde, hasta);
+
+comment on table excepciones is 'Con personal_id en null aplica a todo el comercio: eso es un feriado.';
+
+/* ------------------------------------------------------------
+   Quién ve qué
+
+   Lo mismo que el resto: cada comercio lo suyo. Vale recordar que la
+   política contesta si podés ver algo, no de qué comercio es — filtrar por
+   empresa_id sigue siendo obligación de cada consulta (regla 6).
+   ------------------------------------------------------------ */
+alter table personal           enable row level security;
+alter table personal_servicios enable row level security;
+alter table horarios           enable row level security;
+alter table excepciones        enable row level security;
+
+create policy personal_todo on personal
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+create policy personal_servicios_todo on personal_servicios
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+create policy horarios_todo on horarios
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+create policy excepciones_todo on excepciones
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+/* ------------------------------------------------------------
+   El equipo, ya resuelto
+
+   Las horas semanales y la cantidad de servicios se calculan acá y no en
+   la pantalla, por lo mismo que el estado de una mesa: si cada lugar los
+   dedujera por su cuenta, un día dejan de coincidir.
+   ------------------------------------------------------------ */
+/* `security_invoker` no es opcional: sin esa opción una vista corre con
+   los permisos de quien la creó y saltea RLS por completo. Acá eso
+   significaba que cualquiera con sesión leía el equipo de los otros
+   comercios, con los sueldos adentro. Las otras vistas del sistema la
+   tienen por lo mismo. */
+create or replace view equipo_vista
+with (security_invoker = true) as
+select
+  p.*,
+  coalesce(h.horas, 0)     as horas_semana,
+  coalesce(h.dias, 0)      as dias_semana,
+  coalesce(s.servicios, 0) as servicios,
+  (p.perfil_id is not null) as tiene_cuenta
+from personal p
+left join (
+  select personal_id,
+         sum(extract(epoch from (hasta - desde)) / 3600)::numeric(6,2) as horas,
+         count(distinct dia)                                           as dias
+  from horarios where personal_id is not null and activo
+  group by personal_id
+) h on h.personal_id = p.id
+left join (
+  select personal_id, count(*) as servicios
+  from personal_servicios group by personal_id
+) s on s.personal_id = p.id;
+
+comment on view equipo_vista is 'Personal con sus horas semanales y cuántos servicios da, calculado en la base.';

--- a/supabase/migrations/0031_equipo_en_el_menu.sql
+++ b/supabase/migrations/0031_equipo_en_el_menu.sql
@@ -1,0 +1,81 @@
+/* ============================================================
+   0031 · EQUIPO ENTRA AL MENÚ
+   ============================================================
+
+   En servicios va adentro de "Clientes y equipo", que pasa a ser la
+   primera sección con dos módulos. Ahí es donde el menú de diez secciones
+   empieza a funcionar de verdad: la sección sigue siendo un renglón y los
+   dos módulos se eligen con pestañas arriba del contenido.
+
+   Se lista también en comercio y gastronomía. No aparece hasta que el
+   comercio lo contrate —un módulo no contratado no lo ve ni el dueño— pero
+   dejarlo listado significa que Super 25 puede contratarlo mañana sin una
+   migración.
+   ============================================================ */
+
+update rubros set menu = jsonb_set(
+  menu,
+  '{2,modulos}',
+  '[
+    {"k":"clientes","n":"Clientes","i":"gente","d":"Ficha, historial y turnos de cada cliente"},
+    {"k":"equipo","n":"Equipo","i":"equipo","d":"Quién trabaja, qué hace cada uno y cuándo está"}
+  ]'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 2 ->> 'clave' = 'gente';   /* si el orden cambió, no se toca nada */
+
+/* En los otros dos rubros va detrás de clientes, dentro del grupo único. */
+update rubros set menu = jsonb_set(
+  menu, '{0,modulos}',
+  (
+    select jsonb_agg(m order by orden)
+    from (
+      select m, orden from jsonb_array_elements(menu -> 0 -> 'modulos') with ordinality t(m, orden)
+      union all
+      select '{"k":"equipo","n":"Equipo","i":"equipo","d":"Quién trabaja, qué hace cada uno y cuándo está"}'::jsonb,
+             (select orden + 0.5 from jsonb_array_elements(menu -> 0 -> 'modulos') with ordinality u(m2, orden)
+               where m2 ->> 'k' = 'clientes')
+    ) x
+  )
+)
+where clave in ('minimercado', 'gastronomia')
+  and not exists (
+    select 1 from jsonb_array_elements(menu -> 0 -> 'modulos') m where m ->> 'k' = 'equipo'
+  );
+
+/* ------------------------------------------------------------
+   Almha sí lo contrata: es lo que va a alimentar la agenda.
+
+   Hay que tomar la identidad del dueño de plataforma para esto. El
+   disparador `proteger_lo_comercial` no deja cambiar plan, módulos ni
+   rubro salvo que sea Genez quien lo hace, y una migración corre sin
+   nadie autenticado detrás.
+
+   Que haya frenado a esta migración es exactamente lo que tiene que pasar:
+   la protección no distingue entre un comercio curioso y un script
+   apurado, y está bien que no lo haga.
+   ------------------------------------------------------------ */
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  if v_plataforma is null then
+    raise exception 'No hay ningún perfil de plataforma. Corré antes la semilla 0003.';
+  end if;
+
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['equipo']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  r.clave,
+  (select count(*) from jsonb_array_elements(r.menu) g, jsonb_array_elements(g -> 'modulos') m
+    where m ->> 'k' = 'equipo') as equipo_en_el_menu
+from rubros r order by r.orden;

--- a/supabase/migrations/0032_agenda.sql
+++ b/supabase/migrations/0032_agenda.sql
@@ -1,0 +1,452 @@
+/* ============================================================
+   0032 · LA AGENDA
+   ============================================================
+
+   Una reserva de mesa y un turno de pilates son la misma cosa: alguien
+   compromete un recurso durante un rato. Por eso esto extiende `reservas`
+   en vez de crear una tabla `turnos` al lado. Duplicarla habría hecho que
+   el salón y la agenda se separen y que después haya que arreglar cada
+   bug dos veces.
+
+   Lo que le falta a `reservas` para servir de agenda es saber **quién
+   atiende** y **qué servicio es**. En un restaurante ninguna de las dos
+   existe hasta que la gente se sienta; en una estética son la reserva.
+
+   CUIDADO CON EL ESTADO NUEVO
+   ---------------------------
+   Agregar `confirmada` toca gastronomía en dos lugares que filtran por
+   `pendiente` a secas. Los dos se corrigen acá:
+
+     · `salon_vista` dejaba de pintar la mesa de una reserva confirmada.
+     · `sentar_reserva` no dejaba sentar a alguien que había confirmado.
+
+   Las dos tablas estaban vacías al aplicar esto, así que no hubo datos en
+   riesgo. La corrección va igual, porque el problema no era el dato: era
+   que el modelo quedaba incoherente entre los dos rubros.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · Quién atiende y qué se hace
+   ------------------------------------------------------------ */
+
+alter table reservas add column personal_id uuid references personal(id) on delete set null;
+alter table reservas add column item_id     uuid references items(id)    on delete set null;
+
+create index on reservas (personal_id, desde) where personal_id is not null;
+create index on reservas (item_id) where item_id is not null;
+
+comment on column reservas.personal_id is 'Quién atiende. Null en gastronomía: a una mesa no la atiende alguien en particular.';
+comment on column reservas.item_id     is 'Qué servicio es. Null en gastronomía: lo que se consume se carga después, en la comanda.';
+
+/* ------------------------------------------------------------
+   2 · El estado nuevo
+
+   `pendiente` es "lo pedimos"; `confirmada` es "el cliente dijo que
+   viene". La diferencia importa para saber a quién hay que recordarle.
+   ------------------------------------------------------------ */
+
+alter table reservas drop constraint reservas_estado_valido;
+
+alter table reservas add constraint reservas_estado_valido check (
+  estado in ('pendiente', 'confirmada', 'sentada', 'cumplida', 'cancelada', 'ausente')
+);
+
+/* ------------------------------------------------------------
+   3 · Bloqueos por hora
+
+   `excepciones` guardaba fechas enteras, así que servía para unas
+   vacaciones y no para "el martes de 14 a 16 no atiendo". Con timestamp
+   entran las dos cosas y no hace falta una segunda tabla.
+
+   La tabla está vacía; el cambio de tipo no pierde nada.
+   ------------------------------------------------------------ */
+
+alter table excepciones alter column desde type timestamptz using desde::timestamptz;
+alter table excepciones alter column hasta type timestamptz using hasta::timestamptz;
+
+comment on column excepciones.desde is 'Con horas: sirve igual para unas vacaciones que para bloquear dos horas de un martes.';
+
+/* ------------------------------------------------------------
+   4 · El salón, con el estado nuevo contemplado
+
+   Se rehace la vista entera porque hay que cambiar una línea del lateral
+   de abajo, y una vista no se parchea. Es idéntica a la de 0024 salvo esa
+   condición.
+   ------------------------------------------------------------ */
+
+drop view salon_vista;
+
+create view salon_vista
+with (security_invoker = true) as
+select
+  r.id, r.empresa_id, r.sucursal_id, r.tipo, r.nombre,
+  r.piso, r.sector, r.capacidad, r.orden, r.activo,
+  r.x, r.y, r.ancho, r.alto, r.forma, r.unida_a,
+
+  coalesce(u.unidas, 0) as unidas,
+  r.capacidad + coalesce(u.capacidad_extra, 0) as capacidad_total,
+
+  o.id          as comanda_id,
+  o.abierta_en,
+  o.usuario_id  as abierta_por,
+  pf.nombre     as mozo,
+  o.comensales,
+  o.descuento,
+  o.descuento_pct,
+
+  coalesce(l.consumido, 0)  as consumido,
+  coalesce(l.items, 0)      as items,
+  coalesce(l.sin_enviar, 0) as sin_enviar,
+  coalesce(l.en_cocina, 0)  as en_cocina,
+  coalesce(l.listos, 0)     as listos,
+
+  coalesce(pg.pagado, 0) as pagado,
+
+  res.id       as reserva_id,
+  res.nombre   as reserva_nombre,
+  res.personas as reserva_personas,
+  res.desde    as reserva_desde,
+
+  case when o.abierta_en is null then null
+       else floor(extract(epoch from (now() - o.abierta_en)) / 60)::int
+  end as minutos,
+
+  case
+    when o.id is not null and coalesce(pg.pagado, 0) > 0
+         and coalesce(pg.pagado, 0) >= coalesce(l.consumido, 0) - coalesce(o.descuento, 0)
+      then 'cuenta'
+    when coalesce(l.listos, 0) > 0 then 'entregar'
+    when o.id is not null then 'ocupada'
+    when res.id is not null then 'reservada'
+    else 'libre'
+  end as estado
+
+from recursos r
+
+left join (
+  select unida_a, count(*) as unidas, sum(capacidad) as capacidad_extra
+  from recursos where unida_a is not null group by unida_a
+) u on u.unida_a = r.id
+
+left join operaciones o
+  on o.recurso_id = r.id and o.estado = 'abierta' and o.tipo = 'comanda'
+
+left join perfiles pf on pf.id = o.usuario_id
+
+left join (
+  select
+    operacion_id,
+    sum(total)                                                 as consumido,
+    sum(cantidad)                                              as items,
+    count(*) filter (where estado = 'borrador')                as sin_enviar,
+    count(*) filter (where estado in ('pedido', 'preparando')) as en_cocina,
+    count(*) filter (where estado = 'listo')                   as listos
+  from operacion_lineas
+  where estado <> 'anulada'
+  group by operacion_id
+) l on l.operacion_id = o.id
+
+left join (
+  select operacion_id, sum(monto) as pagado from pagos group by operacion_id
+) pg on pg.operacion_id = o.id
+
+/* La reserva que está por caer: la más próxima que todavía no venció.
+   Media hora antes ya pinta la mesa, porque a esa altura no conviene
+   sentar a nadie más.
+
+   ACÁ ESTÁ EL CAMBIO: antes decía `estado = 'pendiente'` y con eso una
+   reserva confirmada dejaba la mesa figurando libre. */
+left join lateral (
+  select re.id, re.nombre, re.personas, re.desde
+  from reservas re
+  where re.recurso_id = r.id
+    and re.estado in ('pendiente', 'confirmada')
+    and now() >= re.desde - interval '30 minutes'
+    and now() <  re.desde + make_interval(mins => re.duracion_min)
+  order by re.desde
+  limit 1
+) res on true;
+
+comment on view salon_vista is
+  'Cada mesa con su lugar en el plano, su comanda, su reserva y su estado ya resuelto. El estado sale de acá y no de la pantalla: el mapa, la lista y el recuento tienen que decir lo mismo.';
+
+/* ------------------------------------------------------------
+   5 · Sentar una reserva confirmada
+
+   Mismo cambio: antes exigía `pendiente` exacto.
+   ------------------------------------------------------------ */
+
+create or replace function sentar_reserva(p_reserva uuid)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_res reservas%rowtype;
+  v_comanda uuid;
+begin
+  select * into v_res from reservas where id = p_reserva for update;
+
+  if v_res.id is null then
+    raise exception 'No existe esa reserva.' using errcode = 'P0010';
+  end if;
+  if v_res.estado not in ('pendiente', 'confirmada') then
+    raise exception 'Esa reserva ya no está pendiente.' using errcode = 'P0015';
+  end if;
+  if v_res.recurso_id is null then
+    raise exception 'Esa reserva no tiene mesa asignada.' using errcode = 'P0016';
+  end if;
+
+  v_comanda := abrir_comanda(jsonb_build_object(
+    'empresa_id',  v_res.empresa_id,
+    'sucursal_id', v_res.sucursal_id,
+    'recurso_id',  v_res.recurso_id,
+    'cliente_id',  v_res.cliente_id
+  ));
+
+  update operaciones
+     set comensales = coalesce(comensales, v_res.personas)
+   where id = v_comanda;
+
+  update reservas
+     set estado = 'sentada', operacion_id = v_comanda
+   where id = p_reserva;
+
+  return v_comanda;
+end;
+$$;
+
+/* ------------------------------------------------------------
+   6 · Los choques
+
+   La validación vive en la base y no en la pantalla. La pantalla puede
+   anticipar el conflicto para avisar antes, pero dos personas agendando
+   al mismo tiempo desde dos dispositivos solo se resuelven acá.
+
+   La zona horaria sale de la configuración del comercio. Un horario
+   —"martes de 8 a 13"— es hora de pared, y `desde` es un instante
+   absoluto: sin convertir, un turno de las 9 de Buenos Aires se compara
+   contra las 12 UTC y queda siempre fuera de horario.
+   ------------------------------------------------------------ */
+
+create or replace function zona_de(p_empresa uuid)
+returns text
+language sql stable
+as $$
+  select coalesce(nullif(config ->> 'zona', ''), 'America/Argentina/Buenos_Aires')
+  from empresas where id = p_empresa;
+$$;
+
+comment on function zona_de is 'Zona horaria del comercio. Sin ella, comparar un turno contra un horario semanal da cualquier cosa.';
+
+create or replace function revisar_turno(
+  p_id       uuid,
+  p_empresa  uuid,
+  p_desde    timestamptz,
+  p_duracion integer,
+  p_personal uuid,
+  p_recurso  uuid
+)
+returns void
+language plpgsql
+as $$
+declare
+  v_hasta timestamptz := p_desde + make_interval(mins => p_duracion);
+  v_zona  text := zona_de(p_empresa);
+  v_local timestamp := p_desde at time zone v_zona;
+  v_localh timestamp := v_hasta at time zone v_zona;
+begin
+  if p_duracion <= 0 then
+    raise exception 'El turno tiene que durar algo.' using errcode = 'P0030';
+  end if;
+
+  /* Un turno que cruza la medianoche no se puede comparar contra un
+     horario semanal, que es de un solo día. No es un caso real en un
+     negocio de turnos, pero si llega hay que decirlo y no calcular mal. */
+  if v_local::date <> v_localh::date then
+    raise exception 'Un turno no puede cruzar la medianoche.' using errcode = 'P0031';
+  end if;
+
+  /* Que la sala y la persona sean de este comercio. Sin esto, alguien con
+     el id de una sala ajena podría agendar adentro de otro negocio. */
+  if p_recurso is not null and not exists (
+    select 1 from recursos where id = p_recurso and empresa_id = p_empresa
+  ) then
+    raise exception 'Esa sala no es de este comercio.' using errcode = 'P0032';
+  end if;
+
+  if p_personal is not null and not exists (
+    select 1 from personal where id = p_personal and empresa_id = p_empresa
+  ) then
+    raise exception 'Esa persona no es de este comercio.' using errcode = 'P0033';
+  end if;
+
+  /* Choque de sala. Una cancelada o una ausencia liberan el lugar. */
+  if p_recurso is not null and exists (
+    select 1 from reservas r
+    where r.recurso_id = p_recurso
+      and (p_id is null or r.id <> p_id)
+      and r.estado not in ('cancelada', 'ausente')
+      and r.desde < v_hasta
+      and r.desde + make_interval(mins => r.duracion_min) > p_desde
+  ) then
+    raise exception 'Esa sala ya está ocupada en ese horario.' using errcode = 'P0034';
+  end if;
+
+  /* Choque de persona. */
+  if p_personal is not null and exists (
+    select 1 from reservas r
+    where r.personal_id = p_personal
+      and (p_id is null or r.id <> p_id)
+      and r.estado not in ('cancelada', 'ausente')
+      and r.desde < v_hasta
+      and r.desde + make_interval(mins => r.duracion_min) > p_desde
+  ) then
+    raise exception 'Esa persona ya tiene un turno en ese horario.' using errcode = 'P0035';
+  end if;
+
+  /* Fuera del horario de trabajo. Solo se controla si la persona tiene
+     horarios cargados: si no tiene ninguno, todavía nadie los cargó y
+     frenar el turno por eso sería castigar al que está trabajando. */
+  if p_personal is not null
+     and exists (select 1 from horarios where personal_id = p_personal and activo)
+     and not exists (
+       select 1 from horarios h
+       where h.personal_id = p_personal and h.activo
+         and h.dia = extract(dow from v_local)::int
+         and h.desde <= v_local::time
+         and h.hasta >= v_localh::time
+     ) then
+    raise exception 'Esa persona no trabaja en ese horario.' using errcode = 'P0036';
+  end if;
+
+  /* Ausencias, vacaciones y bloqueos. Con personal_id en null el bloqueo
+     es de todo el comercio: un feriado. */
+  if exists (
+    select 1 from excepciones e
+    where e.empresa_id = p_empresa
+      and (e.personal_id is null or e.personal_id = p_personal)
+      and e.desde < v_hasta and e.hasta > p_desde
+  ) then
+    raise exception 'Hay un bloqueo o una ausencia en ese horario.' using errcode = 'P0037';
+  end if;
+end;
+$$;
+
+comment on function revisar_turno is 'Todo lo que puede impedir un turno, en un solo lugar. Lo usan el alta y la reprogramación.';
+
+/* ------------------------------------------------------------
+   7 · Agendar y reprogramar
+
+   Van como funciones y no como inserts sueltos por la regla 5: validar en
+   el navegador y escribir después deja la ventana en la que otro agendó
+   lo mismo entre las dos cosas.
+   ------------------------------------------------------------ */
+
+create or replace function agendar_turno(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_emp      uuid := (p ->> 'empresa_id')::uuid;
+  v_desde    timestamptz := (p ->> 'desde')::timestamptz;
+  v_duracion integer := coalesce((p ->> 'duracion_min')::integer, 60);
+  v_personal uuid := nullif(p ->> 'personal_id', '')::uuid;
+  v_recurso  uuid := nullif(p ->> 'recurso_id', '')::uuid;
+  v_id       uuid;
+begin
+  if not public.puede_ver(v_emp) then
+    raise exception 'No podés agendar en ese comercio.' using errcode = 'P0038';
+  end if;
+
+  perform revisar_turno(null, v_emp, v_desde, v_duracion, v_personal, v_recurso);
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, cliente_id, personal_id, item_id,
+    nombre, telefono, personas, desde, duracion_min, estado, notas, usuario_id
+  ) values (
+    v_emp,
+    nullif(p ->> 'sucursal_id', '')::uuid,
+    v_recurso,
+    nullif(p ->> 'cliente_id', '')::uuid,
+    v_personal,
+    nullif(p ->> 'item_id', '')::uuid,
+    coalesce(nullif(p ->> 'nombre', ''), 'Sin nombre'),
+    nullif(p ->> 'telefono', ''),
+    coalesce((p ->> 'personas')::integer, 1),
+    v_desde,
+    v_duracion,
+    coalesce(nullif(p ->> 'estado', ''), 'pendiente'),
+    nullif(p ->> 'notas', ''),
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function agendar_turno is 'Crea un turno validando choques de sala, de persona y de horario en la misma transacción.';
+
+create or replace function mover_turno(p_id uuid, p_desde timestamptz, p_duracion integer default null)
+returns void
+language plpgsql
+as $$
+declare
+  v_res reservas%rowtype;
+  v_dur integer;
+begin
+  select * into v_res from reservas where id = p_id for update;
+  if v_res.id is null then
+    raise exception 'No existe ese turno.' using errcode = 'P0010';
+  end if;
+  if v_res.estado in ('cumplida', 'cancelada') then
+    raise exception 'Un turno cumplido o cancelado no se reprograma.' using errcode = 'P0039';
+  end if;
+
+  v_dur := coalesce(p_duracion, v_res.duracion_min);
+  perform revisar_turno(p_id, v_res.empresa_id, p_desde, v_dur, v_res.personal_id, v_res.recurso_id);
+
+  update reservas set desde = p_desde, duracion_min = v_dur where id = p_id;
+end;
+$$;
+
+comment on function mover_turno is 'Reprograma un turno con las mismas validaciones que el alta, ignorándose a sí mismo.';
+
+/* ------------------------------------------------------------
+   8 · La agenda, con los nombres ya resueltos
+
+   `security_invoker` no es opcional: sin eso la vista corre con los
+   permisos de quien la creó y saltea RLS. Ya nos pasó con `equipo_vista`.
+   ------------------------------------------------------------ */
+
+create or replace view agenda_vista
+with (security_invoker = true) as
+select
+  r.id, r.empresa_id, r.sucursal_id, r.recurso_id, r.cliente_id,
+  r.personal_id, r.item_id,
+  r.nombre, r.telefono, r.personas, r.desde, r.duracion_min,
+  r.desde + make_interval(mins => r.duracion_min) as hasta,
+  r.estado, r.notas, r.operacion_id, r.creada_en,
+
+  c.razon_social as cliente,
+  p.nombre       as profesional,
+  p.especialidad,
+  i.nombre       as servicio,
+  i.categoria    as area,
+  i.precio,
+  re.nombre      as sala,
+  re.tipo        as sala_tipo,
+
+  /* Lo cobrado del turno, si se cobró. Sale de los pagos de la operación
+     y no de una columna: un saldo guardado se desincroniza. */
+  coalesce(pg.pagado, 0) as pagado
+from reservas r
+left join clientes  c  on c.id  = r.cliente_id
+left join personal  p  on p.id  = r.personal_id
+left join items     i  on i.id  = r.item_id
+left join recursos  re on re.id = r.recurso_id
+left join (
+  select operacion_id, sum(monto) as pagado from pagos group by operacion_id
+) pg on pg.operacion_id = r.operacion_id;
+
+comment on view agenda_vista is 'Un turno con su cliente, su profesional, su servicio y su sala ya resueltos, para no pedir cinco consultas por pantalla.';

--- a/supabase/migrations/0033_agenda_en_el_menu.sql
+++ b/supabase/migrations/0033_agenda_en_el_menu.sql
@@ -1,0 +1,50 @@
+/* ============================================================
+   0033 · LA AGENDA DEJA DE ESTAR APAGADA
+   ============================================================
+
+   La sección Agenda estaba declarada como `proximo` desde la 0028: se
+   dibujaba en gris para que se viera a dónde iba el sistema, sin fingir
+   que andaba. Ahora tiene pantalla y backend, así que se enciende.
+
+   Las clases grupales, la lista de espera y la vista de mes siguen
+   apagadas adentro de la pantalla, con el mismo criterio.
+   ============================================================ */
+
+update rubros set menu = jsonb_set(
+  menu, '{1}',
+  '{
+    "clave":"agenda", "nombre":"Agenda", "i":"agenda",
+    "modulos":[
+      {"k":"agenda","n":"Agenda","i":"agenda","d":"Turnos del día, quién los da y en qué sala"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 1 ->> 'clave' = 'agenda';   /* si el orden cambió, no toca nada */
+
+/* Almha la contrata. Igual que en la 0031, hay que tomar la identidad de
+   plataforma: `proteger_lo_comercial` no deja que un script sin nadie
+   detrás cambie los módulos de un comercio. */
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['agenda']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  g ->> 'clave' as seccion,
+  coalesce(g ->> 'nombre', '(sin rótulo)') as rotulo,
+  jsonb_array_length(g -> 'modulos') as modulos,
+  coalesce(g ->> 'proximo', 'false') as proximo
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios'
+order by x.orden;

--- a/supabase/migrations/0034_clases_y_espera.sql
+++ b/supabase/migrations/0034_clases_y_espera.sql
@@ -1,0 +1,400 @@
+/* ============================================================
+   0034 · CLASES GRUPALES Y LISTA DE ESPERA
+   ============================================================
+
+   Una clase de reformer compromete la sala y a la profesora durante una
+   hora, igual que un turno individual. La diferencia es que adentro entran
+   seis personas en vez de una. Así que sigue siendo una `reserva` y no una
+   tabla nueva: el mismo argumento por el que un turno no fue una tabla
+   aparte de una reserva de mesa.
+
+   TRES FORMAS EN UNA TABLA
+   ------------------------
+   Una fila de `reservas` puede ser una de estas tres, y una restricción se
+   encarga de que nunca sea dos a la vez:
+
+     · TURNO INDIVIDUAL   cupo null, clase_id null
+     · CLASE              cupo >= 1, clase_id null, sin cliente
+     · INSCRIPCIÓN        clase_id apunta a la clase, cupo null
+
+   Que una clase exista con cero inscriptos no es un caso raro: es lo
+   normal. El horario se publica antes de que nadie se anote, y por eso la
+   clase no puede ser "las inscripciones que hay".
+
+   QUIÉN OCUPA LA SALA
+   -------------------
+   Solo la clase. Las inscripciones no ocupan nada: si ocuparan, seis
+   personas anotadas al mismo reformer se leerían como seis choques y no
+   se podría anotar a la segunda. Es el cambio más importante de esta
+   migración y va adentro de `revisar_turno`.
+   ============================================================ */
+
+alter table reservas add column cupo     integer;
+alter table reservas add column clase_id uuid references reservas(id) on delete cascade;
+
+create index on reservas (clase_id) where clase_id is not null;
+
+alter table reservas add constraint reservas_forma_valida check (
+  not (cupo is not null and clase_id is not null)
+);
+
+alter table reservas add constraint reservas_cupo_valido check (
+  cupo is null or cupo >= 1
+);
+
+/* `personas > 0` se escribió cuando toda reserva era una mesa con
+   comensales, y ahí tenía razón: una mesa para cero no es una reserva.
+   Una clase sí arranca en cero —la gente la traen las inscripciones— así
+   que la regla se afina en vez de aflojarse: cero solo lo puede tener una
+   clase. Un turno y una inscripción siguen necesitando al menos uno. */
+alter table reservas drop constraint reservas_personas_valido;
+
+alter table reservas add constraint reservas_personas_valido check (
+  personas > 0 or cupo is not null
+);
+
+comment on column reservas.cupo     is 'Lugares de una clase grupal. Null en un turno individual y en una inscripción.';
+comment on column reservas.clase_id is 'La clase a la que esta persona se anotó. Null en la clase misma y en un turno individual.';
+
+/* ------------------------------------------------------------
+   Los choques, corregidos
+
+   Igual que la versión de la 0032 salvo una línea: las inscripciones no
+   ocupan. Sin eso, anotar a la segunda persona en una clase de seis daba
+   "esa sala ya está ocupada".
+   ------------------------------------------------------------ */
+
+create or replace function revisar_turno(
+  p_id       uuid,
+  p_empresa  uuid,
+  p_desde    timestamptz,
+  p_duracion integer,
+  p_personal uuid,
+  p_recurso  uuid
+)
+returns void
+language plpgsql
+as $$
+declare
+  v_hasta timestamptz := p_desde + make_interval(mins => p_duracion);
+  v_zona  text := zona_de(p_empresa);
+  v_local timestamp := p_desde at time zone v_zona;
+  v_localh timestamp := v_hasta at time zone v_zona;
+begin
+  if p_duracion <= 0 then
+    raise exception 'El turno tiene que durar algo.' using errcode = 'P0030';
+  end if;
+
+  if v_local::date <> v_localh::date then
+    raise exception 'Un turno no puede cruzar la medianoche.' using errcode = 'P0031';
+  end if;
+
+  if p_recurso is not null and not exists (
+    select 1 from recursos where id = p_recurso and empresa_id = p_empresa
+  ) then
+    raise exception 'Esa sala no es de este comercio.' using errcode = 'P0032';
+  end if;
+
+  if p_personal is not null and not exists (
+    select 1 from personal where id = p_personal and empresa_id = p_empresa
+  ) then
+    raise exception 'Esa persona no es de este comercio.' using errcode = 'P0033';
+  end if;
+
+  /* Solo miran las filas que ocupan de verdad: turnos individuales y
+     clases. Las inscripciones viven adentro de una clase que ya reservó
+     el lugar por todas. */
+  if p_recurso is not null and exists (
+    select 1 from reservas r
+    where r.recurso_id = p_recurso
+      and r.clase_id is null
+      and (p_id is null or r.id <> p_id)
+      and r.estado not in ('cancelada', 'ausente')
+      and r.desde < v_hasta
+      and r.desde + make_interval(mins => r.duracion_min) > p_desde
+  ) then
+    raise exception 'Esa sala ya está ocupada en ese horario.' using errcode = 'P0034';
+  end if;
+
+  if p_personal is not null and exists (
+    select 1 from reservas r
+    where r.personal_id = p_personal
+      and r.clase_id is null
+      and (p_id is null or r.id <> p_id)
+      and r.estado not in ('cancelada', 'ausente')
+      and r.desde < v_hasta
+      and r.desde + make_interval(mins => r.duracion_min) > p_desde
+  ) then
+    raise exception 'Esa persona ya tiene un turno en ese horario.' using errcode = 'P0035';
+  end if;
+
+  if p_personal is not null
+     and exists (select 1 from horarios where personal_id = p_personal and activo)
+     and not exists (
+       select 1 from horarios h
+       where h.personal_id = p_personal and h.activo
+         and h.dia = extract(dow from v_local)::int
+         and h.desde <= v_local::time
+         and h.hasta >= v_localh::time
+     ) then
+    raise exception 'Esa persona no trabaja en ese horario.' using errcode = 'P0036';
+  end if;
+
+  if exists (
+    select 1 from excepciones e
+    where e.empresa_id = p_empresa
+      and (e.personal_id is null or e.personal_id = p_personal)
+      and e.desde < v_hasta and e.hasta > p_desde
+  ) then
+    raise exception 'Hay un bloqueo o una ausencia en ese horario.' using errcode = 'P0037';
+  end if;
+end;
+$$;
+
+/* ------------------------------------------------------------
+   Abrir una clase
+   ------------------------------------------------------------ */
+
+create or replace function crear_clase(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_emp      uuid := (p ->> 'empresa_id')::uuid;
+  v_desde    timestamptz := (p ->> 'desde')::timestamptz;
+  v_duracion integer := coalesce((p ->> 'duracion_min')::integer, 60);
+  v_personal uuid := nullif(p ->> 'personal_id', '')::uuid;
+  v_recurso  uuid := nullif(p ->> 'recurso_id', '')::uuid;
+  v_item     uuid := nullif(p ->> 'item_id', '')::uuid;
+  v_cupo     integer := coalesce((p ->> 'cupo')::integer, 1);
+  v_cap      integer;
+  v_id       uuid;
+begin
+  if not public.puede_ver(v_emp) then
+    raise exception 'No podés agendar en ese comercio.' using errcode = 'P0038';
+  end if;
+
+  if v_cupo < 1 then
+    raise exception 'Una clase necesita al menos un lugar.' using errcode = 'P0040';
+  end if;
+
+  /* El cupo no puede pasarse de lo que entra en la sala. La capacidad de
+     la sala es un dato físico; el cupo de la clase es una decisión, y
+     puede ser menor —una clase de principiantes con menos gente— pero
+     nunca mayor. */
+  if v_recurso is not null then
+    select capacidad into v_cap from recursos where id = v_recurso;
+    if v_cap is not null and v_cupo > v_cap then
+      raise exception 'En esa sala entran % personas.', v_cap using errcode = 'P0041';
+    end if;
+  end if;
+
+  perform revisar_turno(null, v_emp, v_desde, v_duracion, v_personal, v_recurso);
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, personal_id, item_id,
+    nombre, personas, desde, duracion_min, estado, notas, cupo, usuario_id
+  ) values (
+    v_emp,
+    nullif(p ->> 'sucursal_id', '')::uuid,
+    v_recurso, v_personal, v_item,
+    coalesce(nullif(p ->> 'nombre', ''), 'Clase'),
+    0,                                   -- la clase no trae gente; la traen las inscripciones
+    v_desde, v_duracion,
+    coalesce(nullif(p ->> 'estado', ''), 'confirmada'),
+    nullif(p ->> 'notas', ''),
+    v_cupo,
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function crear_clase is 'Abre una clase grupal. Existe aunque no se anote nadie: el horario se publica antes.';
+
+/* ------------------------------------------------------------
+   Anotarse
+
+   El cupo se cuenta y se compara adentro de la misma transacción, con la
+   clase bloqueada. Contarlo en el navegador y escribir después es cómo se
+   meten siete personas en una clase de seis.
+   ------------------------------------------------------------ */
+
+create or replace function inscribir(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_clase   reservas%rowtype;
+  v_tomados integer;
+  v_cliente uuid := nullif(p ->> 'cliente_id', '')::uuid;
+  v_id      uuid;
+begin
+  select * into v_clase from reservas where id = (p ->> 'clase_id')::uuid for update;
+
+  if v_clase.id is null then
+    raise exception 'No existe esa clase.' using errcode = 'P0042';
+  end if;
+  if v_clase.cupo is null then
+    raise exception 'Eso no es una clase: no tiene cupo.' using errcode = 'P0043';
+  end if;
+  if not public.puede_ver(v_clase.empresa_id) then
+    raise exception 'No podés anotar en ese comercio.' using errcode = 'P0038';
+  end if;
+  if v_clase.estado = 'cancelada' then
+    raise exception 'Esa clase está cancelada.' using errcode = 'P0044';
+  end if;
+
+  select count(*) into v_tomados
+    from reservas
+   where clase_id = v_clase.id and estado not in ('cancelada', 'ausente');
+
+  if v_tomados >= v_clase.cupo then
+    raise exception 'Esa clase ya está completa.' using errcode = 'P0045';
+  end if;
+
+  /* Dos veces la misma persona en la misma clase es siempre un error de
+     dedo, y ocupa un lugar que alguien más necesitaba. */
+  if v_cliente is not null and exists (
+    select 1 from reservas
+     where clase_id = v_clase.id and cliente_id = v_cliente
+       and estado not in ('cancelada', 'ausente')
+  ) then
+    raise exception 'Esa persona ya está anotada en esta clase.' using errcode = 'P0046';
+  end if;
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, personal_id, item_id, clase_id,
+    cliente_id, nombre, telefono, personas, desde, duracion_min, estado, notas, usuario_id
+  ) values (
+    v_clase.empresa_id, v_clase.sucursal_id, v_clase.recurso_id,
+    v_clase.personal_id, v_clase.item_id, v_clase.id,
+    v_cliente,
+    coalesce(nullif(p ->> 'nombre', ''), 'Sin nombre'),
+    nullif(p ->> 'telefono', ''),
+    1,
+    v_clase.desde, v_clase.duracion_min,
+    coalesce(nullif(p ->> 'estado', ''), 'confirmada'),
+    nullif(p ->> 'notas', ''),
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function inscribir is 'Anota a alguien en una clase controlando el cupo con la clase bloqueada, para que dos personas no entren en el mismo último lugar.';
+
+/* ------------------------------------------------------------
+   La lista de espera
+
+   Va en tabla propia y no como un estado más de la reserva: alguien en
+   lista de espera no tiene lugar, y una reserva sin lugar no es una
+   reserva. Además una misma persona puede estar esperando dos horarios
+   distintos, y eso como reserva serían dos turnos que no existen.
+   ------------------------------------------------------------ */
+
+create table espera (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  clase_id    uuid not null references reservas(id) on delete cascade,
+  cliente_id  uuid references clientes(id) on delete set null,
+
+  nombre      text not null,
+  telefono    text,
+  notas       text,
+
+  estado      text not null default 'esperando',
+  orden       integer not null default 0,
+  creada_en   timestamptz not null default now(),
+  usuario_id  uuid references perfiles(id) on delete set null,
+
+  constraint espera_estado_valido check (estado in ('esperando', 'avisado', 'entro', 'baja'))
+);
+
+create index on espera (empresa_id, clase_id, orden);
+
+alter table espera enable row level security;
+
+create policy espera_todo on espera
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+comment on table espera is
+  'Quién quiere entrar a una clase llena, y en qué orden. No se promueve solo: liberar un lugar y meter a alguien sin avisarle es peor que el problema.';
+
+/* ------------------------------------------------------------
+   La agenda, con el cupo resuelto
+   ------------------------------------------------------------ */
+
+/* Se tira y se rehace en vez de reemplazarse: `create or replace view` no
+   admite meter columnas en el medio, y `clase_id` y `cupo` van al lado de
+   las otras del turno y no colgando al final. Nadie más depende de esta
+   vista, así que tirarla no arrastra nada. */
+drop view if exists agenda_vista;
+
+create view agenda_vista
+with (security_invoker = true) as
+select
+  r.id, r.empresa_id, r.sucursal_id, r.recurso_id, r.cliente_id,
+  r.personal_id, r.item_id, r.clase_id, r.cupo,
+  r.nombre, r.telefono, r.personas, r.desde, r.duracion_min,
+  r.desde + make_interval(mins => r.duracion_min) as hasta,
+  r.estado, r.notas, r.operacion_id, r.creada_en,
+
+  /* Qué es esta fila, resuelto acá y no en la pantalla. */
+  case when r.clase_id is not null then 'inscripcion'
+       when r.cupo is not null     then 'clase'
+       else 'turno'
+  end as forma,
+
+  coalesce(ins.tomados, 0) as anotados,
+  case when r.cupo is null then null else r.cupo - coalesce(ins.tomados, 0) end as lugares,
+  coalesce(esp.esperando, 0) as esperando,
+
+  c.razon_social as cliente,
+  p.nombre       as profesional,
+  p.especialidad,
+  i.nombre       as servicio,
+  i.categoria    as area,
+  i.precio,
+  re.nombre      as sala,
+  re.tipo        as sala_tipo,
+
+  coalesce(pg.pagado, 0) as pagado
+from reservas r
+left join clientes  c  on c.id  = r.cliente_id
+left join personal  p  on p.id  = r.personal_id
+left join items     i  on i.id  = r.item_id
+left join recursos  re on re.id = r.recurso_id
+left join (
+  select clase_id, count(*) as tomados
+  from reservas where clase_id is not null and estado not in ('cancelada', 'ausente')
+  group by clase_id
+) ins on ins.clase_id = r.id
+left join (
+  select clase_id, count(*) as esperando
+  from espera where estado = 'esperando'
+  group by clase_id
+) esp on esp.clase_id = r.id
+left join (
+  select operacion_id, sum(monto) as pagado from pagos group by operacion_id
+) pg on pg.operacion_id = r.operacion_id;
+
+comment on view agenda_vista is
+  'Turnos, clases e inscripciones con sus nombres resueltos. `forma` dice cuál de las tres es cada fila, y el cupo ya viene contado.';
+
+/* La lista de espera también viaja en tiempo real: si recepción anota a
+   alguien, el profesor lo ve sin refrescar. */
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'espera'
+  ) then
+    alter publication supabase_realtime add table public.espera;
+  end if;
+end;
+$$;

--- a/supabase/migrations/0035_abonos.sql
+++ b/supabase/migrations/0035_abonos.sql
@@ -1,0 +1,479 @@
+/* ============================================================
+   0035 · ABONOS, PACKS Y CUOTAS
+   ============================================================
+
+   Un estudio de pilates cobra ocho clases en marzo y las consume hasta
+   mayo. Sin esto la caja no puede reflejar la realidad del negocio: un
+   martes sin cobrar un peso puede ser el mejor martes del mes.
+
+   LOS PLANES SON ITEMS
+   --------------------
+   "Pack 8 clases" y "Plan 2 por semana" son items del catálogo, con
+   `tipo = 'plan'`. Así se venden por el mismo camino que todo lo demás
+   —`registrar_venta`, que ya escribe la operación, las líneas, los pagos
+   y el movimiento de caja— y entran en los informes sin nada nuevo.
+
+   EL CRÉDITO NO SE GUARDA, SE DERIVA
+   ----------------------------------
+   `usadas` no es una columna. Se cuenta desde los turnos que apuntan al
+   abono, igual que el stock se deriva de sus movimientos (regla 1). Un
+   contador guardado se desincroniza el día que alguien cancela un turno
+   por SQL, y nadie se entera hasta que un cliente reclama.
+
+   EL CONSUMO ES AL RESERVAR, NO AL ASISTIR
+   ----------------------------------------
+   Es lo que hace que "dos por semana" se pueda hacer cumplir: si el
+   crédito se descontara recién al venir, el tope no se puede controlar en
+   el momento en que importa, que es cuando la persona pide el turno.
+
+   Una cancelación devuelve la clase. Una ausencia la devuelve o no según
+   lo decida cada comercio: hay negocios donde faltar es perderla y otros
+   donde se recupera.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · El catálogo admite planes
+   ------------------------------------------------------------ */
+
+alter table items drop constraint items_tipo_valido;
+
+alter table items add constraint items_tipo_valido check (
+  tipo in ('producto', 'servicio', 'insumo', 'combo', 'plan')
+);
+
+comment on column items.tipo is
+  'Un corte de pelo, una Coca y un pack de 8 clases son la misma entidad: cambia si lleva stock, si tiene duración y si da crédito.';
+
+/* ------------------------------------------------------------
+   2 · Los abonos
+
+   `clases` en null es un plan libre: se paga el mes y se viene cuando se
+   quiere. El tope semanal es lo que lo hace distinto de un pack.
+   ------------------------------------------------------------ */
+
+create table abonos (
+  id           uuid primary key default gen_random_uuid(),
+  empresa_id   uuid not null references empresas(id) on delete cascade,
+  cliente_id   uuid not null references clientes(id) on delete cascade,
+  item_id      uuid references items(id) on delete set null,
+  operacion_id uuid references operaciones(id) on delete set null,
+
+  nombre       text not null,
+  clases       integer,
+  tope_semanal integer,
+
+  desde        date not null default current_date,
+  vence        date,
+
+  anulado      boolean not null default false,
+  notas        text,
+  creado_en    timestamptz not null default now(),
+  usuario_id   uuid references perfiles(id) on delete set null,
+
+  constraint abonos_clases_valido check (clases is null or clases > 0),
+  constraint abonos_tope_valido   check (tope_semanal is null or tope_semanal > 0),
+  constraint abonos_vigencia      check (vence is null or vence >= desde)
+);
+
+create index on abonos (empresa_id, cliente_id) where not anulado;
+create index on abonos (empresa_id, vence);
+
+comment on column abonos.clases       is 'Cuántas clases da. Null es libre: se controla con el tope semanal y la vigencia.';
+comment on column abonos.tope_semanal is 'Cuántas veces por semana se puede reservar. Null es sin tope.';
+comment on column abonos.anulado      is 'No se borra: puede tener turnos tomados atrás y borrarlo los dejaría sin crédito de dónde salieron.';
+
+/* El turno sabe contra qué abono se tomó. Null es un turno suelto, que se
+   paga aparte. */
+alter table reservas add column abono_id uuid references abonos(id) on delete set null;
+create index on reservas (abono_id) where abono_id is not null;
+
+alter table abonos enable row level security;
+
+create policy abonos_todo on abonos
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+/* ------------------------------------------------------------
+   3 · La política de ausencias
+
+   Cada comercio decide si faltar cuesta la clase. Va en la configuración
+   del comercio y no en el código: hay estudios que la perdonan y
+   gimnasios que no.
+   ------------------------------------------------------------ */
+
+create or replace function ausencia_consume(p_empresa uuid)
+returns boolean
+language sql stable
+as $$
+  select coalesce((config -> 'turnos' ->> 'ausenciaConsume')::boolean, true)
+  from empresas where id = p_empresa;
+$$;
+
+comment on function ausencia_consume is 'Si faltar a un turno gasta la clase del abono. Por defecto sí; se cambia por comercio.';
+
+/* ------------------------------------------------------------
+   4 · El abono, con su saldo ya contado
+
+   Lo que gasta el crédito son los turnos que apuntan al abono. Una
+   cancelación siempre lo devuelve; una ausencia, según el comercio.
+   ------------------------------------------------------------ */
+
+create or replace view abonos_vista
+with (security_invoker = true) as
+select
+  a.*,
+  c.razon_social as cliente,
+  i.categoria    as area,
+  coalesce(u.usadas, 0) as usadas,
+  case when a.clases is null then null else a.clases - coalesce(u.usadas, 0) end as restantes,
+  (a.vence is not null and a.vence < current_date) as vencido,
+  case
+    when a.anulado then 'anulado'
+    when a.vence is not null and a.vence < current_date then 'vencido'
+    when a.clases is not null and coalesce(u.usadas, 0) >= a.clases then 'consumido'
+    else 'activo'
+  end as estado
+from abonos a
+left join clientes c on c.id = a.cliente_id
+left join items    i on i.id = a.item_id
+left join lateral (
+  select count(*) as usadas
+  from reservas r
+  where r.abono_id = a.id
+    and r.estado <> 'cancelada'
+    and (r.estado <> 'ausente' or ausencia_consume(a.empresa_id))
+) u on true;
+
+comment on view abonos_vista is
+  'El abono con su saldo contado desde los turnos que lo usaron. No hay columna `usadas`: un contador guardado se desincroniza y nadie se entera hasta que un cliente reclama.';
+
+/* ------------------------------------------------------------
+   5 · Vender un abono
+
+   Se apoya en `registrar_venta`, que ya escribe la operación, la línea,
+   los pagos, el movimiento de caja y es idempotente. Acá arriba solo se
+   crea el crédito.
+   ------------------------------------------------------------ */
+
+create or replace function vender_abono(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_emp     uuid := (p ->> 'empresa_id')::uuid;
+  v_cliente uuid := (p ->> 'cliente_id')::uuid;
+  v_item    uuid := nullif(p ->> 'item_id', '')::uuid;
+  v_op      uuid := coalesce(nullif(p ->> 'operacion_id', '')::uuid, gen_random_uuid());
+  v_precio  numeric := coalesce((p ->> 'precio')::numeric, 0);
+  v_nombre  text;
+  v_clases  integer;
+  v_tope    integer;
+  v_dias    integer;
+  v_extra   jsonb;
+  v_id      uuid;
+begin
+  if not public.puede_ver(v_emp) then
+    raise exception 'No podés vender en ese comercio.' using errcode = 'P0038';
+  end if;
+  if v_cliente is null then
+    raise exception 'Un abono necesita un cliente: es de alguien.' using errcode = 'P0050';
+  end if;
+  if not exists (select 1 from clientes where id = v_cliente and empresa_id = v_emp) then
+    raise exception 'Ese cliente no es de este comercio.' using errcode = 'P0051';
+  end if;
+
+  /* Los términos salen del plan del catálogo, no de lo que mande la
+     pantalla: si el comercio cambia el pack de 8 a 10, los que se venden
+     de ahí en adelante salen con 10 sin tocar nada. */
+  if v_item is not null then
+    select nombre, precio, campos_extra into v_nombre, v_precio, v_extra
+      from items where id = v_item and empresa_id = v_emp and tipo = 'plan';
+    if v_nombre is null then
+      raise exception 'Ese plan no existe en el catálogo.' using errcode = 'P0052';
+    end if;
+    v_clases := nullif(v_extra ->> 'clases', '')::integer;
+    v_tope   := nullif(v_extra ->> 'topeSemanal', '')::integer;
+    v_dias   := nullif(v_extra ->> 'vigenciaDias', '')::integer;
+    v_precio := coalesce((p ->> 'precio')::numeric, v_precio);
+  else
+    v_nombre := coalesce(nullif(p ->> 'nombre', ''), 'Abono');
+    v_clases := nullif(p ->> 'clases', '')::integer;
+    v_tope   := nullif(p ->> 'tope_semanal', '')::integer;
+    v_dias   := nullif(p ->> 'vigencia_dias', '')::integer;
+  end if;
+
+  /* La venta, por el camino de siempre. */
+  perform registrar_venta(jsonb_build_object(
+    'id',          v_op,
+    'empresa_id',  v_emp,
+    'sucursal_id', p ->> 'sucursal_id',
+    'sesion_id',   p ->> 'sesion_id',
+    'numero',      p ->> 'numero',
+    'cliente_id',  v_cliente,
+    'subtotal',    v_precio,
+    'total',       v_precio,
+    'lineas', jsonb_build_array(jsonb_build_object(
+      'item_id',         v_item,
+      'descripcion',     v_nombre,
+      'cantidad',        1,
+      'precio_unitario', v_precio,
+      'total',           v_precio
+    )),
+    'pagos', coalesce(p -> 'pagos', '[]'::jsonb)
+  ));
+
+  insert into abonos (
+    empresa_id, cliente_id, item_id, operacion_id, nombre,
+    clases, tope_semanal, desde, vence, notas, usuario_id
+  ) values (
+    v_emp, v_cliente, v_item, v_op, v_nombre,
+    v_clases, v_tope,
+    coalesce((p ->> 'desde')::date, current_date),
+    case when v_dias is null then nullif(p ->> 'vence', '')::date
+         else coalesce((p ->> 'desde')::date, current_date) + v_dias
+    end,
+    nullif(p ->> 'notas', ''),
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function vender_abono is 'Cobra el plan por el camino de siempre y crea el crédito, en una sola transacción.';
+
+/* ------------------------------------------------------------
+   6 · Usar el abono al reservar
+
+   Acá se controla el tope semanal, que es el momento en que importa: si
+   se controlara al cobrar, "dos por semana" no se puede hacer cumplir.
+   ------------------------------------------------------------ */
+
+create or replace function revisar_abono(p_abono uuid, p_cliente uuid, p_desde timestamptz, p_id uuid default null)
+returns void
+language plpgsql
+as $$
+declare
+  v_a    abonos%rowtype;
+  v_v    record;
+  v_zona text;
+  v_sem  integer;
+begin
+  select * into v_a from abonos where id = p_abono;
+  if v_a.id is null then
+    raise exception 'No existe ese abono.' using errcode = 'P0053';
+  end if;
+  if v_a.anulado then
+    raise exception 'Ese abono está anulado.' using errcode = 'P0054';
+  end if;
+  if p_cliente is null or v_a.cliente_id <> p_cliente then
+    raise exception 'Ese abono es de otra persona.' using errcode = 'P0055';
+  end if;
+
+  v_zona := zona_de(v_a.empresa_id);
+
+  if v_a.vence is not null and (p_desde at time zone v_zona)::date > v_a.vence then
+    raise exception 'Ese abono vence el %.', to_char(v_a.vence, 'DD/MM') using errcode = 'P0056';
+  end if;
+  if (p_desde at time zone v_zona)::date < v_a.desde then
+    raise exception 'Ese abono arranca el %.', to_char(v_a.desde, 'DD/MM') using errcode = 'P0057';
+  end if;
+
+  select restantes into v_v from abonos_vista where id = p_abono;
+  if v_a.clases is not null and coalesce(v_v.restantes, 0) <= 0 then
+    raise exception 'Ese abono ya no tiene clases.' using errcode = 'P0058';
+  end if;
+
+  /* El tope es por semana del calendario, de lunes a domingo, que es como
+     lo cuenta la gente. */
+  if v_a.tope_semanal is not null then
+    select count(*) into v_sem
+      from reservas r
+     where r.abono_id = p_abono
+       and (p_id is null or r.id <> p_id)
+       and r.estado <> 'cancelada'
+       and date_trunc('week', r.desde at time zone v_zona)
+           = date_trunc('week', p_desde at time zone v_zona);
+
+    if v_sem >= v_a.tope_semanal then
+      raise exception 'Ese plan permite % por semana.', v_a.tope_semanal using errcode = 'P0059';
+    end if;
+  end if;
+end;
+$$;
+
+comment on function revisar_abono is 'Vigencia, saldo y tope semanal, en el momento de reservar. Después es tarde.';
+
+/* `agendar_turno` e `inscribir` aceptan un abono. Se rehacen enteras
+   porque plpgsql no admite parchear una función. */
+
+create or replace function agendar_turno(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_emp      uuid := (p ->> 'empresa_id')::uuid;
+  v_desde    timestamptz := (p ->> 'desde')::timestamptz;
+  v_duracion integer := coalesce((p ->> 'duracion_min')::integer, 60);
+  v_personal uuid := nullif(p ->> 'personal_id', '')::uuid;
+  v_recurso  uuid := nullif(p ->> 'recurso_id', '')::uuid;
+  v_cliente  uuid := nullif(p ->> 'cliente_id', '')::uuid;
+  v_abono    uuid := nullif(p ->> 'abono_id', '')::uuid;
+  v_id       uuid;
+begin
+  if not public.puede_ver(v_emp) then
+    raise exception 'No podés agendar en ese comercio.' using errcode = 'P0038';
+  end if;
+
+  perform revisar_turno(null, v_emp, v_desde, v_duracion, v_personal, v_recurso);
+  if v_abono is not null then
+    perform revisar_abono(v_abono, v_cliente, v_desde);
+  end if;
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, cliente_id, personal_id, item_id, abono_id,
+    nombre, telefono, personas, desde, duracion_min, estado, notas, usuario_id
+  ) values (
+    v_emp,
+    nullif(p ->> 'sucursal_id', '')::uuid,
+    v_recurso, v_cliente, v_personal,
+    nullif(p ->> 'item_id', '')::uuid,
+    v_abono,
+    coalesce(nullif(p ->> 'nombre', ''), 'Sin nombre'),
+    nullif(p ->> 'telefono', ''),
+    coalesce((p ->> 'personas')::integer, 1),
+    v_desde, v_duracion,
+    coalesce(nullif(p ->> 'estado', ''), 'pendiente'),
+    nullif(p ->> 'notas', ''),
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+create or replace function inscribir(p jsonb)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_clase   reservas%rowtype;
+  v_tomados integer;
+  v_cliente uuid := nullif(p ->> 'cliente_id', '')::uuid;
+  v_abono   uuid := nullif(p ->> 'abono_id', '')::uuid;
+  v_id      uuid;
+begin
+  select * into v_clase from reservas where id = (p ->> 'clase_id')::uuid for update;
+
+  if v_clase.id is null then
+    raise exception 'No existe esa clase.' using errcode = 'P0042';
+  end if;
+  if v_clase.cupo is null then
+    raise exception 'Eso no es una clase: no tiene cupo.' using errcode = 'P0043';
+  end if;
+  if not public.puede_ver(v_clase.empresa_id) then
+    raise exception 'No podés anotar en ese comercio.' using errcode = 'P0038';
+  end if;
+  if v_clase.estado = 'cancelada' then
+    raise exception 'Esa clase está cancelada.' using errcode = 'P0044';
+  end if;
+
+  select count(*) into v_tomados
+    from reservas
+   where clase_id = v_clase.id and estado not in ('cancelada', 'ausente');
+
+  if v_tomados >= v_clase.cupo then
+    raise exception 'Esa clase ya está completa.' using errcode = 'P0045';
+  end if;
+
+  if v_cliente is not null and exists (
+    select 1 from reservas
+     where clase_id = v_clase.id and cliente_id = v_cliente
+       and estado not in ('cancelada', 'ausente')
+  ) then
+    raise exception 'Esa persona ya está anotada en esta clase.' using errcode = 'P0046';
+  end if;
+
+  if v_abono is not null then
+    perform revisar_abono(v_abono, v_cliente, v_clase.desde);
+  end if;
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, personal_id, item_id, clase_id, abono_id,
+    cliente_id, nombre, telefono, personas, desde, duracion_min, estado, notas, usuario_id
+  ) values (
+    v_clase.empresa_id, v_clase.sucursal_id, v_clase.recurso_id,
+    v_clase.personal_id, v_clase.item_id, v_clase.id, v_abono,
+    v_cliente,
+    coalesce(nullif(p ->> 'nombre', ''), 'Sin nombre'),
+    nullif(p ->> 'telefono', ''),
+    1,
+    v_clase.desde, v_clase.duracion_min,
+    coalesce(nullif(p ->> 'estado', ''), 'confirmada'),
+    nullif(p ->> 'notas', ''),
+    auth.uid()
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+/* ------------------------------------------------------------
+   7 · El turno, sabiendo de qué abono salió
+   ------------------------------------------------------------ */
+
+drop view if exists agenda_vista;
+
+create view agenda_vista
+with (security_invoker = true) as
+select
+  r.id, r.empresa_id, r.sucursal_id, r.recurso_id, r.cliente_id,
+  r.personal_id, r.item_id, r.clase_id, r.cupo, r.abono_id,
+  r.nombre, r.telefono, r.personas, r.desde, r.duracion_min,
+  r.desde + make_interval(mins => r.duracion_min) as hasta,
+  r.estado, r.notas, r.operacion_id, r.creada_en,
+
+  case when r.clase_id is not null then 'inscripcion'
+       when r.cupo is not null     then 'clase'
+       else 'turno'
+  end as forma,
+
+  coalesce(ins.tomados, 0) as anotados,
+  case when r.cupo is null then null else r.cupo - coalesce(ins.tomados, 0) end as lugares,
+  coalesce(esp.esperando, 0) as esperando,
+
+  c.razon_social as cliente,
+  p.nombre       as profesional,
+  p.especialidad,
+  i.nombre       as servicio,
+  i.categoria    as area,
+  i.precio,
+  re.nombre      as sala,
+  re.tipo        as sala_tipo,
+  ab.nombre      as abono,
+
+  coalesce(pg.pagado, 0) as pagado
+from reservas r
+left join clientes  c  on c.id  = r.cliente_id
+left join personal  p  on p.id  = r.personal_id
+left join items     i  on i.id  = r.item_id
+left join recursos  re on re.id = r.recurso_id
+left join abonos    ab on ab.id = r.abono_id
+left join (
+  select clase_id, count(*) as tomados
+  from reservas where clase_id is not null and estado not in ('cancelada', 'ausente')
+  group by clase_id
+) ins on ins.clase_id = r.id
+left join (
+  select clase_id, count(*) as esperando
+  from espera where estado = 'esperando'
+  group by clase_id
+) esp on esp.clase_id = r.id
+left join (
+  select operacion_id, sum(monto) as pagado from pagos group by operacion_id
+) pg on pg.operacion_id = r.operacion_id;
+
+comment on view agenda_vista is
+  'Turnos, clases e inscripciones con sus nombres resueltos. `forma` dice cuál de las tres es cada fila, y el cupo ya viene contado.';

--- a/supabase/migrations/0036_ventas_en_el_menu.sql
+++ b/supabase/migrations/0036_ventas_en_el_menu.sql
@@ -1,0 +1,47 @@
+/* ============================================================
+   0036 · VENTAS DEJA DE ESTAR APAGADA
+   ============================================================
+
+   La sección estaba declarada como `proximo` desde la 0028. Ahora tiene
+   pantalla y backend: planes en el catálogo, abonos con su saldo contado
+   y el consumo al reservar.
+
+   Presupuestos y membresías con cobro automático siguen sin existir, y
+   por eso no se listan.
+   ============================================================ */
+
+update rubros set menu = jsonb_set(
+  menu, '{4}',
+  '{
+    "clave":"ventas", "nombre":"Ventas", "i":"bolsa",
+    "modulos":[
+      {"k":"ventas","n":"Ventas","i":"bolsa","d":"Abonos, packs y planes"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 4 ->> 'clave' = 'ventas';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['ventas']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  g ->> 'clave' as seccion,
+  coalesce(g ->> 'nombre', '(sin rótulo)') as rotulo,
+  jsonb_array_length(g -> 'modulos') as modulos,
+  coalesce(g ->> 'proximo', 'false') as proximo
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios'
+order by x.orden;

--- a/supabase/migrations/0037_liquidaciones.sql
+++ b/supabase/migrations/0037_liquidaciones.sql
@@ -1,0 +1,250 @@
+/* ============================================================
+   0037 · LIQUIDACIONES
+   ============================================================
+
+   Lo que se le paga al equipo. Va en Finanzas y no en "Clientes y equipo"
+   por una razón concreta: **pagarle a alguien es un egreso**. Con la
+   liquidación colgando del módulo de personal, Finanzas no se entera del
+   gasto más grande y más regular del negocio, y los egresos del mes
+   mienten.
+
+   LAS HORAS SE PROPONEN, NO SE IMPONEN
+   ------------------------------------
+   Salen de la agenda: la suma de lo que cada uno dictó en el período. Pero
+   quedan editables, porque la agenda no sabe que se quedó media hora más
+   ordenando ni que cubrió a alguien sin que quedara registrado.
+
+   Una clase cuenta una vez —su duración— y no una vez por alumno. Las
+   inscripciones no son horas del profesor: son la misma hora vista desde
+   el otro lado.
+
+   LA NOTA VA PEGADA AL PERÍODO
+   ----------------------------
+   Los reemplazos y lo que haga falta se anotan sobre la liquidación y no
+   sobre la persona. Ahí es donde tienen sentido: son la explicación de por
+   qué esas horas no cierran con lo habitual.
+   ============================================================ */
+
+create table liquidaciones (
+  id           uuid primary key default gen_random_uuid(),
+  empresa_id   uuid not null references empresas(id) on delete cascade,
+  personal_id  uuid not null references personal(id) on delete cascade,
+
+  desde        date not null,
+  hasta        date not null,
+
+  /* La modalidad y el valor se copian al liquidar. Si mañana se le sube
+     el valor hora, la liquidación de marzo tiene que seguir diciendo lo
+     que se le pagó en marzo. Mismo criterio que `costo_unitario` en una
+     línea de venta. */
+  modalidad    text not null default 'hora',
+  valor        numeric(14,2) not null default 0,
+  horas        numeric(8,2)  not null default 0,
+  clases       integer       not null default 0,
+
+  /* Adelantos y extras. En negativo descuenta: un adelanto que se dio a
+     mitad de semana sale de lo que queda por pagar. */
+  ajuste       numeric(14,2) not null default 0,
+  total        numeric(14,2) not null default 0,
+
+  estado       text not null default 'borrador',
+  medio        text,
+  movimiento_id uuid references movimientos_caja(id) on delete set null,
+  pagada_en    timestamptz,
+
+  creada_en    timestamptz not null default now(),
+  usuario_id   uuid references perfiles(id) on delete set null,
+
+  constraint liquidaciones_estado_valido check (estado in ('borrador', 'pagada', 'anulada')),
+  constraint liquidaciones_periodo_valido check (hasta >= desde),
+  constraint liquidaciones_unica unique (empresa_id, personal_id, desde, hasta)
+);
+
+create index on liquidaciones (empresa_id, desde desc);
+create index on liquidaciones (personal_id, desde desc);
+
+create table liquidacion_notas (
+  id              uuid primary key default gen_random_uuid(),
+  empresa_id      uuid not null references empresas(id) on delete cascade,
+  liquidacion_id  uuid not null references liquidaciones(id) on delete cascade,
+  texto           text not null,
+  creada_en       timestamptz not null default now(),
+  usuario_id      uuid references perfiles(id) on delete set null
+);
+
+create index on liquidacion_notas (liquidacion_id, creada_en);
+
+comment on table liquidacion_notas is
+  'Reemplazos y lo que haga falta, pegado al período que se está liquidando: es la explicación de por qué esas horas no cierran con lo habitual.';
+
+alter table liquidaciones      enable row level security;
+alter table liquidacion_notas  enable row level security;
+
+create policy liquidaciones_todo on liquidaciones
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+create policy liquidacion_notas_todo on liquidacion_notas
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+/* ------------------------------------------------------------
+   Lo que dictó cada uno
+
+   Una clase cuenta una vez, por eso se excluyen las inscripciones. Una
+   cancelación no cuenta; una ausencia sí, porque el profesor igual estuvo.
+   ------------------------------------------------------------ */
+
+create or replace function dictado_en(p_personal uuid, p_desde date, p_hasta date)
+returns table (horas numeric, clases integer)
+language sql stable
+as $$
+  select
+    coalesce(sum(r.duracion_min), 0)::numeric / 60 as horas,
+    count(*)::integer                              as clases
+  from reservas r
+  join personal p on p.id = r.personal_id
+  where r.personal_id = p_personal
+    and r.clase_id is null
+    and r.estado <> 'cancelada'
+    and (r.desde at time zone zona_de(p.empresa_id))::date between p_desde and p_hasta;
+$$;
+
+comment on function dictado_en is 'Horas y clases que dio una persona en un período, desde la agenda. Las inscripciones no cuentan: son la misma hora vista desde el otro lado.';
+
+/* ------------------------------------------------------------
+   Armar la liquidación
+
+   Se puede volver a correr: recalcula el borrador con lo que haya en la
+   agenda ahora. Una ya pagada no se toca.
+   ------------------------------------------------------------ */
+
+create or replace function liquidar(p_personal uuid, p_desde date, p_hasta date)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_p    personal%rowtype;
+  v_d    record;
+  v_tot  numeric;
+  v_id   uuid;
+  v_est  text;
+begin
+  select * into v_p from personal where id = p_personal;
+  if v_p.id is null then
+    raise exception 'No existe esa persona.' using errcode = 'P0060';
+  end if;
+  if not public.puede_ver(v_p.empresa_id) then
+    raise exception 'No podés liquidar en ese comercio.' using errcode = 'P0038';
+  end if;
+
+  select estado into v_est from liquidaciones
+   where empresa_id = v_p.empresa_id and personal_id = p_personal
+     and desde = p_desde and hasta = p_hasta;
+
+  if v_est = 'pagada' then
+    raise exception 'Esa liquidación ya está pagada.' using errcode = 'P0061';
+  end if;
+
+  select * into v_d from dictado_en(p_personal, p_desde, p_hasta);
+
+  /* Cómo se llega al total depende de la modalidad de la persona. El
+     sueldo fijo no mira las horas: se paga igual, y las horas quedan
+     igual anotadas para poder controlarlas. */
+  v_tot := case v_p.modalidad
+    when 'hora'  then round(v_d.horas * v_p.valor)
+    when 'clase' then v_d.clases * v_p.valor
+    when 'fijo'  then v_p.valor
+    else 0   -- comisión: se calcula sobre lo facturado y todavía no está
+  end;
+
+  insert into liquidaciones (
+    empresa_id, personal_id, desde, hasta, modalidad, valor, horas, clases, total, usuario_id
+  ) values (
+    v_p.empresa_id, p_personal, p_desde, p_hasta, v_p.modalidad, v_p.valor,
+    v_d.horas, v_d.clases, v_tot, auth.uid()
+  )
+  on conflict (empresa_id, personal_id, desde, hasta) do update
+    set modalidad = excluded.modalidad,
+        valor     = excluded.valor,
+        horas     = excluded.horas,
+        clases    = excluded.clases,
+        /* El ajuste cargado a mano se respeta: lo puso alguien que sabía
+           algo que la agenda no sabe. */
+        total     = excluded.total + liquidaciones.ajuste
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+comment on function liquidar is 'Arma o recalcula el borrador de un período con lo que diga la agenda. Una liquidación pagada no se toca.';
+
+/* ------------------------------------------------------------
+   Pagarla
+
+   Genera el egreso en el mismo acto. Es lo que hace que la caja cierre
+   sola y que nadie tenga que acordarse de anotar el sueldo aparte.
+
+   `sesion_id` puede ir en null: pagar por transferencia un lunes no es un
+   movimiento del cajón del mostrador, y obligar a abrir la caja para eso
+   sería inventar un arqueo que no existió.
+   ------------------------------------------------------------ */
+
+create or replace function pagar_liquidacion(p_id uuid, p_medio text, p_sesion uuid default null)
+returns uuid
+language plpgsql
+as $$
+declare
+  v_l   liquidaciones%rowtype;
+  v_p   text;
+  v_mov uuid;
+begin
+  select * into v_l from liquidaciones where id = p_id for update;
+  if v_l.id is null then
+    raise exception 'No existe esa liquidación.' using errcode = 'P0062';
+  end if;
+  if v_l.estado = 'pagada' then
+    raise exception 'Esa liquidación ya está pagada.' using errcode = 'P0061';
+  end if;
+
+  select nombre into v_p from personal where id = v_l.personal_id;
+
+  insert into movimientos_caja (
+    empresa_id, sesion_id, tipo, medio, monto, detalle, categoria, usuario_id
+  ) values (
+    v_l.empresa_id, p_sesion, 'egreso', coalesce(p_medio, 'efectivo'),
+    v_l.total + v_l.ajuste,
+    'Sueldo ' || coalesce(v_p, '') || ' · ' || to_char(v_l.desde, 'DD/MM') || ' al ' || to_char(v_l.hasta, 'DD/MM'),
+    'sueldos', auth.uid()
+  )
+  returning id into v_mov;
+
+  update liquidaciones
+     set estado = 'pagada', medio = p_medio, movimiento_id = v_mov, pagada_en = now()
+   where id = p_id;
+
+  return v_mov;
+end;
+$$;
+
+comment on function pagar_liquidacion is 'Marca pagada la liquidación y escribe el egreso en el mismo acto, para que nadie tenga que acordarse de anotarlo.';
+
+/* ------------------------------------------------------------
+   La liquidación, con los nombres resueltos
+   ------------------------------------------------------------ */
+
+create or replace view liquidaciones_vista
+with (security_invoker = true) as
+select
+  l.*,
+  p.nombre       as persona,
+  p.tipo         as tipo_persona,
+  p.especialidad,
+  l.total + l.ajuste as a_pagar,
+  coalesce(nt.notas, 0) as notas
+from liquidaciones l
+join personal p on p.id = l.personal_id
+left join (
+  select liquidacion_id, count(*) as notas from liquidacion_notas group by liquidacion_id
+) nt on nt.liquidacion_id = l.id;
+
+comment on view liquidaciones_vista is 'La liquidación con la persona resuelta y el total a pagar ya sumado el ajuste.';

--- a/supabase/migrations/0038_finanzas_en_el_menu.sql
+++ b/supabase/migrations/0038_finanzas_en_el_menu.sql
@@ -1,0 +1,49 @@
+/* ============================================================
+   0038 · FINANZAS ABSORBE A CAJA
+   ============================================================
+
+   Hasta acá la sección Finanzas tenía un solo módulo, Caja, y por eso se
+   dibujaba como un renglón suelto. Ahora tiene la pantalla completa —el
+   mes, los movimientos, lo que falta cobrar y las liquidaciones— con la
+   caja del día adentro como una pestaña más.
+
+   Caja sale del menú pero **no se elimina ni se rehace**: sigue siendo la
+   misma pantalla de siempre, resolviendo lo suyo, que es el día y no el
+   mes. Solo cambió por dónde se llega.
+   ============================================================ */
+
+update rubros set menu = jsonb_set(
+  menu, '{5}',
+  '{
+    "clave":"finanzas", "nombre":"Finanzas", "i":"billetera",
+    "modulos":[
+      {"k":"finanzas","n":"Finanzas","i":"billetera","d":"Caja, ingresos, egresos y lo que se le paga al equipo"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 5 ->> 'clave' = 'finanzas';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['finanzas']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  g ->> 'clave' as seccion,
+  coalesce(g ->> 'nombre', '(sin rótulo)') as rotulo,
+  jsonb_array_length(g -> 'modulos') as modulos,
+  coalesce(g ->> 'proximo', 'false') as proximo
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios'
+order by x.orden;

--- a/supabase/seed/almha.sql
+++ b/supabase/seed/almha.sql
@@ -1,0 +1,168 @@
+/* ============================================================
+   SEMILLA · Almha, un tercer comercio de otro rubro
+   ============================================================
+
+   Estética y pilates. Es el primer inquilino del rubro `servicios`, y con
+   él se estrena el menú agrupado: hasta ahora los dos comercios que había
+   usaban un solo grupo sin rótulo.
+
+   TODOS LOS DATOS SON DE EJEMPLO. El negocio existe, los servicios, los
+   precios y las salas de acá no. Están marcados con `"demo": true` en
+   `campos_extra` para poder barrerlos de una cuando lleguen los reales:
+
+     delete from items    where empresa_id = (select id from empresas where nombre = 'Almha')
+                            and campos_extra ->> 'demo' = 'true';
+     delete from recursos where empresa_id = (select id from empresas where nombre = 'Almha')
+                            and campos_extra ->> 'demo' = 'true';
+
+   No hace falta crear un usuario para entrar: el dueño de plataforma entra
+   a cualquier comercio desde el panel, con "entrar como". Cuando Almha
+   tenga gente propia se le agrega su acceso, igual que al bar.
+
+   Se puede correr más de una vez sin duplicar.
+   ============================================================ */
+
+do $$
+declare
+  v_emp uuid;
+  v_suc uuid;
+  s     record;
+  r     record;
+begin
+
+select id into v_emp from empresas where nombre = 'Almha';
+
+if v_emp is null then
+  insert into empresas (nombre, rubro, plan, modulos, config)
+  values (
+    'Almha',
+    'servicios',
+    'completo',
+    /* Solo los módulos que existen hoy. La agenda, el equipo, los abonos y
+       las finanzas se van contratando a medida que se construyen: aparecen
+       solas en el menú porque el menú sale de `rubros`. */
+    array['cobro','caja','ajustes','clientes','reportes'],
+    jsonb_build_object(
+      'fiscal', jsonb_build_object(
+        'nombreFactura', 'Almha',
+        'razonSocial',   'Almha (datos de ejemplo)',
+        'cuit',          '30-00000000-0',
+        'condicion',     'MONOTRIBUTO',
+        'iibb',          '',
+        'inicio',        '01/08/2026',
+        'puntoVenta',    '0001',
+        'domicilio',     'Domicilio de ejemplo'
+      ),
+      'medios', jsonb_build_array(
+        jsonb_build_object('k','efectivo',      'n','Efectivo',          'tasa',0,   'recargo',false,'activo',true),
+        jsonb_build_object('k','debito',        'n','Débito',            'tasa',1.2, 'recargo',false,'activo',true),
+        jsonb_build_object('k','credito',       'n','Crédito',           'tasa',3.1, 'recargo',false,'activo',true),
+        jsonb_build_object('k','mp',            'n','QR / Mercado Pago', 'tasa',0.8, 'recargo',false,'activo',true),
+        jsonb_build_object('k','transferencia', 'n','Transferencia',     'tasa',0,   'recargo',false,'activo',true)
+      ),
+      'ancho', 58,
+      'demo', true
+    )
+  )
+  returning id into v_emp;
+
+  raise notice 'Almha creada.';
+else
+  raise notice 'Almha ya existía. Se completan catálogo y salas.';
+end if;
+
+select id into v_suc from sucursales where empresa_id = v_emp limit 1;
+if v_suc is null then
+  insert into sucursales (empresa_id, nombre, domicilio)
+  values (v_emp, 'Casa central', 'Domicilio de ejemplo')
+  returning id into v_suc;
+end if;
+
+/* ------------------------------------------------------------
+   Las prestaciones
+
+   Son items como cualquier otro: la misma tabla que las Coca-Colas de
+   Super 25. Lo que cambia es que llevan `duracion_min` y no controlan
+   stock. Eso ya estaba previsto en el modelo desde la primera migración.
+
+   La modalidad y el cupo viven por ahora en `campos_extra`. Cuando exista
+   la tabla de franjas, el cupo pasa a ser de la franja: una clase puede
+   abrirse con menos lugares que los que la sala admite.
+   ------------------------------------------------------------ */
+for s in
+  select * from (values
+    ('Pilates Reformer',        'Pilates',    60, 20000, 'grupal',     6),
+    ('Pilates Mat',             'Pilates',    50, 15000, 'grupal',     8),
+    ('Pilates Personalizado',   'Pilates',    60, 28000, 'individual', 1),
+    ('Clase de Prueba',         'Pilates',    50,  8000, 'grupal',     6),
+    ('Limpieza Facial',         'Estética',   60, 22000, 'individual', 1),
+    ('Depilación Definitiva',   'Estética',   30, 12000, 'individual', 1),
+    ('Masaje Relajante',        'Masajes',    60, 20000, 'individual', 1),
+    ('Masaje Descontracturante','Masajes',    60, 22000, 'individual', 1),
+    ('Drenaje Linfático',       'Corporales', 50, 18000, 'individual', 1)
+  ) as t(nombre, categoria, duracion, precio, modalidad, capacidad)
+loop
+  update items
+     set categoria = s.categoria, duracion_min = s.duracion, precio = s.precio,
+         tipo = 'servicio', controla_stock = false, activo = true,
+         campos_extra = jsonb_build_object('modalidad', s.modalidad, 'capacidad', s.capacidad, 'demo', true)
+   where empresa_id = v_emp and nombre = s.nombre;
+
+  if not found then
+    insert into items (empresa_id, tipo, nombre, categoria, unidad, precio,
+                       controla_stock, duracion_min, campos_extra)
+    values (v_emp, 'servicio', s.nombre, s.categoria, 'un', s.precio,
+            false, s.duracion,
+            jsonb_build_object('modalidad', s.modalidad, 'capacidad', s.capacidad, 'demo', true));
+  end if;
+end loop;
+
+/* ------------------------------------------------------------
+   Las salas
+
+   Mismo mecanismo que las mesas del bar, con otro tipo. Las coordenadas
+   son para que el plano no salga amontonado el día que se contrate: hoy
+   Almha no tiene el módulo, así que no se dibuja.
+   ------------------------------------------------------------ */
+for r in
+  select * from (values
+    ('Sala Reformer 1', 'sala',    'Pilates',  6, 1,  1,  1, 4, 3),
+    ('Sala Reformer 2', 'sala',    'Pilates',  6, 2,  6,  1, 4, 3),
+    ('Sala Mat 1',      'sala',    'Pilates',  8, 3, 11,  1, 4, 3),
+    ('Sala Mat 2',      'sala',    'Pilates',  8, 4, 16,  1, 4, 3),
+    ('Sala Estética',   'sala',    'Estética', 1, 5,  1,  5, 3, 3),
+    ('Gabinete 1',      'camilla', 'Estética', 1, 6,  5,  5, 2, 2),
+    ('Gabinete 2',      'camilla', 'Estética', 1, 7,  8,  5, 2, 2),
+    ('Box Masajes 1',   'camilla', 'Masajes',  1, 8, 11,  5, 2, 2),
+    ('Box Masajes 2',   'camilla', 'Masajes',  1, 9, 14,  5, 2, 2),
+    ('Consultorio 1',   'sala',    'Estética', 1,10, 17,  5, 3, 3)
+  ) as t(nombre, tipo, sector, capacidad, orden, x, y, ancho, alto)
+loop
+  update recursos
+     set tipo = r.tipo, sector = r.sector, capacidad = r.capacidad, orden = r.orden,
+         x = r.x, y = r.y, ancho = r.ancho, alto = r.alto,
+         piso = 'Planta baja', forma = 'rectangulo', activo = true,
+         campos_extra = jsonb_build_object('demo', true)
+   where empresa_id = v_emp and nombre = r.nombre;
+
+  if not found then
+    insert into recursos (empresa_id, sucursal_id, tipo, nombre, sector, piso,
+                          capacidad, orden, x, y, ancho, alto, forma, campos_extra)
+    values (v_emp, v_suc, r.tipo, r.nombre, r.sector, 'Planta baja',
+            r.capacidad, r.orden, r.x, r.y, r.ancho, r.alto, 'rectangulo',
+            jsonb_build_object('demo', true));
+  end if;
+end loop;
+
+raise notice 'Almha lista: % prestaciones y % espacios.',
+  (select count(*) from items    where empresa_id = v_emp and tipo = 'servicio' and activo),
+  (select count(*) from recursos where empresa_id = v_emp and activo);
+end;
+$$;
+
+select
+  e.nombre, e.rubro, e.plan,
+  (select count(*) from items    i where i.empresa_id = e.id and i.tipo = 'servicio') as prestaciones,
+  (select count(*) from recursos r where r.empresa_id = e.id)                         as espacios
+from empresas e
+order by e.nombre;

--- a/supabase/seed/almha_equipo.sql
+++ b/supabase/seed/almha_equipo.sql
@@ -1,0 +1,128 @@
+/* ============================================================
+   SEMILLA · el equipo de Almha
+   ============================================================
+
+   TODO ES DE EJEMPLO: los nombres, los valores hora y los horarios. Van
+   marcados con `"demo": true` para poder barrerlos de una:
+
+     delete from personal where empresa_id = (select id from empresas where nombre = 'Almha')
+                            and campos_extra ->> 'demo' = 'true';
+
+   Los horarios y los servicios habilitados se borran solos con la persona,
+   por la cascada.
+
+   Los servicios de cada uno se asignan por categoría y no uno por uno: así
+   la semilla sigue andando si mañana se agrega una prestación de pilates,
+   y no queda una lista de nombres que hay que mantener a mano.
+
+   Se puede correr más de una vez.
+   ============================================================ */
+
+do $$
+declare
+  v_emp uuid;
+  v_suc uuid;
+  p     record;
+  h     record;
+  v_id  uuid;
+begin
+
+select id into v_emp from empresas where nombre = 'Almha';
+if v_emp is null then
+  raise exception 'No existe Almha. Corré antes supabase/seed/almha.sql.';
+end if;
+
+select id into v_suc from sucursales where empresa_id = v_emp limit 1;
+
+/* ------------------------------------------------------------
+   La gente
+
+   `categoria` es de qué se ocupa; se usa abajo para habilitarle los
+   servicios de esa área. En recepción va en null: no da prestaciones.
+   ------------------------------------------------------------ */
+for p in
+  select * from (values
+    ('Sofía González',  'profesional', 'Pilates',  'Pilates',  'hora',  8000, 1),
+    ('Valentina Rojas', 'profesional', 'Pilates',  'Pilates',  'hora',  8000, 2),
+    ('Carla Gómez',     'profesional', 'Estética', 'Estética', 'hora',  9000, 3),
+    ('Agustina Pérez',  'profesional', 'Masajes',  'Masajes',  'hora',  8500, 4),
+    ('Micaela Ruiz',    'recepcion',   'Mostrador', null,      'hora',  6000, 5)
+  ) as t(nombre, tipo, especialidad, categoria, modalidad, valor, orden)
+loop
+  update personal
+     set tipo = p.tipo, especialidad = p.especialidad, modalidad = p.modalidad,
+         valor = p.valor, orden = p.orden, sucursal_id = v_suc, activo = true,
+         campos_extra = jsonb_build_object('demo', true, 'categoria', p.categoria)
+   where empresa_id = v_emp and nombre = p.nombre
+   returning id into v_id;
+
+  if v_id is null then
+    insert into personal (empresa_id, sucursal_id, nombre, tipo, especialidad,
+                          modalidad, valor, orden, campos_extra)
+    values (v_emp, v_suc, p.nombre, p.tipo, p.especialidad,
+            p.modalidad, p.valor, p.orden,
+            jsonb_build_object('demo', true, 'categoria', p.categoria))
+    returning id into v_id;
+  end if;
+
+  /* Qué puede dar: todo lo de su categoría. Se rehace cada vez para que
+     una prestación nueva del área quede habilitada sin tocar nada. */
+  delete from personal_servicios where personal_id = v_id;
+  if p.categoria is not null then
+    insert into personal_servicios (personal_id, item_id, empresa_id)
+    select v_id, i.id, v_emp
+      from items i
+     where i.empresa_id = v_emp and i.tipo = 'servicio' and i.activo
+       and i.categoria = p.categoria;
+  end if;
+
+  v_id := null;
+end loop;
+
+/* ------------------------------------------------------------
+   Cuándo está cada uno
+
+   Se rehacen enteros para que correr la semilla dos veces no deje franjas
+   duplicadas encima de las mismas horas.
+   ------------------------------------------------------------ */
+delete from horarios
+ where empresa_id = v_emp
+   and personal_id in (select id from personal where empresa_id = v_emp
+                         and campos_extra ->> 'demo' = 'true');
+
+for h in
+  select * from (values
+    /* Las de pilates se reparten la mañana y la tarde. */
+    ('Sofía González',  1, '08:00', '13:00'), ('Sofía González',  3, '08:00', '13:00'),
+    ('Sofía González',  5, '08:00', '13:00'),
+    ('Valentina Rojas', 2, '14:00', '20:00'), ('Valentina Rojas', 4, '14:00', '20:00'),
+    ('Valentina Rojas', 6, '09:00', '13:00'),
+    /* Estética atiende de tarde, que es cuando la gente puede. */
+    ('Carla Gómez',     1, '14:00', '20:00'), ('Carla Gómez',     2, '14:00', '20:00'),
+    ('Carla Gómez',     3, '14:00', '20:00'), ('Carla Gómez',     4, '14:00', '20:00'),
+    ('Agustina Pérez',  2, '10:00', '18:00'), ('Agustina Pérez',  4, '10:00', '18:00'),
+    ('Agustina Pérez',  5, '10:00', '18:00'),
+    /* Recepción cubre todo el horario del local. */
+    ('Micaela Ruiz',    1, '08:00', '20:00'), ('Micaela Ruiz',    2, '08:00', '20:00'),
+    ('Micaela Ruiz',    3, '08:00', '20:00'), ('Micaela Ruiz',    4, '08:00', '20:00'),
+    ('Micaela Ruiz',    5, '08:00', '20:00'), ('Micaela Ruiz',    6, '09:00', '13:00')
+  ) as t(nombre, dia, desde, hasta)
+loop
+  insert into horarios (empresa_id, personal_id, dia, desde, hasta)
+  select v_emp, pe.id, h.dia, h.desde::time, h.hasta::time
+    from personal pe
+   where pe.empresa_id = v_emp and pe.nombre = h.nombre;
+end loop;
+
+raise notice 'Equipo de Almha: % personas, % franjas horarias, % servicios habilitados.',
+  (select count(*) from personal where empresa_id = v_emp and activo),
+  (select count(*) from horarios where empresa_id = v_emp),
+  (select count(*) from personal_servicios where empresa_id = v_emp);
+end;
+$$;
+
+select nombre, tipo, especialidad, modalidad, valor,
+       horas_semana, dias_semana, servicios, tiene_cuenta
+from equipo_vista
+where empresa_id = (select id from empresas where nombre = 'Almha')
+order by orden;


### PR DESCRIPTION
Genez pasa de servir a un minimercado y a un bar, a servir también a un negocio que vende horas. Doce commits, siete migraciones, cuatro módulos nuevos.

El encargo completo está en [`docs/pedido-negocios-de-servicios.md`](docs/pedido-negocios-de-servicios.md).

## El cambio de fondo: el menú es dato

Hasta acá la navegación era una lista fija pensada para un minimercado. Reemplazarla por otra lista fija pensada para una estética dejaba el mismo problema para el rubro siguiente.

Ahora los grupos, qué módulos caen en cada uno, en qué orden, cómo se llaman y con qué ícono salen de la tabla `rubros`. Agregar "Genez para gimnasios" es un `insert`, no un componente. Es la misma decisión que `canales` en el centro de pedidos.

Cada rubro define además por dónde abre el sistema, cuál es su acción principal y qué tablero muestra el inicio. Una estética abría en el lector de códigos de barras del minimercado; ahora abre en su tablero.

**Super 25 y el Bar Rivadavia no cambian.** Los dos usan un grupo único sin rótulo, exactamente como antes. Está verificado contra la base que ninguno de sus módulos contratados quedó fuera del menú.

## Almha

Un tercer comercio, de rubro `servicios`. Estrena el menú de diez secciones: siete activas y tres apagadas con el motivo al pasar el mouse, para que se vea a dónde va el sistema sin que nada aparente funcionar.

Todos sus datos de catálogo son de ejemplo y están marcados con `"demo": true` para poder barrerlos de una cuando lleguen los reales.

## Lo que se puede hacer ahora

**Agenda.** Calendario por día y semana, por profesional o por sala, con el horario laboral de fondo y los turnos proporcionales a su duración. Turnos individuales y clases grupales con cupo, lista de espera, bloqueos por hora, asistencia, reprogramación. En tiempo real entre dispositivos.

**Equipo.** Quién trabaja, qué servicios da cada uno, sus horarios y cómo se le paga —por hora, por clase, por comisión o fijo—. El personal no es usuario del sistema: la mayoría no entra nunca, pero se le puede enganchar una cuenta cuando haga falta.

**Ventas.** Packs, cuotas y planes libres. El crédito se descuenta al reservar y no al asistir, que es lo único que hace que un tope de "dos por semana" se pueda hacer cumplir.

**Finanzas.** El mes, los movimientos, lo que falta cobrar y las liquidaciones del equipo. Pagar una liquidación escribe el egreso en el mismo acto.

## Dos correcciones de seguridad

**Una fuga entre comercios.** `cargarProductos` y `cargarClientes` se apoyaban en RLS para saber de qué comercio era cada fila. RLS contesta *si podés ver algo*, no *de quién es*: para un usuario de comercio las dos respuestas coinciden, pero el dueño de plataforma ve todo, y entrando como Almha se cargaban los 972 productos de Super 25. Ahora filtran por `empresa_id` explícito y revientan si no lo reciben. Quedó como sexta regla en `ARQUITECTURA.md`.

**Una vista sin `security_invoker`.** `equipo_vista` nació sin esa opción, así que corría con los permisos de quien la creó y salteaba RLS: cualquiera con sesión podía leer el equipo y los sueldos de los otros comercios. Corregido, y hay una prueba que ahora recorre **todas** las vistas para que la próxima que se agregue mal caiga ahí.

## Sobre gastronomía

`reservas` se extendió en vez de duplicarse: una mesa comprometida para las nueve y una clase de reformer comprometida para las nueve son la misma cosa.

El estado nuevo `confirmada` tocaba dos lugares que filtraban `pendiente` a secas —`salon_vista` dejaba de pintar la mesa y `sentar_reserva` no dejaba sentar a quien había confirmado—. Los dos quedaron corregidos. Antes de aplicar la migración se guardó la lista de columnas de `salon_vista` y se comparó después: 37 antes, 37 después, mismos tipos.

## Las pruebas

`probar-rls.mjs` pasó de 21 a 75 verificaciones, todas contra la base real. Las de aislamiento cubren turnos, clases, lista de espera, equipo, sueldos y abonos: ningún comercio ve ni escribe lo de otro.

Tres de esas pruebas fallaron primero **por estar mal escritas y pasar sin probar nada** —un id nulo que salteaba la validación, una segunda clase que chocaba antes de llegar a lo que probaba, y una que se estrelló contra turnos reales cargados por el cliente—. Las tres quedaron corregidas y con el motivo anotado.

`npm run build` pasa.

## Lo que queda afuera

Reportes sigue siendo el de un minimercado. Servicios y recursos, CRM y Comunicaciones están apagados. La modalidad comisión en liquidaciones queda en cero: calcularla necesita atribuir cada cobro a la clase y al profesional. Y falta la pantalla de venta propia que reemplace al punto de venta con lector, que no corresponde a un negocio de turnos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
