### PR TITLE
Genez para negocios de servicios: las siete etapas

### DIFF
--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -43,6 +43,13 @@ authenticated`, así las políticas se aplican igual que desde el navegador.
 Las demás corren como administrador y **saltean RLS**: sirven para la
 lógica, no para los permisos. Esa diferencia ya dejó pasar un bug.
 
+Cada script deja la base como estaba, y **la bitácora la limpia por fecha**:
+guarda la hora de arranque —la del reloj de la base, no el de Node— y borra
+solo lo que escribió esa corrida. Antes borraba por acción, o entera, y eso
+se llevaba puesto el registro de los tres comercios. Daba igual mientras
+nadie la leyera; desde que la auditoría tiene pantalla, es destruir un dato
+real cada vez que alguien corre las pruebas.
+
 ## El modelo de datos
 
 ### Multiempresa

--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -118,6 +118,7 @@ Lo que toca varias tablas a la vez vive en Postgres, no en el navegador:
 | `mover_pedido(...)` | Cambia el estado: valida el flujo del canal, mueve la cocina y deja historial. |
 | `estadisticas_pedidos(...)` | Pedidos, ventas, tiempos y evolución de un período. |
 | `informe_ocupacion(...)` | Cuánto de lo que se podía vender se vendió, por profesional y por sala. Ver abajo. |
+| `crm_segmentos(uuid)` | A quién conviene escribirle y por qué. Ver abajo. |
 | `sembrar_canales(uuid)` | Los canales con los que arranca un comercio. |
 | `enviar_a_cocina(uuid)` | Despacha solo lo que falta despachar. |
 | `aplicar_descuento(...)` | Por porcentaje o por importe. |
@@ -241,6 +242,39 @@ nadie carga el horario de una sala: se carga el de la gente. Si algún día
 se cargan horarios propios de un espacio, mandan esos.
 
 **Este módulo usa la fecha real**, no el `HOY` congelado del prototipo.
+
+## El CRM
+
+`crm_segmentos` devuelve cinco listas de gente a la que conviene
+escribirle, y cada una existe porque tiene una acción distinta detrás: el
+que dejó de venir, el que vino una sola vez, el que se queda sin abono,
+el que se le venció y no renovó, y el que reserva y no aparece.
+
+**Los segmentos se derivan, no se guardan.** Misma regla que el stock y
+que el estado de una mesa. Una columna `es_cliente_dormido` se corrompe
+el día que la persona vuelve, y el criterio cambia —hoy son 45 días,
+mañana el comercio decide otra cosa— con lo que habría que recalcular el
+pasado entero.
+
+**`contactos` es lo que hace que la lista se vacíe.** Sin ella el lunes
+aparecen los mismos veinte nombres que el viernes. Escribirle a alguien
+lo saca del segmento por tres semanas, y **solo de ese segmento**: que se
+le haya avisado que su abono vence no significa que no haya que decirle,
+dos meses después, que hace rato no viene.
+
+**Nada se manda solo.** Se abre WhatsApp con el mensaje ya escrito y la
+persona aprieta enviar. El texto es editable antes y lo que se guarda es
+lo que se mandó, no lo que decía la plantilla. Las plantillas guardadas y
+el envío en tanda son de Comunicaciones.
+
+**"No molestar" va en `clientes.campos_extra`**, que es exactamente para
+esto, y se filtra una sola vez arriba de todos los segmentos para que no
+haya forma de agregar uno que se lo saltee.
+
+`telWhatsapp` en `src/utils/helpers.js` arma el número: `wa.me` necesita
+código de país y el `9` de celular, y los teléfonos se cargan como los
+dicta la gente. Sin eso el link abre un chat con nadie, que es lo que
+venía pasando en la agenda y en la ficha.
 
 ## Lo que ya funciona y no hay que rehacer
 

--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -119,6 +119,7 @@ Lo que toca varias tablas a la vez vive en Postgres, no en el navegador:
 | `estadisticas_pedidos(...)` | Pedidos, ventas, tiempos y evolución de un período. |
 | `informe_ocupacion(...)` | Cuánto de lo que se podía vender se vendió, por profesional y por sala. Ver abajo. |
 | `crm_segmentos(uuid)` | A quién conviene escribirle y por qué. Ver abajo. |
+| `comunicaciones_pendientes(...)` | Los turnos que vienen y todavía no tienen su aviso. |
 | `sembrar_canales(uuid)` | Los canales con los que arranca un comercio. |
 | `enviar_a_cocina(uuid)` | Despacha solo lo que falta despachar. |
 | `aplicar_descuento(...)` | Por porcentaje o por importe. |
@@ -275,6 +276,38 @@ haya forma de agregar uno que se lo saltee.
 código de país y el `9` de celular, y los teléfonos se cargan como los
 dicta la gente. Sin eso el link abre un chat con nadie, que es lo que
 venía pasando en la agenda y en la ficha.
+
+## Comunicaciones
+
+CRM contesta a quién conviene escribirle esta semana; esto contesta a
+quién hay que avisarle algo ahora. Son dos módulos porque son dos
+trabajos: recepción manda los recordatorios de mañana cada tarde, y el
+dueño mira lo de CRM una vez por semana. Meterlos en la misma pantalla
+sepulta la tarea diaria debajo de la semanal.
+
+**Una sola tabla de mensajes**, `contactos`, para los dos. Dos registros
+de mensajes enviados es la forma más rápida de no saber nunca si a
+alguien ya se le escribió.
+
+**Se avisa por turno, no por persona.** Por eso `contactos` tiene
+`reserva_id`. Sin él, saber si a alguien ya se le recordó su turno del
+martes sería mirar si se le escribió "hace poco", y con dos turnos en la
+misma semana eso falla siempre. Una clase manda un mensaje por anotado; la
+clase en sí no se avisa, no tiene a quién.
+
+**Un recordatorio no es marketing.** `no contactar` frena todo lo de CRM y
+no frena esto: quien pidió que no le manden promociones no pidió que no le
+avisen que mañana tiene turno a las nueve.
+
+**Las plantillas guardan lo que se cambió, no todo.** Los textos de
+fábrica están en `src/datos/comunicaciones.js`; la tabla `plantillas`
+guarda solo los que el comercio reescribió. Un comercio nuevo funciona el
+primer día sin semilla, "volver al original" es borrar una fila, y si
+mañana ese texto mejora, el que nunca lo tocó se lleva la mejora.
+
+**Un hueco que no existe se deja escrito.** `{profe}` en vez de
+`{profesional}` aparece tal cual en la vista previa y se corrige solo;
+borrarlo en silencio manda un mensaje mocho sin ninguna pista de por qué.
 
 ## Lo que ya funciona y no hay que rehacer
 

--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -117,6 +117,7 @@ Lo que toca varias tablas a la vez vive en Postgres, no en el navegador:
 | `registrar_pago(...)` | Un pago sobre una cuenta abierta. Dividir es esto, varias veces. |
 | `mover_pedido(...)` | Cambia el estado: valida el flujo del canal, mueve la cocina y deja historial. |
 | `estadisticas_pedidos(...)` | Pedidos, ventas, tiempos y evolución de un período. |
+| `informe_ocupacion(...)` | Cuánto de lo que se podía vender se vendió, por profesional y por sala. Ver abajo. |
 | `sembrar_canales(uuid)` | Los canales con los que arranca un comercio. |
 | `enviar_a_cocina(uuid)` | Despacha solo lo que falta despachar. |
 | `aplicar_descuento(...)` | Por porcentaje o por importe. |
@@ -205,6 +206,42 @@ Los cuatro huecos que tenía el sistema quedaron cerrados: estado propio
 del pedido (0021), historial de transiciones (0021), tiempo real (0022) y
 canales como filas (0020).
 
+## El informe de un negocio de servicios
+
+`src/modulos/Informes.jsx` es el informe del rubro servicios.
+`Reportes.jsx` sigue siendo el del minimercado y el bar y **no se toca**:
+son dos módulos distintos porque no comparten una sola métrica. Uno mira
+margen por producto; el otro, horas. Misma decisión que Finanzas: una
+clave nueva en el menú del rubro antes que un `if` adentro de una
+pantalla compartida.
+
+Tres cosas que conviene no romper:
+
+**Un abono no es un turno.** Un pack es plata que entró hoy por horas que
+se van a dar en ocho semanas. Mezclarlos hace que un mes de muchas
+renovaciones parezca un mes de mucha actividad, y el siguiente un
+derrumbe. Por eso el corte entre abonos y turnos está arriba del gráfico
+y no escondido.
+
+**Hay dos ocupaciones y las dos son ciertas.** Una sala de mat para ocho
+con tres personas adentro está usada el 100% del tiempo y al 37% de su
+capacidad. La primera dice si hay lugar para abrir otra clase; la
+segunda, si esa clase conviene que exista. `informe_ocupacion` devuelve
+las dos y la pantalla las muestra separadas.
+
+**Una clase ocupa una vez.** Seis inscripciones a la misma clase de
+reformer no son seis horas de sala: son una. Es el mismo criterio con el
+que `liquidar` cuenta las horas del equipo, y tiene que seguir siendo el
+mismo: si dejan de coincidir, la ocupación de una profesora y lo que se
+le paga cuentan cosas distintas del mismo día de trabajo.
+
+Las horas que ofrece una **sala** salen de cuándo abre el local —de la
+primera a la última hora en que hay alguien trabajando ese día—, porque
+nadie carga el horario de una sala: se carga el de la gente. Si algún día
+se cargan horarios propios de un espacio, mandan esos.
+
+**Este módulo usa la fecha real**, no el `HOY` congelado del prototipo.
+
 ## Lo que ya funciona y no hay que rehacer
 
 Comandas de salón y mostrador, centro de pedidos con estados reales y
@@ -219,6 +256,18 @@ venta, bitácora automática.
 `supabase/seed/pedidos.sql` siembra un mediodía de pedidos en el Bar
 Rivadavia para poder mirar el tablero lleno. Queda marcado y se borra con
 `delete from operaciones where campos_extra->>'demo' = 'pedidos'`.
+
+`supabase/seed/almha_historia.sql` le da a Almha cuatro meses enteros de
+operación —clientes, turnos, clases, abonos, ventas, caja y
+liquidaciones— armados sobre el catálogo que ya tiene cargado. Se niega a
+correr si el comercio no está marcado `demo` en su configuración, que es
+la regla del proyecto puesta donde sirve y no en un comentario. El azar
+va sembrado con `setseed`, así que dos corridas dan lo mismo y una
+captura de pantalla sigue valiendo.
+
+Arranca el 1 de un mes y no "hace 120 días": con la ventana corrida, el
+primer mes queda cortado por la mitad y el informe mensual muestra una
+caída que nunca pasó.
 
 `supabase/seed/salon.sql` dibuja el local del Bar Rivadavia —paredes,
 barra, cocina, terraza y dieciocho mesas— para que el mapa se vea como un

--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -120,6 +120,7 @@ Lo que toca varias tablas a la vez vive en Postgres, no en el navegador:
 | `informe_ocupacion(...)` | Cuánto de lo que se podía vender se vendió, por profesional y por sala. Ver abajo. |
 | `crm_segmentos(uuid)` | A quién conviene escribirle y por qué. Ver abajo. |
 | `comunicaciones_pendientes(...)` | Los turnos que vienen y todavía no tienen su aviso. |
+| `permisos_de(uuid)` / `permiso(text)` | Qué puede hacer alguien. Lo que consultan las políticas. Ver abajo. |
 | `sembrar_canales(uuid)` | Los canales con los que arranca un comercio. |
 | `enviar_a_cocina(uuid)` | Despacha solo lo que falta despachar. |
 | `aplicar_descuento(...)` | Por porcentaje o por importe. |
@@ -308,6 +309,46 @@ mañana ese texto mejora, el que nunca lo tocó se lleva la mejora.
 **Un hueco que no existe se deja escrito.** `{profe}` en vez de
 `{profesional}` aparece tal cual en la vista previa y se corrige solo;
 borrarlo en silencio manda un mensaje mocho sin ninguna pista de por qué.
+
+## Los permisos
+
+Los roles salían de una constante de JavaScript. Ahora salen de la base,
+y no por prolijidad: **las políticas de RLS los tienen que poder leer**.
+Un permiso que solo existe en el navegador no protege nada.
+
+`roles_base` son los cuatro de fábrica y es dato de plataforma, como
+`rubros`. `roles` guarda **solo lo que cada comercio cambió** y se fusiona
+encima. Volver al original es borrar la fila, así una corrección futura de
+un valor de fábrica llega sola al que nunca lo tocó.
+
+**Ninguna política vuelve a nombrar un rol.** `bitacora_leer` y
+`empresas_configurar` decían `rol in ('dueno', 'encargado')` y ahora
+preguntan por `permiso('verBitacora')` y `permiso('configurar')`. Los
+valores de fábrica dan la misma respuesta para la misma gente, así que
+nada cambió hasta que alguien edite; lo cubre `probar-rls.mjs`.
+
+`permisos_de(perfil)` toma el perfil por parámetro en vez de mirar solo
+`auth.uid()`. Es lo que permite probarla —una función que solo se puede
+ejecutar "siendo" cada rol no se prueba, se cruza los dedos— y lo que la
+pantalla necesita para dibujar la grilla entera. Es `security definer`
+porque lee `perfiles` y `roles`, y por eso se limita a sí mismo o a
+perfiles que el que pregunta ya puede ver.
+
+**Dos de los ocho permisos los verifica la base y seis son de pantalla.**
+Está dicho así en la interfaz, con un candado al lado de los dos pesados:
+quien configura tiene que saber si está apagando un botón o cerrando una
+puerta.
+
+**No se puede uno dejar afuera.** Un disparador impide sacarle
+`configurar` al rol propio. Está en la base y no en la pantalla porque una
+validación de pantalla la saltea cualquier otro camino.
+
+**Y cambiar un permiso queda en la bitácora**, con qué había antes y qué
+quedó. Un módulo de permisos sin rastro sería el único que no se puede
+auditar.
+
+`bitacora` existía desde 0007 y nunca había tenido pantalla: se escribía
+y no la leía nadie. La pestaña de Auditoría es esa lectura.
 
 ## Lo que ya funciona y no hay que rehacer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,17 +110,26 @@ luz. Fuera de eso, refrescar pierde lo que esté en memoria.
 
 ## Permisos
 
-`permisosDe(sesion)` cruza dos cosas: los módulos que el **comercio contrató**
-(`comercio.modulos`) y los que el **rol** habilita (`ROLES`). Un módulo no contratado
-no lo ve ni el dueño. `MODULOS_BASE` (cobro, caja, ajustes) no se puede desactivar.
-Los flags finos (`verCostos`, `descuentos`, `anular`, `cerrarCaja`, `cambiarPrecios`)
-viajan como `permisos` hasta los componentes.
+`permisosDe(sesion, roles)` cruza dos cosas: los módulos que el **comercio
+contrató** (`comercio.modulos`) y los que el **rol** habilita. Un módulo no
+contratado no lo ve ni el dueño. `MODULOS_BASE` (cobro, caja, ajustes) no se puede
+desactivar. Las banderas finas (`verCostos`, `descuentos`, `anular`, `cerrarCaja`,
+`cambiarPrecios`, `ajustes`, `verBitacora`, `configurar`) viajan como `permisos`
+hasta los componentes.
 
-Al agregar un módulo nuevo hay que tocar `MODULOS`, `NAV`, `TITULOS`, el `ROLES`
-correspondiente y el switch de `tab` en `Sistema`.
+**Los roles ya no están en el código.** Salen de `roles_base` (los cuatro de
+fábrica, dato de plataforma) más `roles` (lo que cada comercio cambió). La
+constante `ROLES` de `PanelGenez.jsx` sigue existiendo pero solo como respaldo,
+por si la consulta no llegó. Se editan desde el módulo Permisos.
+
+Al agregar un módulo nuevo hay que tocar `MODULOS`, el `menu` del rubro en la
+base, el arreglo `modulos` del rol en `roles_base` si corresponde, y el switch de
+`tab` en `Sistema`. `NAV` y `TITULOS` ya no existen: el menú es dato.
 
 Esto es la pantalla, no la seguridad: **lo que protege los datos es RLS**. Un permiso
-de UI que no tenga su política atrás no protege nada.
+de UI que no tenga su política atrás no protege nada. De las ocho banderas, dos
+—`verBitacora` y `configurar`— las verifica la base con `permiso()`; las otras seis
+apagan botones. Ver `ARQUITECTURA.md`.
 
 ## Lector de códigos de barras
 

--- a/scripts/probar-comanda.mjs
+++ b/scripts/probar-comanda.mjs
@@ -22,6 +22,15 @@ const env = Object.fromEntries(
 
 const c = new pg.Client({ connectionString: env.SUPABASE_DB_URL });
 await c.connect();
+/* Desde cuándo corre esta prueba, según el reloj de la base y no el de
+   Node. Lo usa la limpieza del final para borrar de la bitácora solo lo
+   que escribió esta corrida.
+
+   Antes se borraba por acción —o directamente entera— y eso se llevaba
+   puesto el registro de los tres comercios. Daba igual mientras nadie la
+   leyera; desde que la auditoría tiene pantalla, es destruir un dato
+   real cada vez que alguien corre las pruebas. */
+const arranque = (await c.query("select now() as t")).rows[0].t;
 
 const una = async (sql, args = []) => (await c.query(sql, args)).rows[0];
 let fallas = 0;
@@ -162,8 +171,9 @@ for (const id of [comanda.id, otra.id]) {
   await c.query("delete from operaciones where id = $1", [id]);
 }
 await c.query("delete from sesiones_caja where id = $1", [sesion.id]);
-await c.query("delete from bitacora where accion like 'comanda.%'");
+await c.query("delete from bitacora where fecha >= $1", [arranque]);
 
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien. Base como estaba.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;
+

--- a/scripts/probar-descuento.mjs
+++ b/scripts/probar-descuento.mjs
@@ -19,6 +19,15 @@ const env = Object.fromEntries(
 
 const c = new pg.Client({ connectionString: env.SUPABASE_DB_URL });
 await c.connect();
+/* Desde cuándo corre esta prueba, según el reloj de la base y no el de
+   Node. Lo usa la limpieza del final para borrar de la bitácora solo lo
+   que escribió esta corrida.
+
+   Antes se borraba por acción —o directamente entera— y eso se llevaba
+   puesto el registro de los tres comercios. Daba igual mientras nadie la
+   leyera; desde que la auditoría tiene pantalla, es destruir un dato
+   real cada vez que alguien corre las pruebas. */
+const arranque = (await c.query("select now() as t")).rows[0].t;
 const una = async (s, a = []) => (await c.query(s, a)).rows[0];
 let fallas = 0;
 const decir = (ok, t) => { if (!ok) fallas++; console.log(`  ${ok ? "ok " : "MAL"}  ${t}`); };
@@ -91,8 +100,9 @@ await c.query("delete from movimientos_caja where operacion_id = $1", [cm.id]);
 await c.query("delete from operacion_lineas where operacion_id = $1", [cm.id]);
 await c.query("delete from operaciones where id = $1", [cm.id]);
 await c.query("delete from sesiones_caja where id = $1", [ses.id]);
-await c.query("delete from bitacora");
+await c.query("delete from bitacora where fecha >= $1", [arranque]);
 
 console.log(fallas ? `\n${fallas} fallaron.` : "\nTodo bien. Base como estaba.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;
+

--- a/scripts/probar-pedidos.mjs
+++ b/scripts/probar-pedidos.mjs
@@ -22,6 +22,15 @@ const env = Object.fromEntries(
 
 const c = new pg.Client({ connectionString: env.SUPABASE_DB_URL });
 await c.connect();
+/* Desde cuándo corre esta prueba, según el reloj de la base y no el de
+   Node. Lo usa la limpieza del final para borrar de la bitácora solo lo
+   que escribió esta corrida.
+
+   Antes se borraba por acción —o directamente entera— y eso se llevaba
+   puesto el registro de los tres comercios. Daba igual mientras nadie la
+   leyera; desde que la auditoría tiene pantalla, es destruir un dato
+   real cada vez que alguien corre las pruebas. */
+const arranque = (await c.query("select now() as t")).rows[0].t;
 
 const una = async (sql, args = []) => (await c.query(sql, args)).rows[0];
 const hechos = [];
@@ -215,8 +224,9 @@ for (const id of hechos) {
   await c.query("delete from operaciones where id = $1", [id]);
 }
 await c.query("delete from sesiones_caja where id = $1", [sesion.id]);
-await c.query("delete from bitacora where accion = 'pedido.estado'");
+await c.query("delete from bitacora where fecha >= $1", [arranque]);
 
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien. Base como estaba.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;
+

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -1295,6 +1295,109 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   Permisos configurables
+
+   Lo primero que hay que probar no es lo nuevo: es que lo viejo siga
+   dando lo mismo. Dos políticas dejaron de nombrar roles a mano y
+   pasaron a preguntar por un permiso, y si los valores de fábrica no
+   reprodujeran exactamente lo de antes, tres comercios en producción
+   cambiarían de comportamiento sin que nadie lo pidiera.
+   ------------------------------------------------------------ */
+console.log("\nPermisos configurables");
+
+{
+  /* La matriz de fábrica es la que estaba escrita en el código: dueño y
+     encargado leen la bitácora y configuran; cajero y repositor no. */
+  const base = await una(`
+    select
+      bool_and((permisos ->> 'verBitacora')::boolean) filter (where clave in ('dueno','encargado')) as mandan_ven,
+      bool_or((permisos ->> 'verBitacora')::boolean)  filter (where clave in ('cajero','repositor')) as otros_ven,
+      bool_and((permisos ->> 'configurar')::boolean)  filter (where clave in ('dueno','encargado')) as mandan_config,
+      bool_or((permisos ->> 'configurar')::boolean)   filter (where clave in ('cajero','repositor')) as otros_config
+    from roles_base`);
+  decir(base.mandan_ven === true && base.otros_ven === false,
+    "los valores de fábrica dan la misma respuesta que el viejo rol in ('dueno','encargado')");
+  decir(base.mandan_config === true && base.otros_config === false,
+    "y lo mismo para configurar el comercio");
+
+  await comoUsuario(MOZO, async () => {
+    const yo = await una("select public.permiso('verBitacora') v, public.permiso('configurar') c");
+    decir(yo.v === true && yo.c === true, "un dueño sigue viendo la bitácora y configurando");
+
+    const antes = await una("select count(*)::int n from bitacora where empresa_id = $1", [barId]);
+    decir(antes.n >= 0, `lee la bitácora de su comercio (${antes.n} registros)`);
+
+    /* Ahora se le apaga a su propio rol el permiso de ver la bitácora.
+       Es lo que el módulo permite hacer, y la política tiene que
+       enterarse sin que nadie toque una línea de SQL. */
+    await c.query(
+      `insert into roles (empresa_id, clave, permisos) values ($1, 'dueno', '{"verBitacora": false}'::jsonb)`,
+      [barId]);
+
+    const despues = await una("select count(*)::int n from bitacora where empresa_id = $1", [barId]);
+    decir(despues.n === 0, "apagando el permiso, la bitácora deja de verse");
+    decir((await una("select public.permiso('verBitacora') v")).v === false,
+      "y el permiso da falso, no solo la lista vacía");
+
+    /* Volver al original es borrar la fila, no copiar el texto de
+       fábrica: así una corrección futura llega sola. */
+    await c.query("delete from roles where empresa_id = $1 and clave = 'dueno'", [barId]);
+    const vuelta = await una("select count(*)::int n from bitacora where empresa_id = $1", [barId]);
+    /* Vuelve a verse, y con dos registros más: el cambio y la vuelta
+       atrás. Que el propio módulo de permisos deje rastro de las dos
+       cosas es la mitad de para qué existe. */
+    decir(vuelta.n === antes.n + 2,
+      `borrando el cambio vuelve a verse, con los dos actos anotados (${antes.n} → ${vuelta.n})`);
+
+    /* El accidente que este módulo habilita, y que la base impide. */
+    /* Con savepoint: el rechazo aborta la transacción, y sin volver a un
+       punto guardado todo lo que sigue falla con "transaction is
+       aborted" y la prueba miente diciendo que hay diez errores. */
+    let rechazado = false;
+    await c.query("savepoint intento");
+    try {
+      await c.query(
+        `insert into roles (empresa_id, clave, permisos) values ($1, 'dueno', '{"configurar": false}'::jsonb)`,
+        [barId]);
+      await c.query("release savepoint intento");
+    } catch (e) {
+      rechazado = e.code === "P0070";
+      await c.query("rollback to savepoint intento");
+    }
+    decir(rechazado, "no se puede uno sacar el permiso de configurar a sí mismo");
+
+    /* A otro rol sí: es el punto del módulo. */
+    await c.query(
+      `insert into roles (empresa_id, clave, permisos) values ($1, 'cajero', '{"descuentos": true}'::jsonb)`,
+      [barId]);
+    const cajero = await una(
+      `select ((select permisos from roles_base where clave = 'cajero')
+               || (select permisos from roles where empresa_id = $1 and clave = 'cajero')) ->> 'descuentos' as d`,
+      [barId]);
+    decir(cajero.d === "true", "a otro rol sí se le puede cambiar una bandera");
+
+    /* Y queda escrito quién lo hizo. Un módulo de permisos sin rastro es
+       el único que no se puede auditar. */
+    /* Se busca el acto concreto y no "el último": adentro de una
+       transacción `now()` es el mismo para todas las filas, así que
+       ordenar por fecha entre tres registros hermanos devuelve
+       cualquiera de los tres. */
+    const anotado = await una(
+      `select count(*)::int n, max(detalle -> 'despues' ->> 'descuentos') as valor
+         from bitacora
+        where empresa_id = $1 and accion = 'permisos.cambiar' and detalle ->> 'rol' = 'cajero'`,
+      [barId]);
+    decir(anotado.n === 1 && anotado.valor === "true",
+      "el cambio de permisos queda en la bitácora, con qué se cambió");
+  });
+
+  await comoUsuario(CAJERO, async () => {
+    const v = await una("select count(*)::int n from roles where empresa_id = $1", [barId]);
+    decir(v.n === 0, "un comercio no ve los roles de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -1204,6 +1204,97 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   Comunicaciones
+
+   Lo que importa acá es la unidad: se avisa por turno y no por persona.
+   Confundir las dos cosas hace que alguien con dos turnos en la semana
+   reciba un solo recordatorio, y falte al otro.
+   ------------------------------------------------------------ */
+console.log("\nComunicaciones");
+
+if (ALMHA) {
+  await comoUsuario(PLATAFORMA, async () => {
+    const cuando = (horas) => new Date(Date.now() + horas * 3600000).toISOString();
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social, tel) values ($1, 'Por avisar', '11 3333 3333') returning id`,
+      [ALMHA.id]);
+
+    const nuevo = async (horas, estado) => (await una(
+      `insert into reservas (empresa_id, cliente_id, nombre, desde, duracion_min, estado)
+       values ($1, $2, 'Por avisar', $3, 60, $4) returning id`,
+      [ALMHA.id, cli.id, cuando(horas), estado])).id;
+
+    const mios = async (horas) => (await una(
+      "select count(*)::int n from comunicaciones_pendientes($1, $2) where cliente_id = $3",
+      [ALMHA.id, horas, cli.id])).n;
+
+    const martes = await nuevo(20, "confirmada");
+    const jueves = await nuevo(60, "pendiente");
+
+    decir(await mios(24) === 1, "en la ventana de 24 horas entra solo el turno de mañana");
+    decir(await mios(72) === 2, "con la ventana más ancha entran los dos");
+
+    /* Un turno pasado no se recuerda, y uno cancelado tampoco. */
+    await nuevo(-5, "confirmada");
+    const cancelado = await nuevo(10, "confirmada");
+    await c.query("update reservas set estado = 'cancelada' where id = $1", [cancelado]);
+    decir(await mios(72) === 2, "ni lo que ya pasó ni lo cancelado se avisa");
+
+    /* Avisado el del martes, sigue apareciendo el del jueves: la unidad
+       es el turno y no el cliente. */
+    await c.query(
+      `insert into contactos (empresa_id, cliente_id, reserva_id, motivo, texto)
+       values ($1, $2, $3, 'recordatorio', 'Hola!')`, [ALMHA.id, cli.id, martes]);
+
+    decir(await mios(72) === 1, "el turno avisado sale de la lista");
+    const queda = await una(
+      "select reserva_id from comunicaciones_pendientes($1, 72) where cliente_id = $2",
+      [ALMHA.id, cli.id]);
+    decir(queda.reserva_id === jueves, "el otro turno del mismo cliente sigue esperando su aviso");
+
+    /* "No contactar" frena el marketing, no un recordatorio de turno. */
+    await c.query(
+      `update clientes set campos_extra = '{"noContactar": true}'::jsonb where id = $1`, [cli.id]);
+    decir(await mios(72) === 1, "no contactar no frena el recordatorio de un turno");
+
+    /* Una clase manda un mensaje por anotado, no uno solo. */
+    const clase = (await una(
+      `insert into reservas (empresa_id, nombre, personas, desde, duracion_min, estado, cupo)
+       values ($1, 'Clase de aviso', 0, $2, 60, 'confirmada', 4) returning id`,
+      [ALMHA.id, cuando(30)])).id;
+    for (let i = 1; i <= 2; i++) {
+      await c.query(
+        `insert into reservas (empresa_id, clase_id, cliente_id, nombre, personas, desde, duracion_min, estado)
+         values ($1, $2, $3, 'Anotada', 1, $4, 60, 'confirmada')`,
+        [ALMHA.id, clase, cli.id, cuando(30)]);
+    }
+    const deLaClase = await una(
+      "select count(*)::int n from comunicaciones_pendientes($1, 72) where reserva_id in (select id from reservas where clase_id = $2)",
+      [ALMHA.id, clase]);
+    decir(deLaClase.n === 2, "una clase avisa a cada anotado, no una sola vez");
+    const contenedor = await una(
+      "select count(*)::int n from comunicaciones_pendientes($1, 72) where reserva_id = $2",
+      [ALMHA.id, clase]);
+    decir(contenedor.n === 0, "la clase en sí no se avisa: no tiene a quién");
+
+    /* Una plantilla propia pisa la de fábrica y se puede volver atrás. */
+    await c.query(
+      `insert into plantillas (empresa_id, clave, texto) values ($1, 'recordatorio', 'Texto propio')`,
+      [ALMHA.id]);
+    const p = await una(
+      "select texto from plantillas where empresa_id = $1 and clave = 'recordatorio'", [ALMHA.id]);
+    decir(p.texto === "Texto propio", "el comercio puede reescribir una plantilla");
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from comunicaciones_pendientes($1, 72)", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve los turnos por avisar de otro");
+    const p = await una("select count(*)::int n from plantillas where empresa_id = $1", [ALMHA.id]);
+    decir(p.n === 0, "un comercio no ve las plantillas de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -980,6 +980,63 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   15 · La ficha del cliente
+
+   Lo que se prueba son las cuentas: que "vino tantas veces y faltó
+   tantas" salga de los turnos y no de un contador, y que la asistencia no
+   se hunda por los turnos que todavía no pasaron.
+   ------------------------------------------------------------ */
+console.log("\nFicha del cliente");
+
+if (ALMHA) {
+  await comoUsuario(PLATAFORMA, async () => {
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social, tel) values ($1, 'Ficha de prueba', '11 5555 5555') returning id`,
+      [ALMHA.id]);
+
+    const vacia = await una(
+      "select turnos, asistio, ausencias, asistencia, gastado::float g, alertas from clientes_vista where id = $1", [cli.id]);
+    decir(Number(vacia.turnos) === 0 && vacia.asistencia === null,
+      "un cliente sin turnos no tiene asistencia que mostrar");
+
+    /* Tres turnos pasados: dos vino y uno faltó. Y uno futuro, que no
+       tiene que contar en la asistencia. */
+    const cuando = (dias) => new Date(Date.now() + dias * 86400000).toISOString();
+    for (const [d, e] of [[-30, "cumplida"], [-20, "cumplida"], [-10, "ausente"], [10, "confirmada"]]) {
+      await c.query(
+        `insert into reservas (empresa_id, cliente_id, nombre, desde, duracion_min, estado)
+         values ($1, $2, 'Ficha de prueba', $3, 60, $4)`,
+        [ALMHA.id, cli.id, cuando(d), e]);
+    }
+
+    const v = await una(
+      "select turnos, asistio, ausencias, asistencia::float a, ultima, proxima from clientes_vista where id = $1", [cli.id]);
+    decir(Number(v.turnos) === 4, `cuenta todos los turnos (${v.turnos})`);
+    decir(Number(v.asistio) === 2 && Number(v.ausencias) === 1, "separa los que vino de los que faltó");
+    decir(Math.abs(v.a - 2 / 3) < 0.01,
+      `la asistencia no cuenta los turnos futuros (${Math.round(v.a * 100)}%)`);
+    decir(!!v.ultima && !!v.proxima, "sabe cuándo vino la última vez y cuándo vuelve");
+
+    /* Una alerta es lo que hay que ver antes de atenderla. */
+    await c.query(
+      `insert into cliente_notas (empresa_id, cliente_id, texto, destacada)
+       values ($1, $2, 'Alérgica al glicólico', true)`, [ALMHA.id, cli.id]);
+    await c.query(
+      `insert into cliente_notas (empresa_id, cliente_id, texto) values ($1, $2, 'Prefiere a Carla')`,
+      [ALMHA.id, cli.id]);
+
+    const n = await una("select notas, alertas from clientes_vista where id = $1", [cli.id]);
+    decir(Number(n.notas) === 2 && Number(n.alertas) === 1,
+      "distingue una nota común de una que hay que ver antes");
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from cliente_notas where empresa_id = $1", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve las notas de los clientes de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -1037,6 +1037,86 @@ if (ALMHA) {
   });
 }
 
+/* ------------------------------------------------------------
+   Ocupación
+
+   El número propio de un negocio de turnos: cuánto de lo que se podía
+   vender se vendió. Se prueba sobre una profesional inventada dentro de
+   una transacción que se descarta, y en una ventana de fechas donde no
+   hay nada cargado: así lo que devuelve la función es solo lo que puso
+   esta prueba y no se mezcla con la historia de ejemplo de Almha.
+   ------------------------------------------------------------ */
+console.log("\nOcupación");
+
+if (ALMHA) {
+  await comoUsuario(PLATAFORMA, async () => {
+    /* Bien lejos de la agenda sembrada, que llega hasta dos semanas. */
+    const { dia } = await una("select (current_date + 200)::date as dia");
+    const leer = async () => await una(
+      `select ofrecidos::float o, ocupados::float u, lugares::float l, tomados::float t
+         from informe_ocupacion($1, $2, $2) where nombre = 'Profe de prueba'`,
+      [ALMHA.id, dia]);
+
+    const per = await una(
+      `insert into personal (empresa_id, nombre, tipo, especialidad, modalidad, valor)
+       values ($1, 'Profe de prueba', 'profesional', 'Pilates', 'hora', 1000) returning id`,
+      [ALMHA.id]);
+
+    await c.query(
+      `insert into horarios (empresa_id, personal_id, dia, desde, hasta)
+       values ($1, $2, extract(dow from $3::date)::smallint, '09:00', '13:00')`,
+      [ALMHA.id, per.id, dia]);
+
+    const a = await leer();
+    decir(a.o === 240, `las horas ofrecidas salen del horario cargado (${a.o / 60} hs)`);
+    decir(a.u === 0, "sin nada agendado no hay nada ocupado");
+
+    /* Una clase de seis con tres anotados. La clase ocupa la sala una
+       hora, no tres: si se contaran las inscripciones, la ocupación de
+       una profesora y las horas que se le liquidan contarían cosas
+       distintas del mismo día de trabajo. */
+    const clase = await una(
+      `insert into reservas (empresa_id, personal_id, nombre, personas, desde, duracion_min, estado, cupo)
+       values ($1, $2, 'Clase de prueba', 0, $3::date + time '10:00', 60, 'confirmada', 6) returning id`,
+      [ALMHA.id, per.id, dia]);
+
+    for (let i = 0; i < 3; i++) {
+      await c.query(
+        `insert into reservas (empresa_id, personal_id, clase_id, nombre, personas, desde, duracion_min, estado)
+         values ($1, $2, $3, 'Anotada', 1, $4::date + time '10:00', 60, 'confirmada')`,
+        [ALMHA.id, per.id, clase.id, dia]);
+    }
+
+    const b = await leer();
+    decir(b.u === 60, `una clase ocupa una vez y no una por alumno (${b.u} min)`);
+    decir(b.l === 6 && b.t === 3, "los lugares de la clase se cuentan aparte de las horas (3 de 6)");
+
+    /* Un turno cancelado dejó el lugar libre: no ocupa. */
+    await c.query(
+      `insert into reservas (empresa_id, personal_id, nombre, personas, desde, duracion_min, estado)
+       values ($1, $2, 'Se canceló', 1, $3::date + time '12:00', 60, 'cancelada')`,
+      [ALMHA.id, per.id, dia]);
+
+    const d = await leer();
+    decir(d.u === 60, "lo cancelado no ocupa");
+
+    /* Media jornada de ausencia tiene que restar media jornada, no el
+       día entero: por eso la resta es una intersección de intervalos. */
+    await c.query(
+      `insert into excepciones (empresa_id, personal_id, desde, hasta, motivo)
+       values ($1, $2, $3::date + time '09:00', $3::date + time '11:00', 'ausencia')`,
+      [ALMHA.id, per.id, dia]);
+
+    const e = await leer();
+    decir(e.o === 120, `una ausencia resta solo las horas que pisa (${e.o / 60} hs)`);
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from informe_ocupacion($1, current_date - 30, current_date)", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve la ocupación de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -554,9 +554,15 @@ if (!ALMHA) {
     "select id from recursos where empresa_id = $1 order by orden limit 1", [ALMHA.id]);
   const SERVICIO = await una(
     "select id, duracion_min from items where empresa_id = $1 and tipo = 'servicio' limit 1", [ALMHA.id]);
-  /* Un lunes a las 9 hora de Buenos Aires, que es cuando Sofía trabaja. */
+  /* Un lunes a las 9 hora de Buenos Aires, que es cuando Sofía trabaja,
+     pero dentro de más de medio año. Cuando esto se escribió, Almha no
+     tenía un solo turno cargado y el lunes de esta semana estaba libre;
+     al sembrarle historia y agenda, la sala pasó a estar ocupada y la
+     prueba empezó a fallar por un choque de verdad. Una prueba de
+     permisos no se puede caer porque el negocio de ejemplo tenga trabajo:
+     se corre en una semana donde no hay nada. */
   const CUANDO = (await una(
-    `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+    `select (date_trunc('week', (now() at time zone 'America/Argentina/Buenos_Aires') + interval '30 weeks')
              + interval '9 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
 
   const turno = (extra = {}) => JSON.stringify({
@@ -665,8 +671,9 @@ if (ALMHA) {
   const GRUPAL = await una(
     `select id from items where empresa_id = $1 and tipo = 'servicio'
        and campos_extra ->> 'modalidad' = 'grupal' limit 1`, [ALMHA.id]);
+  /* Misma semana lejana que arriba, por la misma razón. */
   const CUANDO = (await una(
-    `select (date_trunc('week', now() at time zone 'America/Argentina/Buenos_Aires')
+    `select (date_trunc('week', (now() at time zone 'America/Argentina/Buenos_Aires') + interval '30 weeks')
              + interval '10 hours') at time zone 'America/Argentina/Buenos_Aires' as t`)).t;
 
   await comoUsuario(PLATAFORMA, async () => {
@@ -1114,6 +1121,86 @@ if (ALMHA) {
   await comoUsuario(MOZO, async () => {
     const v = await una("select count(*)::int n from informe_ocupacion($1, current_date - 30, current_date)", [ALMHA.id]);
     decir(v.n === 0, "un comercio no ve la ocupación de otro");
+  });
+}
+
+/* ------------------------------------------------------------
+   CRM
+
+   Lo que se prueba no es que la lista salga: es que se vacíe. Un segmento
+   que devuelve siempre a la misma gente es una pantalla que se deja de
+   abrir a la semana.
+   ------------------------------------------------------------ */
+console.log("\nCRM");
+
+if (ALMHA) {
+  await comoUsuario(PLATAFORMA, async () => {
+    const cuando = (dias) => new Date(Date.now() + dias * 86400000).toISOString();
+    const enSegmento = async (k, cli) => (await una(
+      "select count(*)::int n from crm_segmentos($1) where segmento = $2 and cliente_id = $3",
+      [ALMHA.id, k, cli])).n;
+
+    /* Alguien que vino cinco veces y hace tres meses que no aparece. */
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social, tel) values ($1, 'Se fue', '11 4444 4444') returning id`,
+      [ALMHA.id]);
+    for (const d of [-140, -130, -120, -110, -100]) {
+      await c.query(
+        `insert into reservas (empresa_id, cliente_id, nombre, desde, duracion_min, estado)
+         values ($1, $2, 'Se fue', $3, 60, 'cumplida')`, [ALMHA.id, cli.id, cuando(d)]);
+    }
+
+    decir(await enSegmento("se_van", cli.id) === 1, "el que dejó de venir aparece en la lista");
+
+    /* Un turno futuro lo saca: ya volvió, no hay nada que recuperar. */
+    const proximo = await una(
+      `insert into reservas (empresa_id, cliente_id, nombre, desde, duracion_min, estado)
+       values ($1, $2, 'Se fue', $3, 60, 'confirmada') returning id`,
+      [ALMHA.id, cli.id, cuando(5)]);
+    decir(await enSegmento("se_van", cli.id) === 0, "con un turno agendado deja de aparecer");
+    await c.query("delete from reservas where id = $1", [proximo.id]);
+
+    /* Escribirle lo saca por tres semanas: es lo que hace que la lista se
+       vacíe a medida que se trabaja. */
+    await c.query(
+      `insert into contactos (empresa_id, cliente_id, motivo, texto)
+       values ($1, $2, 'se_van', 'Hola!')`, [ALMHA.id, cli.id]);
+    decir(await enSegmento("se_van", cli.id) === 0, "después de escribirle sale de la lista");
+
+    /* Pero solo por ese motivo: que se le haya avisado de un abono no
+       significa que no haya que decirle que hace rato no viene. */
+    await c.query("update contactos set fecha = now() - interval '30 days' where cliente_id = $1", [cli.id]);
+    decir(await enSegmento("se_van", cli.id) === 1, "al mes vuelve a aparecer");
+
+    await c.query(
+      `insert into contactos (empresa_id, cliente_id, motivo) values ($1, $2, 'abono_vencido')`,
+      [ALMHA.id, cli.id]);
+    decir(await enSegmento("se_van", cli.id) === 1,
+      "un mensaje por otro motivo no lo silencia");
+
+    /* No molestar gana sobre todo lo demás. */
+    await c.query(
+      `update clientes set campos_extra = '{"noContactar": true}'::jsonb where id = $1`, [cli.id]);
+    decir(await enSegmento("se_van", cli.id) === 0, "quien pidió no ser molestado no aparece en ningún segmento");
+
+    /* Dos abonos vencidos son un mensaje, no dos. */
+    const dos = await una(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Dos abonos') returning id`, [ALMHA.id]);
+    for (const d of [-25, -10]) {
+      await c.query(
+        `insert into abonos (empresa_id, cliente_id, nombre, clases, desde, vence)
+         values ($1, $2, 'Pack 8 clases', 8, current_date - 60, current_date + $3::int)`,
+        [ALMHA.id, dos.id, d]);
+    }
+    decir(await enSegmento("abono_vencido", dos.id) === 1,
+      "dos abonos vencidos del mismo cliente son una sola fila");
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from crm_segmentos($1)", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve a los clientes de otro en el CRM");
+    const k = await una("select count(*)::int n from contactos where empresa_id = $1", [ALMHA.id]);
+    decir(k.n === 0, "un comercio no ve los contactos de otro");
   });
 }
 

--- a/scripts/probar-salon.mjs
+++ b/scripts/probar-salon.mjs
@@ -22,6 +22,15 @@ const env = Object.fromEntries(
 
 const c = new pg.Client({ connectionString: env.SUPABASE_DB_URL });
 await c.connect();
+/* Desde cuándo corre esta prueba, según el reloj de la base y no el de
+   Node. Lo usa la limpieza del final para borrar de la bitácora solo lo
+   que escribió esta corrida.
+
+   Antes se borraba por acción —o directamente entera— y eso se llevaba
+   puesto el registro de los tres comercios. Daba igual mientras nadie la
+   leyera; desde que la auditoría tiene pantalla, es destruir un dato
+   real cada vez que alguien corre las pruebas. */
+const arranque = (await c.query("select now() as t")).rows[0].t;
 
 const una = async (sql, args = []) => (await c.query(sql, args)).rows[0];
 let fallas = 0;
@@ -123,8 +132,9 @@ for (const id of limpiar) {
 }
 await c.query("delete from reservas where id = $1", [reserva.id]);
 await c.query("delete from sesiones_caja where id = $1", [sesion.id]);
-await c.query("delete from bitacora where accion like 'reserva.%' or accion like 'mesa.%'");
+await c.query("delete from bitacora where fecha >= $1", [arranque]);
 
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien. Base como estaba.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;
+

--- a/scripts/probar-venta.mjs
+++ b/scripts/probar-venta.mjs
@@ -23,6 +23,15 @@ const env = Object.fromEntries(
 
 const c = new pg.Client({ connectionString: env.SUPABASE_DB_URL });
 await c.connect();
+/* Desde cuándo corre esta prueba, según el reloj de la base y no el de
+   Node. Lo usa la limpieza del final para borrar de la bitácora solo lo
+   que escribió esta corrida.
+
+   Antes se borraba por acción —o directamente entera— y eso se llevaba
+   puesto el registro de los tres comercios. Daba igual mientras nadie la
+   leyera; desde que la auditoría tiene pantalla, es destruir un dato
+   real cada vez que alguien corre las pruebas. */
+const arranque = (await c.query("select now() as t")).rows[0].t;
 
 const una = async (sql, args = []) => (await c.query(sql, args)).rows[0];
 const limpiar = [];
@@ -185,8 +194,9 @@ for (const [tabla, id] of limpiar.reverse()) {
   }
   await c.query(`delete from ${tabla} where id = $1`, [id]);
 }
-await c.query("delete from bitacora");
+await c.query("delete from bitacora where fecha >= $1", [arranque]);
 
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien. Base como estaba.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;
+

--- a/src/Genezapp.jsx
+++ b/src/Genezapp.jsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { Login, ClaveNueva, Sistema, PanelGenez } from "./genez/PanelGenez.jsx";
 import { cargarSesion, cargarComercios, salir, alRecuperarClave } from "./datos/sesion.js";
 import { cargarRubro } from "./datos/rubros.js";
+import { cargarRoles } from "./datos/permisos.js";
 
 /* La sesión sobrevive al refresco: Supabase la guarda en el navegador.
    Mientras se resuelve no se puede mostrar ni el login ni el sistema,
@@ -29,6 +30,7 @@ export default function App() {
   const [iniciando, setIniciando] = useState(true);
   /* undefined = todavía no se sabe. Distinto de null, que es "no tiene". */
   const [rubro, setRubro] = useState(undefined);
+  const [roles, setRoles] = useState(null);
   const [errorInicio, setErrorInicio] = useState("");
   const [recuperando, setRecuperando] = useState(false);
 
@@ -84,6 +86,23 @@ export default function App() {
            respaldo. No vale la pena frenar a nadie por esto. */
         console.error("No se pudo cargar el rubro:", e);
         if (vigente) setRubro(null);
+      });
+    return () => { vigente = false; };
+  }, [comercio && comercio.id]);
+
+  /* Los roles del comercio, por lo mismo que el rubro: deciden qué menú
+     ve la persona. La diferencia es que acá sí se puede seguir sin ellos
+     —`permisosDe` cae en los roles de fábrica, que son los mismos— así
+     que no se frena el arranque esperándolos. Un parpadeo de menú es
+     peor remedio que enfermedad. */
+  useEffect(() => {
+    if (!comercio) { setRoles(null); return; }
+    let vigente = true;
+    cargarRoles(comercio.id)
+      .then((rs) => { if (vigente) setRoles(rs); })
+      .catch((e) => {
+        console.error("No se pudieron cargar los roles:", e);
+        if (vigente) setRoles(null);
       });
     return () => { vigente = false; };
   }, [comercio && comercio.id]);
@@ -153,6 +172,7 @@ export default function App() {
     <Sistema
       key={comercio.id}
       rubro={rubro}
+      roles={roles}
       tema={tema} setTema={setTema}
       sesion={sesionSistema}
       setComercios={setComercios}

--- a/src/datos/clientes.js
+++ b/src/datos/clientes.js
@@ -111,3 +111,163 @@ export async function desactivarCliente(id) {
   const { error } = await supabase.from("clientes").update({ activo: false }).eq("id", id);
   if (error) throw error;
 }
+
+/* ============================================================
+   LA FICHA
+   ============================================================
+
+   En una estética la ficha es la mitad del valor del sistema: qué se le
+   hizo, cuándo, con qué y si hay algo que no se le puede hacer. Ver la
+   migración 0040 para por qué las notas son un cuaderno fechado y no un
+   campo que se pisa.
+   ============================================================ */
+
+const num = (v) => (v === null || v === undefined ? 0 : Number(v));
+
+function conCuentas(f) {
+  return {
+    ...aCliente(f),
+    turnos: num(f.turnos),
+    asistio: num(f.asistio),
+    ausencias: num(f.ausencias),
+    cancelados: num(f.cancelados),
+    asistencia: f.asistencia === null || f.asistencia === undefined ? null : Number(f.asistencia),
+    ultima: f.ultima ? new Date(f.ultima) : null,
+    proxima: f.proxima ? new Date(f.proxima) : null,
+    gastado: num(f.gastado),
+    compras: num(f.compras),
+    abonosActivos: num(f.abonos_activos),
+    notas: num(f.notas),
+    alertas: num(f.alertas),
+  };
+}
+
+/* La lista con las cuentas hechas. Es la misma consulta que la de arriba
+   pero contra la vista: se usa donde importa el resumen y no solo el
+   nombre, como la pantalla de clientes. */
+export async function cargarClientesConCuentas(empresaId) {
+  if (!empresaId) throw new Error("cargarClientesConCuentas necesita saber de qué comercio.");
+
+  const filas = [];
+  for (let desde = 0; ; desde += PAGINA) {
+    const { data, error } = await supabase
+      .from("clientes_vista")
+      .select("*")
+      .eq("empresa_id", empresaId)
+      .eq("activo", true)
+      .order("razon_social")
+      .range(desde, desde + PAGINA - 1);
+    if (error) throw error;
+    filas.push(...data);
+    if (data.length < PAGINA) return filas.map(conCuentas);
+  }
+}
+
+/* Todo lo de una persona, de una. Son cinco consultas y no una sola con
+   joins a propósito: cada cosa tiene su orden y su límite, y un join las
+   multiplicaría entre sí. */
+export async function cargarFicha(empresaId, clienteId) {
+  if (!empresaId || !clienteId) throw new Error("cargarFicha necesita el comercio y el cliente.");
+
+  const [cli, turnos, abonos, ventas, notas] = await Promise.all([
+    supabase.from("clientes_vista").select("*").eq("empresa_id", empresaId).eq("id", clienteId).maybeSingle(),
+
+    supabase.from("agenda_vista")
+      .select("id, desde, duracion_min, estado, servicio, profesional, sala, precio, forma, abono_id")
+      .eq("empresa_id", empresaId).eq("cliente_id", clienteId)
+      .order("desde", { ascending: false }).limit(200),
+
+    supabase.from("abonos_vista")
+      .select("*").eq("empresa_id", empresaId).eq("cliente_id", clienteId)
+      .order("creado_en", { ascending: false }).limit(50),
+
+    supabase.from("operaciones")
+      .select("id, fecha, numero, total, tipo, pagos(monto)")
+      .eq("empresa_id", empresaId).eq("cliente_id", clienteId).eq("estado", "confirmada")
+      .order("fecha", { ascending: false }).limit(100),
+
+    supabase.from("cliente_notas")
+      .select("id, texto, destacada, creada_en")
+      .eq("empresa_id", empresaId).eq("cliente_id", clienteId)
+      .order("creada_en", { ascending: false }).limit(100),
+  ]);
+
+  for (const r of [cli, turnos, abonos, ventas, notas]) if (r.error) throw r.error;
+  if (!cli.data) throw new Error("No encontramos ese cliente.");
+
+  return {
+    cliente: conCuentas(cli.data),
+
+    turnos: (turnos.data || []).map((t) => ({
+      id: t.id,
+      desde: new Date(t.desde),
+      duracion: t.duracion_min,
+      estado: t.estado,
+      servicio: t.servicio || "",
+      profesional: t.profesional || "",
+      sala: t.sala || "",
+      precio: num(t.precio),
+      forma: t.forma,
+      conAbono: !!t.abono_id,
+    })),
+
+    abonos: (abonos.data || []).map((a) => ({
+      id: a.id,
+      nombre: a.nombre,
+      clases: a.clases,
+      usadas: num(a.usadas),
+      restantes: a.restantes === null || a.restantes === undefined ? null : num(a.restantes),
+      vence: a.vence ? new Date(`${a.vence}T12:00:00`) : null,
+      estado: a.estado,
+    })),
+
+    ventas: (ventas.data || []).map((o) => {
+      const pagado = (o.pagos || []).reduce((s, p) => s + num(p.monto), 0);
+      return {
+        id: o.id,
+        fecha: new Date(o.fecha),
+        numero: o.numero || "",
+        total: num(o.total),
+        pagado,
+        falta: num(o.total) - pagado,
+      };
+    }),
+
+    notas: (notas.data || []).map((x) => ({
+      id: x.id,
+      texto: x.texto,
+      destacada: x.destacada,
+      fecha: new Date(x.creada_en),
+    })),
+  };
+}
+
+export async function anotarEnFicha(empresaId, clienteId, texto, destacada = false) {
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("cliente_notas").insert({
+    empresa_id: empresaId, cliente_id: clienteId,
+    texto, destacada, usuario_id: user ? user.id : null,
+  });
+  if (error) throw error;
+}
+
+export async function borrarNota(id) {
+  const { error } = await supabase.from("cliente_notas").delete().eq("id", id);
+  if (error) throw error;
+}
+
+/* Las alertas de una persona: lo que hay que ver antes de atenderla. Lo
+   usa la agenda al elegir un cliente, no solo la ficha. */
+export async function alertasDe(empresaId, clienteId) {
+  if (!empresaId || !clienteId) return [];
+  const { data, error } = await supabase
+    .from("cliente_notas")
+    .select("id, texto")
+    .eq("empresa_id", empresaId)
+    .eq("cliente_id", clienteId)
+    .eq("destacada", true)
+    .order("creada_en", { ascending: false })
+    .limit(5);
+  if (error) throw error;
+  return data || [];
+}

--- a/src/datos/comunicaciones.js
+++ b/src/datos/comunicaciones.js
@@ -1,0 +1,211 @@
+/* ============================================================
+   COMUNICACIONES · lo que hay que avisar hoy
+   ============================================================
+
+   CRM contesta a quién conviene escribirle esta semana. Esto contesta a
+   quién hay que avisarle algo ahora, que es una tarea de todos los días y
+   la hace otra persona. Ver la migración 0044 para por qué son dos
+   módulos y una sola tabla de mensajes.
+
+   LAS PLANTILLAS SON UN TEXTO CON HUECOS
+   --------------------------------------
+   `{nombre}`, `{fecha}`, `{hora}`, `{servicio}`. Se reemplazan acá y no
+   en la base: el texto lo escribe una persona en un textarea y tiene que
+   poder verlo resuelto mientras lo escribe, sin ida y vuelta al servidor.
+
+   Un hueco que no existe se deja tal cual y no se borra: si alguien
+   escribe `{profe}` y no anda, tiene que verlo en la pantalla. Borrarlo
+   en silencio le deja un mensaje mocho y ninguna pista de por qué.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+import { voz } from "./rubros.js";
+
+const primerNombre = (n) => String(n || "").trim().split(/\s+/)[0] || "";
+
+/* ------------------------------------------------------------
+   Los textos de fábrica
+
+   No están en la base a propósito: un comercio nuevo tiene que poder
+   mandar un recordatorio el primer día sin que nadie le siembre nada, y
+   "volver al original" tiene que ser borrar una fila y no reescribir un
+   texto de memoria.
+
+   Están escritos como los escribe alguien del mostrador: cortos, sin una
+   palabra de sistema y sin mayúsculas de formulario.
+   ------------------------------------------------------------ */
+
+export const PLANTILLAS = [
+  {
+    k: "recordatorio",
+    n: "Recordatorio de turno",
+    d: "El aviso del día anterior. Es el que más se manda y el que evita la mitad de las ausencias.",
+    texto:
+      "Hola {nombre}! Te recuerdo tu turno de {servicio} el {fecha} a las {hora}. " +
+      "Si no vas a poder venir avisame así libero el lugar. ¡Nos vemos!",
+  },
+  {
+    k: "confirmacion",
+    n: "Pedido de confirmación",
+    d: "Para los turnos que todavía figuran sin confirmar.",
+    texto:
+      "Hola {nombre}! Tenés turno de {servicio} el {fecha} a las {hora} con {profesional}. " +
+      "¿Me confirmás que venís? Gracias!",
+  },
+  {
+    k: "cambio",
+    n: "Cambio de horario",
+    d: "Cuando hay que mover un turno ya dado.",
+    texto:
+      "Hola {nombre}! Se nos complicó con el horario del {fecha} a las {hora}. " +
+      "¿Te sirve otro día de esta semana? Decime cuál te queda cómodo y te lo reservo.",
+  },
+  {
+    k: "hueco",
+    n: "Se liberó un lugar",
+    d: "Para ofrecer un lugar que quedó libre a quien está esperando.",
+    texto:
+      "Hola {nombre}! Se liberó un lugar en {servicio} el {fecha} a las {hora}. " +
+      "¿Lo querés? Avisame y te lo guardo.",
+  },
+];
+
+export const plantillaPorK = (k) => PLANTILLAS.find((p) => p.k === k) || PLANTILLAS[0];
+
+/* Los huecos que se pueden usar, con un ejemplo al lado. La pantalla los
+   muestra para que nadie tenga que adivinarlos ni buscarlos en un
+   manual que no existe. */
+export const HUECOS = [
+  { k: "nombre", d: "el primer nombre del cliente" },
+  { k: "fecha", d: "martes 26 de agosto" },
+  { k: "hora", d: "09:00" },
+  { k: "servicio", d: "Pilates Reformer" },
+  { k: "profesional", d: "quién lo atiende" },
+  { k: "sala", d: "dónde es" },
+  { k: "negocio", d: "el nombre del comercio" },
+];
+
+const fechaLarga = (d) =>
+  d.toLocaleDateString("es-AR", { weekday: "long", day: "numeric", month: "long" });
+
+const horaCorta = (d) =>
+  d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+/* Reemplaza los huecos con lo del turno. Lo que no reconoce lo deja
+   escrito: un `{profe}` que aparece tal cual en la vista previa se
+   corrige solo; uno que desaparece manda un mensaje incompleto. */
+export function resolver(texto, turno, ajustes, rubro) {
+  const valores = {
+    nombre: primerNombre(turno.cliente),
+    fecha: turno.desde ? fechaLarga(turno.desde) : "",
+    hora: turno.desde ? horaCorta(turno.desde) : "",
+    servicio: turno.servicio || voz(rubro, "turno", "turno"),
+    profesional: turno.profesional || voz(rubro, "profesional", "profesional"),
+    sala: turno.sala || "",
+    negocio: (ajustes && ajustes.negocio) || "",
+  };
+
+  return String(texto || "").replace(/\{(\w+)\}/g, (todo, k) =>
+    Object.prototype.hasOwnProperty.call(valores, k) ? valores[k] : todo);
+}
+
+/* ------------------------------------------------------------
+   Las lecturas
+   ------------------------------------------------------------ */
+
+export async function cargarPendientes(empresaId, horas = 24) {
+  if (!empresaId) throw new Error("cargarPendientes necesita saber de qué comercio.");
+
+  const { data, error } = await supabase.rpc("comunicaciones_pendientes", {
+    p_empresa: empresaId,
+    p_horas: horas,
+  });
+  if (error) throw error;
+
+  return (data || []).map((f) => ({
+    reservaId: f.reserva_id,
+    clienteId: f.cliente_id,
+    cliente: f.cliente || "",
+    tel: f.tel || "",
+    desde: new Date(f.desde),
+    estado: f.estado,
+    servicio: f.servicio || "",
+    profesional: f.profesional || "",
+    sala: f.sala || "",
+    esClase: !!f.es_clase,
+  }));
+}
+
+/* Las plantillas del comercio, con las de fábrica abajo. Devuelve las
+   cuatro siempre: la pantalla no tiene que saber cuál está guardada y
+   cuál no, solo si fue cambiada —para poder ofrecer volver atrás—. */
+export async function cargarPlantillas(empresaId) {
+  if (!empresaId) throw new Error("cargarPlantillas necesita saber de qué comercio.");
+
+  const { data, error } = await supabase
+    .from("plantillas")
+    .select("clave, texto, actualizada")
+    .eq("empresa_id", empresaId);
+  if (error) throw error;
+
+  const propias = new Map((data || []).map((p) => [p.clave, p]));
+
+  return PLANTILLAS.map((p) => {
+    const mia = propias.get(p.k);
+    return {
+      ...p,
+      texto: mia ? mia.texto : p.texto,
+      original: p.texto,
+      propia: !!mia,
+      actualizada: mia ? new Date(mia.actualizada) : null,
+    };
+  });
+}
+
+/* ------------------------------------------------------------
+   Las escrituras
+   ------------------------------------------------------------ */
+
+export async function guardarPlantilla(empresaId, clave, texto) {
+  if (!empresaId) throw new Error("guardarPlantilla necesita saber de qué comercio.");
+
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase
+    .from("plantillas")
+    .upsert(
+      { empresa_id: empresaId, clave, texto, actualizada: new Date().toISOString(), usuario_id: user ? user.id : null },
+      { onConflict: "empresa_id,clave" });
+  if (error) throw error;
+}
+
+/* Volver al original es borrar la fila y no copiar el texto de fábrica
+   encima: si mañana ese texto mejora, el comercio que nunca lo tocó se
+   lleva la mejora sin hacer nada. */
+export async function restaurarPlantilla(empresaId, clave) {
+  if (!empresaId) throw new Error("restaurarPlantilla necesita saber de qué comercio.");
+
+  const { error } = await supabase
+    .from("plantillas")
+    .delete()
+    .eq("empresa_id", empresaId)
+    .eq("clave", clave);
+  if (error) throw error;
+}
+
+export async function anotarAviso({ empresaId, clienteId, reservaId, motivo = "recordatorio", canal = "whatsapp", texto = null }) {
+  if (!empresaId) throw new Error("anotarAviso necesita saber de qué comercio.");
+
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("contactos").insert({
+    empresa_id: empresaId,
+    cliente_id: clienteId,
+    reserva_id: reservaId,
+    motivo,
+    canal,
+    texto,
+    usuario_id: user ? user.id : null,
+  });
+  if (error) throw error;
+}

--- a/src/datos/crm.js
+++ b/src/datos/crm.js
@@ -1,0 +1,238 @@
+/* ============================================================
+   CRM · a quién conviene escribirle esta semana
+   ============================================================
+
+   No es una base de contactos —eso ya es `clientes`— ni una casilla de
+   mensajes. Es una lista de trabajo: cinco motivos concretos por los que
+   vale la pena escribirle a alguien, con la persona ya elegida y el
+   mensaje ya escrito.
+
+   Los segmentos los arma `crm_segmentos` en la base. Ver la migración
+   0043 para por qué se derivan y no se guardan.
+
+   NADA SE MANDA SOLO
+   ------------------
+   El encargo lo dice y acá se respeta: la única integración de mensajería
+   es abrir WhatsApp con el texto ya cargado. La persona lee, corrige si
+   quiere y aprieta enviar. Un sistema que manda mensajes en nombre de un
+   negocio sin que nadie los lea es una forma rápida de perder clientes.
+
+   Por eso el texto es editable antes de abrir el chat, y por eso lo que
+   queda registrado es lo que se mandó y no lo que la plantilla decía.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+import { voz } from "./rubros.js";
+
+const primerNombre = (n) => String(n || "").trim().split(/\s+/)[0] || "";
+
+/* ------------------------------------------------------------
+   Los cinco motivos
+
+   Cada uno trae su texto por defecto. No son plantillas guardadas —eso
+   es de Comunicaciones— son el punto de partida, y están escritos como
+   los escribiría alguien del mostrador: cortos, en primera persona y sin
+   una sola palabra de sistema.
+
+   `palabras` es lo que cambia por rubro: un estudio de pilates dice
+   "clases" y un consultorio dice "sesiones". Sale de `rubros.voces`, el
+   mismo mecanismo que VOZ_MESA en la comanda.
+   ------------------------------------------------------------ */
+
+export const SEGMENTOS = [
+  {
+    k: "se_van",
+    n: "Hace rato que no vienen",
+    d: "Venían seguido y dejaron de aparecer. Todavía se acuerdan del lugar.",
+    tono: "mal",
+    texto: (c, v) =>
+      `Hola ${primerNombre(c.cliente)}! ¿Cómo va? Te escribo del estudio, ` +
+      `hace un tiempo que no te vemos y queríamos saber cómo andás. ` +
+      `Si querés retomar, decime qué días te quedan cómodos y te busco un lugar. ¡Un abrazo!`,
+  },
+  {
+    k: "sin_segunda",
+    n: "Vinieron una sola vez",
+    d: "Probaron y no volvieron. Es donde se pierde un cliente y donde más barato sale recuperarlo.",
+    tono: "ojo",
+    texto: (c, v) =>
+      `Hola ${primerNombre(c.cliente)}! ¿Cómo estás? Te escribo del estudio. ` +
+      `Viniste una vez y quería saber qué te pareció, si hubo algo que no te cerró ` +
+      `nos sirve un montón que nos lo digas. Y si querés volver, avisame y te reservo lugar.`,
+  },
+  {
+    k: "abono_por_vencer",
+    n: "Se les termina el abono",
+    d: "Renovar antes de que se corte la rutina es mucho más fácil que después.",
+    tono: "info",
+    texto: (c, v) =>
+      `Hola ${primerNombre(c.cliente)}! Te aviso que se te está por terminar el ${v.plan}. ` +
+      `Si querés seguir con los mismos días lo renovamos y no perdés el lugar. ¿Lo dejo listo?`,
+  },
+  {
+    k: "abono_vencido",
+    n: "Se les venció y no renovaron",
+    d: "Hace poco que se cortó. Todavía tienen la rutina fresca.",
+    tono: "ojo",
+    texto: (c, v) =>
+      `Hola ${primerNombre(c.cliente)}! ¿Cómo va? Se te venció el ${v.plan} y no te vimos más por acá. ` +
+      `¿Querés que te lo renueve y seguimos con los mismos horarios?`,
+  },
+  {
+    k: "falta_seguido",
+    n: "Reservan y no vienen",
+    d: "Acá no hay nada que vender: hay algo que preguntar. Si nadie pregunta, el que se va es él.",
+    tono: "tenue",
+    texto: (c, v) =>
+      `Hola ${primerNombre(c.cliente)}! ¿Cómo andás? Vi que se te complicó venir a varios ${v.turnos} ` +
+      `de los últimos. ¿Te sirven los horarios que tenés o te busco otros? Así no perdés las ${v.clases}.`,
+  },
+];
+
+export const segmentoPorK = (k) => SEGMENTOS.find((s) => s.k === k) || { k, n: k, d: "", tono: "tenue" };
+
+export const RESULTADOS = [
+  { k: "enviado", n: "Enviado", tono: "info" },
+  { k: "respondio", n: "Contestó", tono: "acento" },
+  { k: "volvio", n: "Volvió", tono: "bien" },
+  { k: "sin_respuesta", n: "Sin respuesta", tono: "tenue" },
+];
+
+/* Las palabras del rubro, resueltas una vez. Sin rubro cargado devuelve
+   las de fábrica, así una pantalla nueva anda desde el primer día. */
+export function palabrasDe(rubro) {
+  return {
+    cliente: voz(rubro, "cliente", "cliente").toLowerCase(),
+    turnos: voz(rubro, "turnos", "turnos").toLowerCase(),
+    clases: voz(rubro, "clases", "clases").toLowerCase(),
+    plan: "plan",
+  };
+}
+
+/* El texto que se le propone a quien va a escribir. `plan` sale del
+   motivo, que es donde está el nombre del abono: "Pack 8 clases · le
+   quedan 2 clases". */
+export function mensajeDe(segmento, fila, rubro) {
+  const s = segmentoPorK(segmento);
+  if (!s.texto) return "";
+  const palabras = palabrasDe(rubro);
+  const plan = String(fila.motivo || "").split("·")[0].trim() || palabras.plan;
+  return s.texto(fila, { ...palabras, plan });
+}
+
+/* ------------------------------------------------------------
+   Las lecturas
+   ------------------------------------------------------------ */
+
+export async function cargarSegmentos(empresaId) {
+  if (!empresaId) throw new Error("cargarSegmentos necesita saber de qué comercio.");
+
+  const { data, error } = await supabase.rpc("crm_segmentos", { p_empresa: empresaId });
+  if (error) throw error;
+
+  const filas = (data || []).map((f) => ({
+    segmento: f.segmento,
+    clienteId: f.cliente_id,
+    cliente: f.cliente,
+    tel: f.tel || "",
+    motivo: f.motivo,
+    dias: f.dias === null ? null : Number(f.dias),
+    valor: Number(f.valor || 0),
+    ultimoContacto: f.ultimo_contacto ? new Date(f.ultimo_contacto) : null,
+  }));
+
+  /* Se devuelve en el orden de SEGMENTOS y no en el que vino: el orden es
+     una decisión —primero el que se está yendo, último el que falta— y no
+     puede depender de cómo la base junte los UNION. */
+  return SEGMENTOS.map((s) => ({
+    ...s,
+    gente: filas
+      .filter((f) => f.segmento === s.k)
+      .sort((a, b) => b.valor - a.valor),
+  }));
+}
+
+/* Lo que se mandó, para poder decir si esto sirvió de algo. Sin la
+   columna `resultado` marcada a mano el módulo no se puede evaluar: se
+   sabe a cuántos se les escribió y a ninguno cuántos volvieron. */
+export async function cargarContactos(empresaId, { clienteId = null, dias = 90 } = {}) {
+  if (!empresaId) throw new Error("cargarContactos necesita saber de qué comercio.");
+
+  let q = supabase
+    .from("contactos")
+    .select("id, cliente_id, motivo, canal, texto, resultado, fecha, clientes(razon_social)")
+    .eq("empresa_id", empresaId)
+    .gte("fecha", new Date(Date.now() - dias * 86400000).toISOString())
+    .order("fecha", { ascending: false })
+    .limit(500);
+
+  if (clienteId) q = q.eq("cliente_id", clienteId);
+
+  const { data, error } = await q;
+  if (error) throw error;
+
+  return (data || []).map((f) => ({
+    id: f.id,
+    clienteId: f.cliente_id,
+    cliente: (f.clientes && f.clientes.razon_social) || "",
+    motivo: f.motivo,
+    canal: f.canal,
+    texto: f.texto || "",
+    resultado: f.resultado,
+    fecha: new Date(f.fecha),
+  }));
+}
+
+/* ------------------------------------------------------------
+   Las escrituras
+   ------------------------------------------------------------ */
+
+export async function anotarContacto({ empresaId, clienteId, motivo, canal = "whatsapp", texto = null }) {
+  if (!empresaId) throw new Error("anotarContacto necesita saber de qué comercio.");
+
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("contactos").insert({
+    empresa_id: empresaId,
+    cliente_id: clienteId,
+    motivo,
+    canal,
+    /* Se guarda lo que se mandó y no lo que decía la plantilla: si
+       alguien lo reescribió entero, eso es lo que la persona leyó. */
+    texto,
+    usuario_id: user ? user.id : null,
+  });
+  if (error) throw error;
+}
+
+export async function marcarResultado(id, resultado) {
+  const { error } = await supabase.from("contactos").update({ resultado }).eq("id", id);
+  if (error) throw error;
+}
+
+/* "No molestar" vive en `campos_extra` del cliente y no en una tabla
+   propia: es una marca que se pone cinco veces por año. Se lee entera y
+   se reescribe entera para no pisar lo que haya guardado otro módulo. */
+export async function noContactar(empresaId, clienteId, valor) {
+  if (!empresaId) throw new Error("noContactar necesita saber de qué comercio.");
+
+  const { data, error } = await supabase
+    .from("clientes")
+    .select("campos_extra")
+    .eq("empresa_id", empresaId)
+    .eq("id", clienteId)
+    .single();
+  if (error) throw error;
+
+  const extra = { ...(data.campos_extra || {}) };
+  if (valor) extra.noContactar = true;
+  else delete extra.noContactar;
+
+  const { error: e2 } = await supabase
+    .from("clientes")
+    .update({ campos_extra: extra })
+    .eq("empresa_id", empresaId)
+    .eq("id", clienteId);
+  if (e2) throw e2;
+}

--- a/src/datos/equipo.js
+++ b/src/datos/equipo.js
@@ -122,31 +122,6 @@ export async function cargarEquipo(empresaId) {
   }));
 }
 
-/* El catálogo de prestaciones, para elegir qué da cada uno. Vive acá y no
-   en `items.js` porque `cargarProductos` trae solo `tipo = 'producto'`: un
-   servicio no es un producto y no comparte ni pantalla ni columnas útiles. */
-export async function cargarServicios(empresaId) {
-  if (!empresaId) throw new Error("cargarServicios necesita saber de qué comercio.");
-
-  const { data, error } = await supabase
-    .from("items")
-    .select("id, nombre, categoria, duracion_min, precio")
-    .eq("empresa_id", empresaId)
-    .eq("tipo", "servicio")
-    .eq("activo", true)
-    .order("categoria")
-    .order("nombre");
-  if (error) throw error;
-
-  return (data || []).map((i) => ({
-    id: i.id,
-    nombre: i.nombre,
-    categoria: i.categoria || "Sin categoría",
-    duracion: i.duracion_min || 0,
-    precio: n(i.precio),
-  }));
-}
-
 export async function crearPersona(empresaId, datos) {
   const fila = { ...aFila(datos), empresa_id: empresaId };
   if (!fila.nombre) throw new Error("La persona necesita un nombre.");

--- a/src/datos/informes.js
+++ b/src/datos/informes.js
@@ -1,0 +1,349 @@
+/* ============================================================
+   INFORMES · lo que pasó, para un negocio que vende horas
+   ============================================================
+
+   El informe del minimercado responde "qué se vende y qué margen deja".
+   Acá las preguntas son otras cuatro, y en este orden:
+
+     1. Cuánto entró, y de dónde.
+     2. Cuánto de lo que se podía vender se vendió.
+     3. Cuánta de la gente que sacó turno vino.
+     4. Quién es esa gente: cuántos nuevos, cuántos vuelven, cuántos se
+        fueron sin avisar.
+
+   Las tres primeras se leen de tablas que ya existen. La ocupación no:
+   cruza cinco tablas y recorre el período día por día, así que la
+   resuelve `informe_ocupacion` en la base. Ver la migración 0042.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6), y
+   las funciones revientan si no lo reciben: un id olvidado tiene que
+   fallar acá y no convertirse en los números de otro negocio.
+
+   LA FECHA ES LA DE VERDAD
+   ------------------------
+   Nada de `HOY` congelado. Este módulo no toca el generador: si un dato
+   no está en la base, no está.
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+const suma = (xs, f) => xs.reduce((s, x) => s + n(f(x)), 0);
+const dia = 86400000;
+
+/* Sin base contra la que comparar no hay variación. Un "+100%" contra
+   cero no informa nada y encima alarma. Mismo criterio que el tablero. */
+const variacion = (ahora, antes) => (antes > 0 ? ahora / antes - 1 : null);
+
+export const PERIODOS = [
+  { k: 7, n: "7 días" },
+  { k: 30, n: "30 días" },
+  { k: 90, n: "90 días" },
+];
+
+/* Los cinco estados de un turno, en el orden en que se leen. `cumplida`
+   y `ausente` son las dos caras de lo mismo y por eso van juntas. */
+export const ESTADOS_TURNO = [
+  { k: "cumplida", n: "Vinieron", tono: "bien" },
+  { k: "ausente", n: "No vinieron", tono: "mal" },
+  { k: "cancelada", n: "Cancelaron", tono: "tenue" },
+  { k: "confirmada", n: "Confirmados", tono: "info" },
+  { k: "pendiente", n: "Sin confirmar", tono: "ojo" },
+];
+
+/* ------------------------------------------------------------
+   Las lecturas
+   ------------------------------------------------------------ */
+
+/* Se traen dos períodos de una y se parten en memoria: es una consulta en
+   vez de dos y la comparación sale gratis. */
+async function lineasVendidas(empresaId, desde, hasta) {
+  const { data, error } = await supabase
+    .from("operacion_lineas")
+    .select("descripcion, cantidad, total, item_id, items(categoria, tipo), operaciones!inner(fecha, estado, tipo, cliente_id)")
+    .eq("empresa_id", empresaId)
+    .eq("operaciones.estado", "confirmada")
+    .in("operaciones.tipo", ["venta", "comanda"])
+    .gte("operaciones.fecha", desde.toISOString())
+    .lt("operaciones.fecha", hasta.toISOString())
+    .limit(6000);
+  if (error) throw error;
+  return data || [];
+}
+
+/* La agenda del período y de los seis meses previos: los previos no se
+   dibujan, sirven para saber quién ya venía. Sin eso no se puede
+   distinguir un cliente nuevo de uno que volvió. */
+async function turnos(empresaId, desde, hasta) {
+  const { data, error } = await supabase
+    .from("agenda_vista")
+    .select("id, desde, estado, forma, cliente_id, cliente, servicio, area, profesional, sala, precio, duracion_min")
+    .eq("empresa_id", empresaId)
+    .gte("desde", desde.toISOString())
+    .lt("desde", hasta.toISOString())
+    .order("desde")
+    .limit(8000);
+  if (error) throw error;
+  return data || [];
+}
+
+async function ocupacion(empresaId, desde, hasta) {
+  const iso = (d) => d.toISOString().slice(0, 10);
+  const { data, error } = await supabase.rpc("informe_ocupacion", {
+    p_empresa: empresaId,
+    p_desde: iso(desde),
+    p_hasta: iso(hasta),
+  });
+  if (error) throw error;
+  return data || [];
+}
+
+async function altas(empresaId, desde) {
+  const { data, error } = await supabase
+    .from("clientes")
+    .select("id, razon_social, creado_en")
+    .eq("empresa_id", empresaId)
+    .eq("activo", true)
+    .gte("creado_en", desde.toISOString())
+    .limit(3000);
+  if (error) throw error;
+  return data || [];
+}
+
+/* ------------------------------------------------------------
+   El informe
+
+   Una sola función arma las cuatro secciones. La pantalla recibe un
+   objeto y dibuja: mismo trato que el tablero, y por la misma razón —que
+   dos lugares del sistema no puedan decir números distintos del mismo
+   período—.
+   ------------------------------------------------------------ */
+export async function cargarInforme(empresaId, dias = 30) {
+  if (!empresaId) throw new Error("cargarInforme necesita saber de qué comercio.");
+
+  const hasta = new Date();
+  hasta.setHours(23, 59, 59, 999);
+  const desde = new Date(hasta.getTime() - (dias - 1) * dia);
+  desde.setHours(0, 0, 0, 0);
+  const previo = new Date(desde.getTime() - dias * dia);
+  const historia = new Date(desde.getTime() - 180 * dia);
+
+  const [lineas, agenda, ocup, nuevos] = await Promise.all([
+    lineasVendidas(empresaId, previo, hasta),
+    turnos(empresaId, historia, hasta),
+    ocupacion(empresaId, desde, hasta),
+    altas(empresaId, previo),
+  ]);
+
+  return {
+    dias,
+    desde,
+    hasta,
+    ingresos: armarIngresos(lineas, desde, hasta, dias),
+    ocupacion: armarOcupacion(ocup),
+    asistencia: armarAsistencia(agenda, desde, hasta),
+    clientes: armarClientes(agenda, nuevos, desde, previo),
+  };
+}
+
+/* ------------------------------------------------------------
+   1 · Cuánto entró y de dónde
+   ------------------------------------------------------------ */
+
+function armarIngresos(lineas, desde, hasta, dias) {
+  const enPeriodo = lineas.filter((l) => new Date(l.operaciones.fecha) >= desde);
+  const enPrevio = lineas.filter((l) => new Date(l.operaciones.fecha) < desde);
+
+  const total = suma(enPeriodo, (l) => l.total);
+  const totalPrevio = suma(enPrevio, (l) => l.total);
+
+  /* Un abono no es un turno: es plata que entró hoy por horas que se van
+     a dar en las próximas ocho semanas. Mezclarlos hace que un mes con
+     muchas renovaciones parezca un mes de mucha actividad. */
+  const esPlan = (l) => (l.items && l.items.tipo === "plan");
+  const abonos = suma(enPeriodo.filter(esPlan), (l) => l.total);
+
+  const porArea = new Map();
+  const porServicio = new Map();
+  for (const l of enPeriodo) {
+    const area = (l.items && l.items.categoria) || "Sin área";
+    porArea.set(area, (porArea.get(area) || 0) + n(l.total));
+    const s = porServicio.get(l.descripcion) || { nombre: l.descripcion, cantidad: 0, total: 0, plan: esPlan(l) };
+    s.cantidad += n(l.cantidad);
+    s.total += n(l.total);
+    porServicio.set(l.descripcion, s);
+  }
+
+  /* Una operación puede traer varias líneas; el ticket se cuenta por
+     operación y no por línea, o un pack vendido junto con una crema
+     bajaría el promedio sin que nadie haya gastado menos. */
+  const ops = new Set(enPeriodo.map((l) => l.operaciones.fecha + "|" + (l.operaciones.cliente_id || "")));
+
+  const fin = new Date(hasta);
+  fin.setHours(0, 0, 0, 0);
+  const serie = new Array(dias).fill(0);
+  for (const l of enPeriodo) {
+    const f = new Date(l.operaciones.fecha);
+    f.setHours(0, 0, 0, 0);
+    const d = Math.round((fin.getTime() - f.getTime()) / dia);
+    if (d >= 0 && d < dias) serie[dias - 1 - d] += n(l.total);
+  }
+
+  return {
+    total,
+    delta: variacion(total, totalPrevio),
+    ticket: ops.size ? Math.round(total / ops.size) : 0,
+    operaciones: ops.size,
+    promedioDiario: Math.round(total / dias),
+    abonos,
+    sueltos: total - abonos,
+    serie,
+    porArea: [...porArea.entries()].map(([nombre, t]) => ({ nombre, total: t })).sort((a, b) => b.total - a.total),
+    porServicio: [...porServicio.values()].sort((a, b) => b.total - a.total).slice(0, 10),
+  };
+}
+
+/* ------------------------------------------------------------
+   2 · Cuánto de lo que se podía vender se vendió
+
+   Dos ocupaciones distintas y las dos ciertas: una sala de mat para ocho
+   con tres personas adentro está usada el 100% del tiempo y al 37% de su
+   capacidad. Ver el comentario de la migración 0042.
+   ------------------------------------------------------------ */
+
+function armarOcupacion(filas) {
+  const armar = (f) => ({
+    id: f.id,
+    nombre: f.nombre,
+    detalle: f.detalle || "",
+    horasOfrecidas: n(f.ofrecidos) / 60,
+    horasOcupadas: n(f.ocupados) / 60,
+    pct: n(f.ofrecidos) > 0 ? n(f.ocupados) / n(f.ofrecidos) : null,
+    lugares: n(f.lugares),
+    tomados: n(f.tomados),
+    pctCupo: n(f.lugares) > 0 ? n(f.tomados) / n(f.lugares) : null,
+  });
+
+  const profesionales = filas.filter((f) => f.ambito === "profesional").map(armar)
+    .sort((a, b) => (b.pct || 0) - (a.pct || 0));
+  const salas = filas.filter((f) => f.ambito === "sala").map(armar)
+    .sort((a, b) => b.horasOcupadas - a.horasOcupadas);
+
+  const lugares = suma(profesionales, (p) => p.lugares);
+  const tomados = suma(profesionales, (p) => p.tomados);
+
+  return {
+    profesionales,
+    salas,
+    clases: { lugares, tomados, pct: lugares > 0 ? tomados / lugares : null },
+  };
+}
+
+/* ------------------------------------------------------------
+   3 · Cuánta de la gente que sacó turno vino
+
+   Solo sobre turnos que ya pasaron. Contar los futuros como "no vino"
+   hunde el porcentaje sin motivo: es el mismo criterio que usa la ficha
+   del cliente, y tiene que seguir siendo el mismo.
+   ------------------------------------------------------------ */
+
+function armarAsistencia(agenda, desde, hasta) {
+  const ahora = Date.now();
+  /* Las clases no se cuentan: la clase no falta ni viene, faltan o vienen
+     los inscriptos. Contarlas mezcla una unidad con la otra. */
+  const delPeriodo = agenda.filter((t) => {
+    const f = new Date(t.desde);
+    return f >= desde && f <= hasta && t.forma !== "clase";
+  });
+
+  const pasados = delPeriodo.filter((t) => new Date(t.desde).getTime() < ahora);
+  const cuenta = (k) => pasados.filter((t) => t.estado === k).length;
+
+  const cumplidas = cuenta("cumplida");
+  const ausentes = cuenta("ausente");
+  const canceladas = cuenta("cancelada");
+  const base = cumplidas + ausentes;
+
+  const porServicio = new Map();
+  for (const t of pasados) {
+    const k = t.servicio || "Sin servicio";
+    const s = porServicio.get(k) || { nombre: k, area: t.area || "", total: 0, vino: 0, falto: 0 };
+    s.total += 1;
+    if (t.estado === "cumplida") s.vino += 1;
+    if (t.estado === "ausente") s.falto += 1;
+    porServicio.set(k, s);
+  }
+
+  return {
+    total: delPeriodo.length,
+    pasados: pasados.length,
+    cumplidas,
+    ausentes,
+    canceladas,
+    /* Sobre vinieron + faltaron, no sobre el total: una cancelación
+       avisada a tiempo no es una inasistencia, es un turno que se pudo
+       volver a vender. */
+    pct: base > 0 ? cumplidas / base : null,
+    pctCancelacion: pasados.length > 0 ? canceladas / pasados.length : null,
+    porEstado: ESTADOS_TURNO.map((e) => ({
+      ...e,
+      v: delPeriodo.filter((t) => t.estado === e.k).length,
+    })).filter((e) => e.v > 0),
+    porServicio: [...porServicio.values()]
+      .filter((s) => s.vino + s.falto >= 3)
+      .map((s) => ({ ...s, pct: s.vino / (s.vino + s.falto) }))
+      .sort((a, b) => a.pct - b.pct)
+      .slice(0, 8),
+  };
+}
+
+/* ------------------------------------------------------------
+   4 · Quién es la gente
+
+   La antesala del CRM. Todavía no manda un mensaje: dice a quién habría
+   que mandárselo.
+   ------------------------------------------------------------ */
+
+function armarClientes(agenda, nuevos, desde, previo) {
+  const delPeriodo = nuevos.filter((c) => new Date(c.creado_en) >= desde);
+  const delPrevio = nuevos.filter((c) => new Date(c.creado_en) < desde && new Date(c.creado_en) >= previo);
+
+  const vinieron = agenda.filter((t) => t.estado === "cumplida" && t.cliente_id);
+
+  /* La última vez de cada uno, sobre los seis meses que se trajeron. */
+  const ultima = new Map();
+  const veces = new Map();
+  for (const t of vinieron) {
+    const f = new Date(t.desde);
+    if (f > new Date()) continue;
+    if (!ultima.has(t.cliente_id) || f > ultima.get(t.cliente_id).fecha) {
+      ultima.set(t.cliente_id, { fecha: f, nombre: t.cliente || null });
+    }
+    veces.set(t.cliente_id, (veces.get(t.cliente_id) || 0) + 1);
+  }
+
+  const enPeriodo = new Map();
+  for (const t of vinieron) {
+    const f = new Date(t.desde);
+    if (f < desde) continue;
+    enPeriodo.set(t.cliente_id, (enPeriodo.get(t.cliente_id) || 0) + 1);
+  }
+
+  /* Dormido: vino alguna vez y hace más de 45 días que no aparece. No es
+     "cliente perdido" —eso lo decide el negocio, no el sistema— es a
+     quién conviene llamar. */
+  const corte = Date.now() - 45 * dia;
+  const dormidos = [...ultima.entries()]
+    .filter(([, u]) => u.fecha.getTime() < corte)
+    .map(([id, u]) => ({ id, nombre: u.nombre, ultima: u.fecha, veces: veces.get(id) || 0, dias: Math.round((Date.now() - u.fecha.getTime()) / dia) }))
+    .sort((a, b) => b.veces - a.veces);
+
+  return {
+    nuevos: delPeriodo.length,
+    deltaNuevos: variacion(delPeriodo.length, delPrevio.length),
+    activos: enPeriodo.size,
+    recurrentes: [...enPeriodo.values()].filter((v) => v >= 2).length,
+    dormidos: dormidos.slice(0, 8),
+    dormidosTotal: dormidos.length,
+  };
+}

--- a/src/datos/permisos.js
+++ b/src/datos/permisos.js
@@ -1,0 +1,203 @@
+/* ============================================================
+   PERMISOS · qué puede hacer cada rol, y quién cambió qué
+   ============================================================
+
+   Hasta acá los roles eran una constante de JavaScript. Ahora salen de
+   la base, que es donde tienen que estar por una razón concreta: **las
+   políticas de RLS los tienen que poder leer**. Un permiso que solo
+   existe en el navegador no protege nada —está escrito en `CLAUDE.md` y
+   es la regla que este módulo no puede romper.
+
+   `roles_base` son los cuatro de fábrica y `roles` guarda solo lo que
+   cada comercio cambió. Ver la migración 0045 para por qué son dos
+   tablas y por qué las dos políticas que nombraban roles a mano dan
+   exactamente el mismo resultado que antes.
+
+   SE GUARDA LA DIFERENCIA, NO LA FOTO
+   -----------------------------------
+   Al guardar se compara contra el valor de fábrica y se escribe
+   únicamente lo que difiere. Guardar el objeto entero funcionaría igual
+   hoy y rompería mañana: el día que un valor de fábrica cambie, el
+   comercio que nunca lo tocó tiene que llevarse el cambio, y con la foto
+   guardada se quedaría con el viejo para siempre sin que nadie lo note.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+/* Las banderas finas, en el orden en que se leen en pantalla. La
+   descripción no es decorativa: "anular" a secas no le dice nada a quien
+   tiene que decidir si dárselo al cajero. */
+export const BANDERAS = [
+  { k: "verCostos", n: "Ver costos y ganancias", d: "Cuánto costó cada cosa y cuánto deja." },
+  { k: "descuentos", n: "Hacer descuentos", d: "Bajar el precio de una venta o una cuenta." },
+  { k: "anular", n: "Anular ventas", d: "Dar de baja algo ya cobrado. Queda en la bitácora." },
+  { k: "cerrarCaja", n: "Cerrar la caja", d: "Hacer el arqueo y cerrar el día." },
+  { k: "cambiarPrecios", n: "Cambiar precios", d: "Editar el precio de venta del catálogo." },
+  { k: "ajustes", n: "Entrar a Ajustes", d: "La configuración del negocio y del sistema." },
+  { k: "verBitacora", n: "Ver la auditoría", d: "Leer lo que hicieron los demás." },
+  {
+    k: "configurar",
+    n: "Configurar el comercio",
+    d: "Cambiar la ficha del negocio y estos mismos permisos. Es el más pesado de todos.",
+    pesado: true,
+  },
+];
+
+export const banderaPorK = (k) => BANDERAS.find((b) => b.k === k) || { k, n: k, d: "" };
+
+/* Qué se registra en la bitácora, traducido. Lo que no esté acá se
+   muestra tal cual: es preferible un `pedido.estado` crudo a esconder un
+   acto porque nadie escribió su nombre. */
+const ACCIONES = {
+  "permisos.cambiar": "Cambió los permisos de un rol",
+  "permisos.restaurar": "Volvió un rol a los valores de fábrica",
+  "venta.anular": "Anuló una venta",
+  "linea.anular": "Anuló una línea",
+  "linea.cantidad": "Cambió una cantidad",
+  "descuento.aplicar": "Aplicó un descuento",
+  "caja.abrir": "Abrió la caja",
+  "caja.cerrar": "Cerró la caja",
+  "caja.egreso": "Registró un egreso",
+  "reserva.crear": "Tomó un turno",
+  "pedido.estado": "Movió un pedido",
+  "item.precio": "Cambió un precio",
+};
+
+export const nombreAccion = (k) => ACCIONES[k] || k;
+
+/* Los actos que se pueden filtrar. Se arma de lo que hay registrado y no
+   de esta lista: un comercio de servicios no tiene pedidos y no tiene por
+   qué ver ese filtro. */
+export const FAMILIAS = [
+  { k: "permisos", n: "Permisos" },
+  { k: "caja", n: "Caja" },
+  { k: "venta", n: "Ventas" },
+  { k: "linea", n: "Líneas" },
+  { k: "descuento", n: "Descuentos" },
+  { k: "reserva", n: "Turnos" },
+  { k: "item", n: "Catálogo" },
+  { k: "pedido", n: "Pedidos" },
+];
+
+/* ------------------------------------------------------------
+   Los roles
+   ------------------------------------------------------------ */
+
+export async function cargarRoles(empresaId) {
+  if (!empresaId) throw new Error("cargarRoles necesita saber de qué comercio.");
+
+  const [base, propios] = await Promise.all([
+    supabase.from("roles_base").select("clave, nombre, descripcion, modulos, permisos, orden").order("orden"),
+    supabase.from("roles").select("clave, nombre, modulos, permisos, actualizado").eq("empresa_id", empresaId),
+  ]);
+  if (base.error) throw base.error;
+  if (propios.error) throw propios.error;
+
+  const mios = new Map((propios.data || []).map((r) => [r.clave, r]));
+
+  return (base.data || []).map((b) => {
+    const mio = mios.get(b.clave);
+    return {
+      k: b.clave,
+      n: (mio && mio.nombre) || b.nombre,
+      d: b.descripcion || "",
+      /* `todos` es null en la base: el rol alcanza todo lo que el
+         comercio haya contratado, sea lo que sea mañana. */
+      modulos: mio && mio.modulos ? mio.modulos : b.modulos,
+      todos: !(mio && mio.modulos) && b.modulos === null,
+      permisos: { ...(b.permisos || {}), ...((mio && mio.permisos) || {}) },
+      base: { modulos: b.modulos, permisos: b.permisos || {} },
+      propio: !!mio,
+      actualizado: mio && mio.actualizado ? new Date(mio.actualizado) : null,
+    };
+  });
+}
+
+/* Se escribe la diferencia contra el valor de fábrica. Si no quedó
+   ninguna, la fila se borra: un rol sin cambios no tiene por qué existir
+   en la tabla de cambios. */
+export async function guardarRol(empresaId, rol, { modulos, permisos }) {
+  if (!empresaId) throw new Error("guardarRol necesita saber de qué comercio.");
+
+  const diff = {};
+  for (const b of BANDERAS) {
+    const nuevo = !!permisos[b.k];
+    if (nuevo !== !!rol.base.permisos[b.k]) diff[b.k] = nuevo;
+  }
+
+  const mismos = (a, b) =>
+    (a === null && b === null) ||
+    (Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((x) => b.includes(x)));
+
+  const modulosCambiaron = !mismos(modulos, rol.base.modulos);
+
+  if (!Object.keys(diff).length && !modulosCambiaron) {
+    return restaurarRol(empresaId, rol.k);
+  }
+
+  const { data: { user } } = await supabase.auth.getUser();
+  const { error } = await supabase.from("roles").upsert({
+    empresa_id: empresaId,
+    clave: rol.k,
+    modulos: modulosCambiaron ? modulos : null,
+    permisos: diff,
+    actualizado: new Date().toISOString(),
+    usuario_id: user ? user.id : null,
+  }, { onConflict: "empresa_id,clave" });
+
+  if (error) throw traducir(error);
+}
+
+export async function restaurarRol(empresaId, clave) {
+  if (!empresaId) throw new Error("restaurarRol necesita saber de qué comercio.");
+
+  const { error } = await supabase
+    .from("roles").delete().eq("empresa_id", empresaId).eq("clave", clave);
+  if (error) throw traducir(error);
+}
+
+/* El error del disparador llega con su código; se traduce acá para que
+   la pantalla no tenga que saber de códigos de Postgres. */
+function traducir(error) {
+  if (error && error.code === "P0070") {
+    return new Error("No podés sacarle a tu propio rol el permiso de configurar: te quedarías afuera.");
+  }
+  return new Error((error && error.message) || "No se pudo guardar.");
+}
+
+/* ------------------------------------------------------------
+   La auditoría
+
+   `bitacora` existía desde el principio y nunca tuvo pantalla: se
+   escribía y no la leía nadie. Solo admite insertar y leer, así que lo
+   que está ahí no se puede corregir ni borrar, que es la única forma de
+   que sirva para algo.
+   ------------------------------------------------------------ */
+
+export async function cargarBitacora(empresaId, { familia = null, dias = 30 } = {}) {
+  if (!empresaId) throw new Error("cargarBitacora necesita saber de qué comercio.");
+
+  let q = supabase
+    .from("bitacora")
+    .select("id, accion, entidad, entidad_id, detalle, fecha, usuario_id, perfiles(nombre)")
+    .eq("empresa_id", empresaId)
+    .gte("fecha", new Date(Date.now() - dias * 86400000).toISOString())
+    .order("fecha", { ascending: false })
+    .limit(400);
+
+  if (familia) q = q.like("accion", `${familia}.%`);
+
+  const { data, error } = await q;
+  if (error) throw error;
+
+  return (data || []).map((f) => ({
+    id: f.id,
+    accion: f.accion,
+    entidad: f.entidad || "",
+    detalle: f.detalle || {},
+    fecha: new Date(f.fecha),
+    usuario: (f.perfiles && f.perfiles.nombre) || "—",
+  }));
+}

--- a/src/datos/servicios.js
+++ b/src/datos/servicios.js
@@ -1,0 +1,223 @@
+/* ============================================================
+   SERVICIOS Y RECURSOS · qué se ofrece y dónde se hace
+   ============================================================
+
+   No hay tablas propias: una prestación es un `item` con
+   `tipo = 'servicio'` y una sala es un `recurso`. Estaba previsto desde la
+   primera migración —`duracion_min` dice, textual, "solo para servicios
+   con turno"— así que acá no se inventa nada, se lee lo que ya está.
+
+   La modalidad y el cupo viven en `campos_extra` y no en columnas propias
+   porque son de este rubro: a un producto de minimercado no le sirven, y
+   una columna que está siempre vacía en dos de cada tres comercios es una
+   columna que sobra.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
+   ============================================================ */
+
+import { supabase } from "./supabase.js";
+
+const n = (v) => (v === null || v === undefined ? 0 : Number(v));
+
+export const TIPOS_RECURSO = [
+  { k: "sala", n: "Sala", d: "Un ambiente donde se atiende" },
+  { k: "camilla", n: "Camilla o box", d: "Un puesto adentro de un ambiente" },
+  { k: "equipamiento", n: "Equipamiento", d: "Una máquina que se reserva y puede moverse" },
+  { k: "sillon", n: "Sillón", d: "Un puesto de peluquería o barbería" },
+  { k: "otro", n: "Otro", d: "" },
+];
+
+export const nombreTipo = (k) => (TIPOS_RECURSO.find((t) => t.k === k) || { n: k }).n;
+
+function aServicio(i) {
+  const extra = i.campos_extra || {};
+  return {
+    id: i.id,
+    nombre: i.nombre,
+    categoria: i.categoria || "",
+    duracion: i.duracion_min || 0,
+    precio: n(i.precio),
+    activo: i.activo,
+    /* Sin modalidad guardada, un servicio con cupo mayor a uno es grupal:
+       el dato está, solo que dicho de otra manera. */
+    modalidad: extra.modalidad || (Number(extra.capacidad) > 1 ? "grupal" : "individual"),
+    capacidad: extra.capacidad != null ? Number(extra.capacidad) : 1,
+    demo: extra.demo === true,
+  };
+}
+
+export async function cargarServicios(empresaId, { soloActivos = true } = {}) {
+  if (!empresaId) throw new Error("cargarServicios necesita saber de qué comercio.");
+
+  let q = supabase
+    .from("items")
+    .select("id, nombre, categoria, duracion_min, precio, activo, campos_extra")
+    .eq("empresa_id", empresaId)
+    .eq("tipo", "servicio");
+  if (soloActivos) q = q.eq("activo", true);
+
+  const { data, error } = await q.order("categoria").order("nombre");
+  if (error) throw error;
+  return (data || []).map(aServicio);
+}
+
+export async function guardarServicio(empresaId, s) {
+  const fila = {
+    empresa_id: empresaId,
+    tipo: "servicio",
+    nombre: s.nombre,
+    categoria: s.categoria || null,
+    duracion_min: Number(s.duracion) || null,
+    precio: Number(s.precio) || 0,
+    controla_stock: false,
+    activo: s.activo !== false,
+    campos_extra: {
+      modalidad: s.modalidad || "individual",
+      capacidad: s.modalidad === "grupal" ? Math.max(2, Number(s.capacidad) || 2) : 1,
+      /* La marca de demostración se conserva: es lo que permite barrer de
+         una los datos de ejemplo cuando lleguen los de verdad. */
+      ...(s.demo ? { demo: true } : {}),
+    },
+  };
+
+  if (s.id) {
+    const { error } = await supabase.from("items").update(fila).eq("id", s.id);
+    if (error) throw error;
+    return s.id;
+  }
+
+  const { data, error } = await supabase.from("items").insert(fila).select("id").single();
+  if (error) {
+    if (error.code === "23505") throw new Error("Ya hay una prestación con ese código.");
+    throw error;
+  }
+  return data.id;
+}
+
+/* No se borra: puede tener turnos dados atrás, y borrarla dejaría esos
+   turnos sin saber qué se hizo. */
+export async function desactivarServicio(id) {
+  const { error } = await supabase.from("items").update({ activo: false }).eq("id", id);
+  if (error) throw error;
+}
+
+/* ------------------------------------------------------------
+   Quién da cada cosa
+
+   La tabla es la misma que usa Equipo. Se puede llegar desde los dos
+   lados —desde la persona o desde el servicio— porque en la práctica se
+   piensa de las dos maneras: "qué hace Carla" y "quién puede dar esto".
+   ------------------------------------------------------------ */
+
+export async function cargarQuienDaQue(empresaId) {
+  if (!empresaId) throw new Error("cargarQuienDaQue necesita saber de qué comercio.");
+  const { data, error } = await supabase
+    .from("personal_servicios")
+    .select("personal_id, item_id")
+    .eq("empresa_id", empresaId);
+  if (error) throw error;
+
+  const porServicio = new Map();
+  for (const r of data || []) {
+    if (!porServicio.has(r.item_id)) porServicio.set(r.item_id, []);
+    porServicio.get(r.item_id).push(r.personal_id);
+  }
+  return porServicio;
+}
+
+export async function guardarQuienLoDa(empresaId, itemId, personalIds) {
+  const { error: eBorrar } = await supabase
+    .from("personal_servicios").delete().eq("empresa_id", empresaId).eq("item_id", itemId);
+  if (eBorrar) throw eBorrar;
+
+  const filas = (personalIds || []).map((personal_id) => ({ empresa_id: empresaId, item_id: itemId, personal_id }));
+  if (!filas.length) return;
+
+  const { error } = await supabase.from("personal_servicios").insert(filas);
+  if (error) throw error;
+}
+
+/* ------------------------------------------------------------
+   Los espacios
+   ------------------------------------------------------------ */
+
+function aRecurso(r) {
+  return {
+    id: r.id,
+    nombre: r.nombre,
+    tipo: r.tipo,
+    sector: r.sector || "",
+    capacidad: r.capacidad == null ? 1 : Number(r.capacidad),
+    orden: r.orden,
+    activo: r.activo,
+    demo: r.campos_extra && r.campos_extra.demo === true,
+  };
+}
+
+export async function cargarEspacios(empresaId, { soloActivos = true } = {}) {
+  if (!empresaId) throw new Error("cargarEspacios necesita saber de qué comercio.");
+
+  let q = supabase
+    .from("recursos")
+    .select("id, nombre, tipo, sector, capacidad, orden, activo, campos_extra")
+    .eq("empresa_id", empresaId);
+  if (soloActivos) q = q.eq("activo", true);
+
+  const { data, error } = await q.order("orden").order("nombre");
+  if (error) throw error;
+  return (data || []).map(aRecurso);
+}
+
+export async function guardarEspacio(empresaId, e) {
+  const fila = {
+    empresa_id: empresaId,
+    nombre: e.nombre,
+    tipo: e.tipo || "sala",
+    sector: e.sector || null,
+    capacidad: Number(e.capacidad) || 1,
+    orden: Number(e.orden) || 0,
+    activo: e.activo !== false,
+  };
+
+  if (e.id) {
+    const { error } = await supabase.from("recursos").update(fila).eq("id", e.id);
+    if (error) throw error;
+    return e.id;
+  }
+
+  const { data, error } = await supabase.from("recursos").insert(fila).select("id").single();
+  if (error) {
+    if (error.code === "23505") throw new Error("Ya hay un espacio con ese nombre.");
+    throw error;
+  }
+  return data.id;
+}
+
+/* Tampoco se borra: hay turnos que apuntan a esta sala. */
+export async function desactivarEspacio(id) {
+  const { error } = await supabase.from("recursos").update({ activo: false }).eq("id", id);
+  if (error) throw error;
+}
+
+/* Cuántos turnos tiene cada cosa en los próximos días. Sirve para avisar
+   antes de dar de baja algo que está en uso. */
+export async function usoProximo(empresaId, { dias = 30 } = {}) {
+  const hasta = new Date(Date.now() + dias * 86400000);
+  const { data, error } = await supabase
+    .from("reservas")
+    .select("recurso_id, item_id")
+    .eq("empresa_id", empresaId)
+    .gte("desde", new Date().toISOString())
+    .lt("desde", hasta.toISOString())
+    .neq("estado", "cancelada")
+    .limit(3000);
+  if (error) throw error;
+
+  const porRecurso = new Map();
+  const porItem = new Map();
+  for (const r of data || []) {
+    if (r.recurso_id) porRecurso.set(r.recurso_id, (porRecurso.get(r.recurso_id) || 0) + 1);
+    if (r.item_id) porItem.set(r.item_id, (porItem.get(r.item_id) || 0) + 1);
+  }
+  return { porRecurso, porItem };
+}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -39,6 +39,7 @@ import { Finanzas } from "../modulos/Finanzas.jsx";
 import { Servicios } from "../modulos/Servicios.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
+import { Informes } from "../modulos/Informes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
 import { Ajustes, FichaRapida, AvisoCobro } from "../modulos/Ajustes.jsx";
 import { Comandas, Cocina, PantallaComandas } from "../modulos/Comandas.jsx";
@@ -73,6 +74,10 @@ const MODULOS = [
   { k: "finanzas", n: "Finanzas", d: "Caja, ingresos, egresos y sueldos" },
   { k: "servicios", n: "Servicios y recursos", d: "Qué se ofrece y dónde se hace" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
+  /* Dos informes y no uno con un `if` adentro: el del comercio mira
+     margen por producto y el del negocio de turnos mira ocupación, que no
+     comparten ni una métrica. Misma decisión que Finanzas en 0038. */
+  { k: "informes", n: "Informes", d: "Ingresos, ocupación, asistencia y clientes" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
 
@@ -89,7 +94,7 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "informes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
@@ -1744,6 +1749,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
             <Reportes productos={productos} k={k} ir={ir}
               empresaId={empresaId} conPedidos={modulos.includes("comandas")} />
           )}
+          {tab === "informes" && <Informes empresaId={empresaId} />}
           {tab === "asistente" && <Asistente k={k} ins={ins} ir={ir} negocio={ajustes.negocio} />}
           {tab === "ajustes" && <Ajustes ajustes={ajustes} setAjustes={setAjustes} productos={productos} setProductos={setProductos} toast={toast} mp={mp} setMp={setMp} simularCobro={simularCobro} />}
         </main>

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -1716,7 +1716,10 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           )}
           {tab === "cocina" && <Cocina empresaId={empresaId} config={config} toast={toast} />}
           {tab === "pedidos" && <Picking pedidos={pedidosCli} setPedidos={setPedidosCli} productos={productos} setProductos={setProductos} cobrar={cobrar} ajustes={ajustes} toast={toast} />}
-          {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
+          {tab === "clientes" && (
+            <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets}
+              ajustes={ajustes} empresaId={empresaId} permisos={permisos} toast={toast} />
+          )}
           {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "agenda" && <Agenda empresaId={empresaId} sucursalId={null} permisos={permisos} clientes={clientes} toast={toast} ir={ir} />}
           {tab === "servicios" && <Servicios empresaId={empresaId} permisos={permisos} toast={toast} />}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -40,6 +40,7 @@ import { Servicios } from "../modulos/Servicios.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Informes } from "../modulos/Informes.jsx";
+import { Crm } from "../modulos/Crm.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
 import { Ajustes, FichaRapida, AvisoCobro } from "../modulos/Ajustes.jsx";
 import { Comandas, Cocina, PantallaComandas } from "../modulos/Comandas.jsx";
@@ -78,6 +79,7 @@ const MODULOS = [
      margen por producto y el del negocio de turnos mira ocupación, que no
      comparten ni una métrica. Misma decisión que Finanzas en 0038. */
   { k: "informes", n: "Informes", d: "Ingresos, ocupación, asistencia y clientes" },
+  { k: "crm", n: "Seguimiento", d: "A quién conviene escribirle, y por qué" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
 
@@ -94,7 +96,7 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "informes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "informes", "crm", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
@@ -1750,6 +1752,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
               empresaId={empresaId} conPedidos={modulos.includes("comandas")} />
           )}
           {tab === "informes" && <Informes empresaId={empresaId} />}
+          {tab === "crm" && <Crm empresaId={empresaId} rubro={rubro} toast={toast} />}
           {tab === "asistente" && <Asistente k={k} ins={ins} ir={ir} negocio={ajustes.negocio} />}
           {tab === "ajustes" && <Ajustes ajustes={ajustes} setAjustes={setAjustes} productos={productos} setProductos={setProductos} toast={toast} mp={mp} setMp={setMp} simularCobro={simularCobro} />}
         </main>

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -41,6 +41,7 @@ import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Informes } from "../modulos/Informes.jsx";
 import { Crm } from "../modulos/Crm.jsx";
+import { Comunicaciones } from "../modulos/Comunicaciones.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
 import { Ajustes, FichaRapida, AvisoCobro } from "../modulos/Ajustes.jsx";
 import { Comandas, Cocina, PantallaComandas } from "../modulos/Comandas.jsx";
@@ -80,6 +81,7 @@ const MODULOS = [
      comparten ni una métrica. Misma decisión que Finanzas en 0038. */
   { k: "informes", n: "Informes", d: "Ingresos, ocupación, asistencia y clientes" },
   { k: "crm", n: "Seguimiento", d: "A quién conviene escribirle, y por qué" },
+  { k: "comunicaciones", n: "Avisos", d: "Recordatorios de turno, plantillas e historial" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
 
@@ -96,7 +98,7 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "informes", "crm", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "informes", "crm", "comunicaciones", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
@@ -1753,6 +1755,10 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           )}
           {tab === "informes" && <Informes empresaId={empresaId} />}
           {tab === "crm" && <Crm empresaId={empresaId} rubro={rubro} toast={toast} />}
+          {tab === "comunicaciones" && (
+            <Comunicaciones empresaId={empresaId} rubro={rubro}
+              ajustes={ajustes} setAjustes={setAjustes} toast={toast} />
+          )}
           {tab === "asistente" && <Asistente k={k} ins={ins} ir={ir} negocio={ajustes.negocio} />}
           {tab === "ajustes" && <Ajustes ajustes={ajustes} setAjustes={setAjustes} productos={productos} setProductos={setProductos} toast={toast} mp={mp} setMp={setMp} simularCobro={simularCobro} />}
         </main>

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -42,6 +42,7 @@ import { Reportes } from "../modulos/Reportes.jsx";
 import { Informes } from "../modulos/Informes.jsx";
 import { Crm } from "../modulos/Crm.jsx";
 import { Comunicaciones } from "../modulos/Comunicaciones.jsx";
+import { Permisos } from "../modulos/Permisos.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
 import { Ajustes, FichaRapida, AvisoCobro } from "../modulos/Ajustes.jsx";
 import { Comandas, Cocina, PantallaComandas } from "../modulos/Comandas.jsx";
@@ -82,6 +83,7 @@ const MODULOS = [
   { k: "informes", n: "Informes", d: "Ingresos, ocupación, asistencia y clientes" },
   { k: "crm", n: "Seguimiento", d: "A quién conviene escribirle, y por qué" },
   { k: "comunicaciones", n: "Avisos", d: "Recordatorios de turno, plantillas e historial" },
+  { k: "permisos", n: "Permisos", d: "Qué puede hacer cada rol, y quién cambió qué" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
 
@@ -117,21 +119,38 @@ const rolPorK = (k) => ROLES.find((r) => r.k === k) || ROLES[ROLES.length - 1];
 
 /* Lo que puede hacer una sesión: cruce entre lo que el comercio contrató y lo
    que el rol habilita. Un módulo no contratado no lo ve ni el dueño. */
-function permisosDe(sesion) {
+/* `roles` viene de la base y ROLES de acá arriba es el respaldo: si la
+   consulta no llegó todavía —o falló— el sistema abre con los roles de
+   fábrica en vez de dejar a alguien sin menú. Los dos valores de fábrica
+   son los mismos, así que el respaldo no cambia lo que se ve.
+
+   Las dos formas conviven a propósito y por poco tiempo: la de la base
+   dice `todos: true` con `modulos` en null, y la vieja decía la cadena
+   "todos". Se normalizan acá, en un solo lugar. */
+function permisosDe(sesion, roles = null) {
   if (!sesion) return { modulos: [], permisos: {}, esPlataforma: false };
+
+  const buscar = (k) => (roles || []).find((r) => r.k === k) || rolPorK(k);
+  const alcanzaTodo = (rol) => (rol.todos !== undefined ? rol.todos : rol.modulos === "todos");
+
   if (sesion.tipo === "plataforma") {
-    return { modulos: MODULOS.map((m) => m.k), permisos: rolPorK("dueno").permisos, esPlataforma: true };
+    return { modulos: MODULOS.map((m) => m.k), permisos: buscar("dueno").permisos, esPlataforma: true };
   }
-  const rol = rolPorK(sesion.rol);
+
+  const rol = buscar(sesion.rol);
   const contratados = sesion.comercio.modulos || [];
-  const delRol = rol.modulos === "todos" ? contratados : rol.modulos;
+  const delRol = alcanzaTodo(rol) ? contratados : (rol.modulos || []);
   return {
     modulos: contratados.filter((k) => delRol.includes(k)),
-    permisos: rol.permisos,
+    permisos: rol.permisos || {},
     esPlataforma: false,
   };
 }
 
+/* Muestra el alcance de fábrica del rol y no el que el comercio pueda
+   haber editado: esto vive en el panel de plataforma, que administra
+   muchos comercios a la vez y no tiene uno solo del que leer. Lo que el
+   comercio cambió se ve en su propia pantalla de Permisos. */
 function FormUsuario({ abierto, inicial, modulosComercio, onGuardar, onCerrar }) {
   const [d, setD] = useState({});
   useEffect(() => { if (abierto) setD({ rol: "cajero", ...(inicial || {}) }); }, [abierto, inicial]);
@@ -843,8 +862,8 @@ function aDatosDeBase(d) {
   };
 }
 
-function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
-  const { modulos, permisos, esPlataforma } = permisosDe(sesion);
+function Sistema({ sesion, rubro, roles, onSalir, setComercios, tema, setTema }) {
+  const { modulos, permisos, esPlataforma } = permisosDe(sesion, roles);
 
   /* La configuración del comercio se lee directo de la sesión. `ajustes`
      todavía arranca con valores fijos del minimercado, así que para lo que
@@ -1758,6 +1777,12 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "comunicaciones" && (
             <Comunicaciones empresaId={empresaId} rubro={rubro}
               ajustes={ajustes} setAjustes={setAjustes} toast={toast} />
+          )}
+          {tab === "permisos" && (
+            <Permisos empresaId={empresaId}
+              modulosComercio={(sesion.comercio && sesion.comercio.modulos) || []}
+              catalogoModulos={MODULOS.filter((m) => !m.base)}
+              miRol={sesion.rol} esPlataforma={esPlataforma} toast={toast} />
           )}
           {tab === "asistente" && <Asistente k={k} ins={ins} ir={ir} negocio={ajustes.negocio} />}
           {tab === "ajustes" && <Ajustes ajustes={ajustes} setAjustes={setAjustes} productos={productos} setProductos={setProductos} toast={toast} mp={mp} setMp={setMp} simularCobro={simularCobro} />}

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -36,6 +36,7 @@ import { Equipo } from "../modulos/Equipo.jsx";
 import { Agenda } from "../modulos/Agenda.jsx";
 import { Ventas } from "../modulos/Ventas.jsx";
 import { Finanzas } from "../modulos/Finanzas.jsx";
+import { Servicios } from "../modulos/Servicios.jsx";
 import { Caja, CajaCerrada } from "../modulos/Caja.jsx";
 import { Reportes } from "../modulos/Reportes.jsx";
 import { Asistente } from "../modulos/Asistente.jsx";
@@ -70,6 +71,7 @@ const MODULOS = [
   { k: "agenda", n: "Agenda", d: "Turnos, clases y disponibilidad" },
   { k: "ventas", n: "Ventas", d: "Abonos, packs y planes" },
   { k: "finanzas", n: "Finanzas", d: "Caja, ingresos, egresos y sueldos" },
+  { k: "servicios", n: "Servicios y recursos", d: "Qué se ofrece y dónde se hace" },
   { k: "reportes", n: "Informes", d: "Ventas, márgenes y rubros" },
   { k: "asistente", n: "Asistente", d: "Diagnóstico y consultas" },
 ];
@@ -87,12 +89,12 @@ const ROLES = [
   },
   {
     k: "encargado", n: "Encargado", d: "Todo menos la configuración",
-    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "reportes", "asistente"],
+    modulos: ["cobro", "caja", "comandas", "productos", "stock", "compras", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios", "reportes", "asistente"],
     permisos: { verCostos: true, descuentos: true, anular: true, cerrarCaja: true, cambiarPrecios: true, ajustes: false },
   },
   {
     k: "cajero", n: "Cajero", d: "Cobra, sin ver costos ni ganancias",
-    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas"],
+    modulos: ["cobro", "caja", "comandas", "pedidos", "clientes", "equipo", "agenda", "ventas", "finanzas", "servicios"],
     permisos: { verCostos: false, descuentos: false, anular: false, cerrarCaja: false, cambiarPrecios: false, ajustes: false },
   },
   {
@@ -1717,6 +1719,7 @@ function Sistema({ sesion, rubro, onSalir, setComercios, tema, setTema }) {
           {tab === "clientes" && <Clientes clientes={clientes} guardarCliente={guardarClienteEn} tickets={tickets} ajustes={ajustes} />}
           {tab === "equipo" && <Equipo empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "agenda" && <Agenda empresaId={empresaId} sucursalId={null} permisos={permisos} clientes={clientes} toast={toast} ir={ir} />}
+          {tab === "servicios" && <Servicios empresaId={empresaId} permisos={permisos} toast={toast} />}
           {tab === "finanzas" && (
             <Finanzas empresaId={empresaId} caja={caja} movCaja={movCaja} ajustes={ajustes}
               abrirCaja={abrirCajaDelDia} cerrarCaja={cerrarCajaDelDia}

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -35,7 +35,7 @@ import { cargarEquipo } from "../datos/equipo.js";
 import { cargarAbonos } from "../datos/abonos.js";
 import { alertasDe } from "../datos/clientes.js";
 import { cargarRecursos } from "../datos/comandas.js";
-import { money } from "../utils/helpers.js";
+import { money, linkWhatsapp } from "../utils/helpers.js";
 import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado, Apagado } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 import { Drawer } from "../ui/Drawer.jsx";
@@ -755,8 +755,8 @@ export function Agenda({ empresaId, sucursalId, permisos, clientes, toast, ir })
               </div>
             )}
 
-            {abierto.telefono && (
-              <a href={`https://wa.me/${abierto.telefono.replace(/\D/g, "")}`} target="_blank" rel="noreferrer"
+            {linkWhatsapp(abierto.telefono) && (
+              <a href={linkWhatsapp(abierto.telefono)} target="_blank" rel="noreferrer"
                 className="block text-sm text-acento hover:underline">Escribirle por WhatsApp</a>
             )}
 

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -22,7 +22,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import {
   Plus, ChevronLeft, ChevronRight, Search, Check, X, CalendarDays,
-  Clock, User, MapPin, Trash2, RotateCcw,
+  Clock, User, MapPin, Trash2, RotateCcw, AlertTriangle,
 } from "lucide-react";
 import {
   cargarTurnos, agendarTurno, moverTurno, cambiarEstado, guardarNotas,
@@ -33,6 +33,7 @@ import {
 import { cargarServicios } from "../datos/servicios.js";
 import { cargarEquipo } from "../datos/equipo.js";
 import { cargarAbonos } from "../datos/abonos.js";
+import { alertasDe } from "../datos/clientes.js";
 import { cargarRecursos } from "../datos/comandas.js";
 import { money } from "../utils/helpers.js";
 import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado, Apagado } from "../ui/Base.jsx";
@@ -84,16 +85,24 @@ function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, empre
   const [guardando, setGuardando] = useState(false);
   const [error, setError] = useState("");
   const [abonos, setAbonos] = useState([]);
+  const [alertas, setAlertas] = useState([]);
 
-  /* Los abonos del cliente elegido. Se piden al elegirlo y no antes: si se
-     trajeran todos los del comercio, un negocio con mil clientes cargaría
-     mil abonos para mostrar dos. */
+  /* Los abonos y las alertas del cliente elegido. Se piden al elegirlo y
+     no antes: si se trajeran todos los del comercio, un negocio con mil
+     clientes cargaría mil abonos para mostrar dos.
+
+     Las alertas son lo que no se puede descubrir tarde —una alergia, una
+     contraindicación— y por eso aparecen acá y no solo en la ficha: acá
+     es donde se decide con quién y para qué se lo agenda. */
   useEffect(() => {
-    if (!abierto || !d.clienteId) { setAbonos([]); return; }
+    if (!abierto || !d.clienteId) { setAbonos([]); setAlertas([]); return; }
     let vigente = true;
-    cargarAbonos(empresaId, { clienteId: d.clienteId, soloActivos: true })
-      .then((xs) => { if (vigente) setAbonos(xs); })
-      .catch(() => { if (vigente) setAbonos([]); });
+    Promise.all([
+      cargarAbonos(empresaId, { clienteId: d.clienteId, soloActivos: true }),
+      alertasDe(empresaId, d.clienteId),
+    ])
+      .then(([xs, al]) => { if (vigente) { setAbonos(xs); setAlertas(al); } })
+      .catch(() => { if (vigente) { setAbonos([]); setAlertas([]); } });
     return () => { vigente = false; };
   }, [abierto, d.clienteId, empresaId]);
 
@@ -272,6 +281,16 @@ function FormTurno({ abierto, inicial, equipo, servicios, salas, clientes, empre
                   : `${persona.nombre} no trabaja ese día.`;
               })()}
             </p>
+          )}
+
+          {/* Lo que no se puede descubrir tarde, antes de confirmar. */}
+          {alertas.length > 0 && (
+            <div className="rounded-xl border border-mal bg-mal-suave p-3 flex gap-2.5">
+              <AlertTriangle size={16} className="text-mal shrink-0 mt-0.5" />
+              <ul className="min-w-0 flex-1 space-y-0.5">
+                {alertas.map((a) => <li key={a.id} className="text-sm text-texto">{a.texto}</li>)}
+              </ul>
+            </div>
           )}
 
           {/* El crédito se descuenta al reservar, no al venir: es lo que

--- a/src/modulos/Agenda.jsx
+++ b/src/modulos/Agenda.jsx
@@ -30,7 +30,8 @@ import {
   crearClase, inscribir, cargarInscriptos, cargarEspera, anotarEnEspera,
   marcarEspera, bloquear, MOTIVOS_BLOQUEO,
 } from "../datos/agenda.js";
-import { cargarEquipo, cargarServicios } from "../datos/equipo.js";
+import { cargarServicios } from "../datos/servicios.js";
+import { cargarEquipo } from "../datos/equipo.js";
 import { cargarAbonos } from "../datos/abonos.js";
 import { cargarRecursos } from "../datos/comandas.js";
 import { money } from "../utils/helpers.js";

--- a/src/modulos/Clientes.jsx
+++ b/src/modulos/Clientes.jsx
@@ -2,10 +2,12 @@
    9 ter. CLIENTES
    ============================================================ */
 
-import React, { useState, useEffect } from "react";
-import { Search, Plus, Check } from "lucide-react";
-import { CONDICIONES, FISCAL_INICIAL, condicionNombre, money, letraComprobante } from "../utils/helpers.js";
-import { Modal, Boton, Card, Vacio } from "../ui/Base.jsx";
+import React, { useState, useEffect, useCallback } from "react";
+import { Search, Plus, Check, AlertTriangle } from "lucide-react";
+import { CONDICIONES, FISCAL_INICIAL, condicionNombre, money, letraComprobante, nf } from "../utils/helpers.js";
+import { Modal, Boton, Card, Vacio, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
+import { cargarClientesConCuentas } from "../datos/clientes.js";
+import { FichaCliente } from "./FichaCliente.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";
 
 export function FormCliente({ abierto, inicial, onGuardar, onCerrar }) {
@@ -63,49 +65,117 @@ export function FormCliente({ abierto, inicial, onGuardar, onCerrar }) {
   );
 }
 
-export function Clientes({ clientes, guardarCliente, tickets, ajustes }) {
+
+/* ============================================================
+   La lista
+
+   Muestra las cuentas de cada uno —cuántas veces vino, cuánto hace, si
+   debe— porque en un negocio de turnos eso es lo que se mira. La letra
+   del comprobante sigue estando: un comercio que factura la necesita, y
+   uno de servicios simplemente no la usa.
+
+   Se carga sola contra `clientes_vista` en vez de usar la lista que baja
+   por props: esa la necesitan el punto de venta y la agenda, y no tiene
+   por qué cargar las cuentas de todos para elegir un nombre.
+   ============================================================ */
+
+export function Clientes({ clientes, guardarCliente, tickets, ajustes, empresaId, permisos, toast }) {
   const [q, setQ] = useState("");
   const [alta, setAlta] = useState(null);
-  const norm = (t) => String(t || "").toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-  const lista = q.trim().length >= 2
-    ? clientes.filter((c) => norm(c.razonSocial).includes(norm(q)) || String(c.doc || "").includes(q.trim()))
-    : clientes;
-  const emisor = (ajustes.fiscal || FISCAL_INICIAL).condicion;
+  const [ficha, setFicha] = useState(null);
+  const [lista, setLista] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
 
-  const facturadoA = (id) => tickets.filter((t) => t.cliente && t.cliente.id === id).reduce((s, t) => s + t.total, 0);
+  const releer = useCallback(async () => {
+    const xs = await cargarClientesConCuentas(empresaId);
+    setLista(xs);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar los clientes."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer, clientes]);
+
+  if (ficha) {
+    return (
+      <FichaCliente empresaId={empresaId} clienteId={ficha} permisos={permisos} toast={toast}
+        onVolver={() => { setFicha(null); releer().catch(() => {}); }}
+        onEditar={(c) => setAlta(c)} />
+    );
+  }
+
+  const norm = (t) => String(t || "").toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  const filtrados = q.trim().length >= 2
+    ? lista.filter((c) => norm(c.razonSocial).includes(norm(q)) || String(c.doc || "").includes(q.trim()) || String(c.tel || "").includes(q.trim()))
+    : lista;
+
+  const emisor = (ajustes.fiscal || FISCAL_INICIAL).condicion;
+  const conAlertas = lista.filter((c) => c.alertas > 0).length;
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
         <div className="relative flex-1 min-w-[220px]">
           <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-texto-tenue" />
-          <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Buscar por nombre o CUIT"
+          <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Buscar por nombre, documento o teléfono"
             className="w-full pl-9 pr-3 py-2 text-sm border border-borde rounded-xl outline-none focus:border-acento bg-superficie" />
         </div>
         <Boton size="sm" onClick={() => setAlta({})}><Plus size={14} /> Nuevo cliente</Boton>
       </div>
 
       <Card className="overflow-hidden">
-        {lista.length === 0 ? <Vacio>No hay clientes cargados. Los necesitás solo para emitir facturas: la venta al mostrador no requiere ninguno.</Vacio> : (
+        {error ? (
+          <ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado>
+        ) : cargando ? (
+          <Cargando />
+        ) : filtrados.length === 0 ? (
+          <Vacio>
+            {lista.length === 0
+              ? "Todavía no hay clientes cargados. Cada turno y cada abono apuntan a uno."
+              : "Nadie coincide con esa búsqueda."}
+          </Vacio>
+        ) : (
           <ul className="divide-y divide-borde">
-            {lista.map((c) => {
+            {filtrados.map((c) => {
               const letra = letraComprobante(emisor, c.condicion);
-              const total = facturadoA(c.id);
+              const debe = c.gastado > 0 && c.compras > 0;
               return (
                 <li key={c.id}>
-                  <button onClick={() => setAlta(c)} className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                  <button onClick={() => setFicha(c.id)}
+                    className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                    <span className="w-9 h-9 shrink-0 rounded-full bg-superficie-2 flex items-center justify-center text-[11px] font-bold text-texto-suave">
+                      {iniciales(c.razonSocial)}
+                    </span>
                     <div className="min-w-0 flex-1">
-                      <div className="font-medium text-texto">{c.razonSocial}</div>
+                      <div className="font-medium text-texto flex items-center gap-2">
+                        {c.razonSocial}
+                        {c.alertas > 0 && <AlertTriangle size={13} className="text-mal" />}
+                      </div>
                       <div className="f-m text-[11px] text-texto-tenue">
-                        {c.tipoDoc} {c.doc || "sin número"} · {condicionNombre(c.condicion)}
-                        {c.tel ? ` · ${c.tel}` : ""}
+                        {c.tel || (c.doc ? `${c.tipoDoc} ${c.doc}` : "sin contacto")}
+                        {c.turnos > 0 && ` · ${nf.format(c.turnos)} turnos`}
                       </div>
                     </div>
-                    <span className={`text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded border ${
-                      letra === "A" ? "bg-superficie-3 text-texto border-superficie-3" : "bg-superficie-2 text-texto-suave border-borde"}`}>
-                      Factura {letra}
-                    </span>
-                    {total > 0 && <span className="f-m text-sm text-texto-suave">{money(total)}</span>}
+
+                    {c.abonosActivos > 0 && <Sello tono="bien">{c.abonosActivos} abono{c.abonosActivos > 1 ? "s" : ""}</Sello>}
+
+                    <div className="text-right shrink-0 w-28">
+                      <div className="f-m text-xs text-texto-suave">{haceCuanto(c.ultima)}</div>
+                      {c.gastado > 0 && <div className="f-m text-[11px] text-texto-tenue">{money(c.gastado)}</div>}
+                    </div>
+
+                    {/* La letra solo tiene sentido donde se factura. */}
+                    {c.doc && (
+                      <span className="text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded border bg-superficie-2 text-texto-suave border-borde">
+                        {letra}
+                      </span>
+                    )}
                   </button>
                 </li>
               );
@@ -114,20 +184,30 @@ export function Clientes({ clientes, guardarCliente, tickets, ajustes }) {
         )}
       </Card>
 
-      <p className="text-xs text-texto-suave">
-        La letra la calcula el sistema: sos <strong>{condicionNombre(emisor)}</strong>, así que a un responsable inscripto
-        le emitís {letraComprobante(emisor, "RI")} y al resto {letraComprobante(emisor, "CF")}.
-        Se cambia en Ajustes, en Datos fiscales.
-      </p>
+      {conAlertas > 0 && (
+        <p className="text-xs text-texto-suave">
+          {conAlertas === 1 ? "Una persona tiene" : `${conAlertas} personas tienen`} algo anotado para ver antes de atenderla.
+        </p>
+      )}
 
-      {/* El modal se cierra recién cuando la base confirmó. Cerrarlo antes
-          dejaba al usuario creyendo que había guardado cuando el alta podía
-          fallar, y el aviso de error aparecía sobre la lista sin el cliente. */}
       <FormCliente abierto={!!alta} inicial={alta} onCerrar={() => setAlta(null)}
         onGuardar={async (d) => {
           const c = await guardarCliente(d);
-          if (c) setAlta(null);
+          if (c) { setAlta(null); await releer(); }
         }} />
     </div>
   );
 }
+
+const haceCuanto = (d) => {
+  if (!d) return "nunca vino";
+  const dias = Math.floor((Date.now() - d) / 86400000);
+  if (dias <= 0) return "hoy";
+  if (dias === 1) return "ayer";
+  if (dias < 30) return `hace ${dias} d`;
+  const meses = Math.floor(dias / 30);
+  return `hace ${meses} ${meses === 1 ? "mes" : "meses"}`;
+};
+
+const iniciales = (nombre) =>
+  String(nombre || "?").trim().split(/\s+/).map((p) => p[0]).slice(0, 2).join("").toUpperCase();

--- a/src/modulos/Comunicaciones.jsx
+++ b/src/modulos/Comunicaciones.jsx
@@ -1,0 +1,334 @@
+/* ============================================================
+   22. COMUNICACIONES · lo que hay que avisar hoy
+   ============================================================
+
+   La tarea de todas las tardes: mandar los recordatorios de mañana. Es
+   lo que evita la mitad de las ausencias y hoy se hace de memoria,
+   mirando la agenda y abriendo WhatsApp a mano uno por uno.
+
+   ES UNA COLA, NO UNA TABLA
+   -------------------------
+   La lista está ordenada por hora y cada mensaje que se manda desaparece
+   de ella. Se trabaja de arriba para abajo hasta que queda vacía, que es
+   como se hace de verdad. Una grilla con casillas para tildar obliga a
+   llevar la cuenta en la cabeza.
+
+   Se avisa por turno y no por persona: alguien con dos turnos esta
+   semana recibe los dos recordatorios, y el que ya recibió el del martes
+   sigue apareciendo para el del jueves.
+
+   EL TEXTO SE VE RESUELTO, NO CON LOS HUECOS
+   ------------------------------------------
+   En la lista se lee el mensaje tal como le va a llegar a la persona, con
+   el nombre y la hora puestos. Una plantilla con `{nombre}` a la vista no
+   deja ver el error más común, que es que quede mal redactada una vez
+   completada.
+
+   UN HUECO QUE NO EXISTE SE DEJA ESCRITO
+   --------------------------------------
+   Si alguien escribe `{profe}` en vez de `{profesional}`, en la vista
+   previa aparece `{profe}` y se corrige solo. Borrarlo en silencio deja
+   un mensaje mocho y ninguna pista de por qué.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { MessageCircle, Check, RotateCcw, Clock } from "lucide-react";
+import {
+  cargarPendientes, cargarPlantillas, guardarPlantilla, restaurarPlantilla,
+  anotarAviso, resolver, plantillaPorK, HUECOS,
+} from "../datos/comunicaciones.js";
+import { cargarContactos, segmentoPorK } from "../datos/crm.js";
+import { linkWhatsapp, nf } from "../utils/helpers.js";
+import {
+  Card, Boton, Tabs, Kpi, Vacio, Cargando, ErrorEstado, Sello, TablaSimple,
+} from "../ui/Base.jsx";
+import { inputCls } from "../ui/Campos.jsx";
+
+const ROTULO = "text-[11px] uppercase tracking-[0.1em] text-texto-tenue font-bold";
+
+const VENTANAS = [
+  { k: 12, n: "12 horas" },
+  { k: 24, n: "24 horas" },
+  { k: 48, n: "2 días" },
+];
+
+const cuando = (d) =>
+  d.toLocaleDateString("es-AR", { weekday: "short", day: "2-digit", month: "2-digit" }) +
+  " · " + d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+export function Comunicaciones({ empresaId, rubro, ajustes, setAjustes, toast }) {
+  const [pestana, setPestana] = useState("avisar");
+  const [horas, setHoras] = useState(() => Number(ajustes.recordatorioHoras) || 24);
+  const [cual, setCual] = useState("recordatorio");
+
+  const [pendientes, setPendientes] = useState([]);
+  const [plantillas, setPlantillas] = useState([]);
+  const [historial, setHistorial] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [editando, setEditando] = useState(null);   // { k, texto }
+
+  const releer = useCallback(async () => {
+    const [p, t, h] = await Promise.all([
+      cargarPendientes(empresaId, horas),
+      cargarPlantillas(empresaId),
+      cargarContactos(empresaId, { dias: 60 }),
+    ]);
+    setPendientes(p);
+    setPlantillas(t);
+    setHistorial(h);
+  }, [empresaId, horas]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos armar la lista."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  const plantilla = useMemo(
+    () => plantillas.find((p) => p.k === cual) || { k: cual, texto: plantillaPorK(cual).texto },
+    [plantillas, cual]);
+
+  const sinConfirmar = useMemo(
+    () => pendientes.filter((t) => t.estado === "pendiente").length, [pendientes]);
+  const avisadosHoy = useMemo(() => {
+    const desde = new Date(); desde.setHours(0, 0, 0, 0);
+    return historial.filter((h) => h.motivo === "recordatorio" && h.fecha >= desde).length;
+  }, [historial]);
+
+  /* La ventana es del comercio y no de la pantalla: quien la cambia lo
+     hace una vez y espera encontrarla igual mañana. */
+  function cambiarVentana(h) {
+    setHoras(h);
+    setAjustes({ ...ajustes, recordatorioHoras: h });
+  }
+
+  async function avisar(t) {
+    const texto = resolver(plantilla.texto, t, ajustes, rubro);
+    try {
+      await anotarAviso({
+        empresaId, clienteId: t.clienteId, reservaId: t.reservaId,
+        motivo: "recordatorio", canal: "whatsapp", texto,
+      });
+      const url = linkWhatsapp(t.tel, texto);
+      if (url) window.open(url, "_blank", "noopener");
+      else toast("Anotado, pero el teléfono no sirve para WhatsApp.");
+      await releer();
+    } catch (e) {
+      toast(e.message || "No se pudo anotar.");
+    }
+  }
+
+  async function guardar() {
+    try {
+      await guardarPlantilla(empresaId, editando.k, editando.texto);
+      setEditando(null);
+      await releer();
+      toast("Plantilla guardada.");
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.");
+    }
+  }
+
+  async function restaurar(k) {
+    try {
+      await restaurarPlantilla(empresaId, k);
+      setEditando(null);
+      await releer();
+      toast("Volvió al texto original.");
+    } catch (e) {
+      toast(e.message || "No se pudo restaurar.");
+    }
+  }
+
+  if (error) return <ErrorEstado onReintentar={releer}>{error}</ErrorEstado>;
+  if (cargando && !plantillas.length) return <Cargando>Buscando los turnos que vienen…</Cargando>;
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Kpi label="Turnos por avisar" valor={nf.format(pendientes.length)}
+          icono={MessageCircle}
+          sub={pendientes.length ? `en las próximas ${horas} horas` : "no queda nadie"} />
+        <Kpi label="Sin confirmar" valor={nf.format(sinConfirmar)}
+          tono={sinConfirmar ? "ojo" : "neutro"}
+          sub="todavía no dijeron que vienen" />
+        <Kpi label="Avisados hoy" valor={nf.format(avisadosHoy)} icono={Check} />
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "avisar", n: "Por avisar", badge: pendientes.length },
+        { k: "plantillas", n: "Plantillas" },
+        { k: "historial", n: "Lo que se mandó", badge: historial.length },
+      ]} />
+
+      {pestana === "avisar" && (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={ROTULO}><Clock size={12} className="inline mb-0.5 mr-1" />Avisar con</span>
+            {VENTANAS.map((v) => (
+              <button key={v.k} onClick={() => cambiarVentana(v.k)}
+                className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                  horas === v.k
+                    ? "bg-superficie-3 text-texto border-superficie-3"
+                    : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
+                {v.n}
+              </button>
+            ))}
+            <span className="text-xs text-texto-tenue">de anticipación</span>
+          </div>
+
+          {!pendientes.length ? (
+            <Card className="p-6">
+              <Vacio>
+                No queda nadie a quien avisarle en las próximas {horas} horas.
+                O ya está todo mandado, o no hay turnos.
+              </Vacio>
+            </Card>
+          ) : (
+            <Card className="overflow-hidden">
+              <div className="px-5 py-4 border-b border-borde flex items-start justify-between gap-4 flex-wrap">
+                <div>
+                  <h3 className="f-d">Los turnos que vienen</h3>
+                  <p className="text-xs text-texto-suave mt-1">
+                    Cada uno se va de la lista cuando se manda. Se avisa por turno:
+                    quien tiene dos esta semana recibe los dos.
+                  </p>
+                </div>
+                <select value={cual} onChange={(e) => setCual(e.target.value)}
+                  className="bg-superficie border border-borde rounded-md px-2.5 py-1.5 text-xs outline-none focus:border-acento">
+                  {plantillas.map((p) => <option key={p.k} value={p.k}>{p.n}</option>)}
+                </select>
+              </div>
+
+              <ul className="divide-y divide-borde">
+                {pendientes.map((t) => (
+                  <li key={t.reservaId} className="px-5 py-3.5 flex items-start gap-4 hover:bg-superficie-2">
+                    <div className="w-28 shrink-0">
+                      <div className="f-m text-sm">{cuando(t.desde)}</div>
+                      {t.estado === "pendiente" && <Sello tono="ojo" className="mt-1">Sin confirmar</Sello>}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium truncate">
+                        {t.cliente}
+                        {t.esClase && <span className="text-xs text-texto-tenue font-normal ml-2">en clase</span>}
+                      </div>
+                      <div className="text-xs text-texto-suave truncate">
+                        {[t.servicio, t.profesional, t.sala].filter(Boolean).join(" · ")}
+                      </div>
+                      {/* El mensaje tal como le va a llegar, no la plantilla. */}
+                      <p className="text-xs text-texto-tenue mt-1.5 leading-relaxed">
+                        {resolver(plantilla.texto, t, ajustes, rubro)}
+                      </p>
+                    </div>
+                    <Boton size="sm" variant="ghost" className="shrink-0"
+                      onClick={() => avisar(t)} disabled={!t.tel}
+                      title={t.tel ? "" : "No tiene teléfono cargado"}>
+                      <MessageCircle size={15} /> Avisar
+                    </Boton>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          )}
+        </>
+      )}
+
+      {pestana === "plantillas" && (
+        <div className="space-y-4">
+          <Card className="p-5">
+            <div className={ROTULO}>Los huecos que se pueden usar</div>
+            <div className="flex flex-wrap gap-2 mt-3">
+              {HUECOS.map((h) => (
+                <span key={h.k} className="text-xs border border-borde rounded-md px-2 py-1 text-texto-suave">
+                  <span className="f-m text-acento">{"{" + h.k + "}"}</span>
+                  <span className="text-texto-tenue ml-1.5">{h.d}</span>
+                </span>
+              ))}
+            </div>
+            <p className="text-xs text-texto-suave mt-3">
+              Lo que no sea uno de estos queda escrito tal cual en el mensaje. Es a
+              propósito: así un error de tipeo se ve en la vista previa en vez de
+              desaparecer.
+            </p>
+          </Card>
+
+          {plantillas.map((p) => (
+            <Card key={p.k} className="p-5">
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="min-w-0">
+                  <h3 className="f-d flex items-center gap-2">
+                    {p.n}
+                    {p.propia && <Sello tono="acento">Cambiada</Sello>}
+                  </h3>
+                  <p className="text-xs text-texto-suave mt-1">{p.d}</p>
+                </div>
+                {editando && editando.k === p.k ? (
+                  <div className="flex items-center gap-2">
+                    <Boton size="sm" onClick={guardar}>Guardar</Boton>
+                    <Boton size="sm" variant="ghost" onClick={() => setEditando(null)}>Cancelar</Boton>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    {p.propia && (
+                      <Boton size="sm" variant="ghost" onClick={() => restaurar(p.k)}
+                        title="Vuelve al texto de fábrica">
+                        <RotateCcw size={14} /> Volver al original
+                      </Boton>
+                    )}
+                    <Boton size="sm" variant="ghost" onClick={() => setEditando({ k: p.k, texto: p.texto })}>
+                      Editar
+                    </Boton>
+                  </div>
+                )}
+              </div>
+
+              {editando && editando.k === p.k ? (
+                <textarea value={editando.texto} rows={4}
+                  onChange={(e) => setEditando({ ...editando, texto: e.target.value })}
+                  className={`${inputCls} resize-y leading-relaxed mt-3`} />
+              ) : (
+                <p className="text-sm text-texto-suave mt-3 leading-relaxed border border-borde rounded-lg p-3 bg-superficie-2">
+                  {p.texto}
+                </p>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {pestana === "historial" && (
+        <Card className="overflow-hidden">
+          <div className="px-5 py-4 border-b border-borde">
+            <h3 className="f-d">Todo lo que se mandó</h3>
+            <p className="text-xs text-texto-suave mt-1">
+              Los recordatorios de acá y los mensajes de seguimiento, juntos.
+              Son el mismo registro: dos listas de mensajes enviados es la forma
+              más rápida de no saber nunca si a alguien ya se le escribió.
+            </p>
+          </div>
+          <TablaSimple
+            cols={["Cliente", "Por qué", "Cuándo", "Qué se le dijo"]}
+            filas={historial.map((h) => [
+              <span key="a" className="font-medium">{h.cliente || "—"}</span>,
+              <span className="text-texto-suave">
+                {h.motivo === "recordatorio" ? "Recordatorio de turno" : segmentoPorK(h.motivo).n}
+              </span>,
+              <span className="f-m text-texto-suave">
+                {h.fecha.toLocaleDateString("es-AR", { day: "2-digit", month: "short" })}
+              </span>,
+              <span className="text-xs text-texto-tenue block max-w-md truncate" title={h.texto}>
+                {h.texto || "—"}
+              </span>,
+            ])}
+            vacio="Todavía no se mandó ningún mensaje."
+          />
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/modulos/Crm.jsx
+++ b/src/modulos/Crm.jsx
@@ -1,0 +1,267 @@
+/* ============================================================
+   21. CRM Y MARKETING · a quién escribirle esta semana
+   ============================================================
+
+   Una lista de trabajo, no un tablero de métricas. La pantalla existe
+   para que alguien la abra un martes a la mañana, escriba ocho mensajes
+   y la cierre vacía.
+
+   POR ESO ES UNA LISTA QUE SE VACÍA
+   ---------------------------------
+   Cada persona a la que se le escribe desaparece del segmento por tres
+   semanas. Sin eso, el lunes aparecen los mismos veinte nombres que el
+   viernes, nadie se acuerda a cuáles ya les escribió, y la pantalla se
+   deja de abrir. Es la diferencia entre una herramienta y un informe más.
+
+   EL MENSAJE SE LEE ANTES DE MANDARSE
+   -----------------------------------
+   El texto viene escrito pero editable, y lo que se guarda es lo que se
+   mandó. Nada sale solo: se abre WhatsApp con el mensaje cargado y la
+   persona aprieta enviar. Un sistema que escribe en nombre de un negocio
+   sin que nadie lo lea es una forma rápida de perder clientes.
+
+   LO QUE PASÓ DESPUÉS
+   -------------------
+   "Volvió" se marca a mano y es la única columna que dice si esto sirve.
+   Sin ella, el módulo informa cuántos mensajes se mandaron y nada sobre
+   si valió la pena mandarlos.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { MessageCircle, Phone, BellOff } from "lucide-react";
+import {
+  cargarSegmentos, cargarContactos, anotarContacto, marcarResultado,
+  noContactar, mensajeDe, segmentoPorK, palabrasDe, RESULTADOS,
+} from "../datos/crm.js";
+import { linkWhatsapp, money, nf } from "../utils/helpers.js";
+import {
+  Card, Boton, Modal, Tabs, Kpi, Vacio, Cargando, ErrorEstado, Sello, TablaSimple,
+} from "../ui/Base.jsx";
+import { inputCls } from "../ui/Campos.jsx";
+
+const ROTULO = "text-[11px] uppercase tracking-[0.1em] text-texto-tenue font-bold";
+const fecha = (d) => d.toLocaleDateString("es-AR", { day: "2-digit", month: "short" });
+
+export function Crm({ empresaId, rubro, toast }) {
+  const [pestana, setPestana] = useState("hacer");
+  const [segmentos, setSegmentos] = useState([]);
+  const [contactos, setContactos] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [abierto, setAbierto] = useState(null);   // { fila, segmento }
+  const [texto, setTexto] = useState("");
+
+  /* Cómo llama este rubro a un cliente: alumno, paciente, socio. Mismo
+     mecanismo que VOZ_MESA en la comanda. */
+  const palabras = useMemo(() => palabrasDe(rubro), [rubro]);
+
+  const releer = useCallback(async () => {
+    const [s, c] = await Promise.all([
+      cargarSegmentos(empresaId),
+      cargarContactos(empresaId, { dias: 90 }),
+    ]);
+    setSegmentos(s);
+    setContactos(c);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos armar la lista."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  const pendientes = useMemo(
+    () => segmentos.reduce((s, x) => s + x.gente.length, 0), [segmentos]);
+  const volvieron = useMemo(
+    () => contactos.filter((c) => c.resultado === "volvio").length, [contactos]);
+  const ultimos30 = useMemo(
+    () => contactos.filter((c) => c.fecha > new Date(Date.now() - 30 * 86400000)).length, [contactos]);
+
+  function abrir(fila, segmento) {
+    setAbierto({ fila, segmento });
+    setTexto(mensajeDe(segmento, fila, rubro));
+  }
+
+  /* Se anota primero y se abre después. Si se hiciera al revés y el
+     navegador bloqueara la pestaña, quedaría un mensaje mandado que el
+     sistema no registró, que es peor que uno registrado de más. */
+  async function escribir(canal) {
+    const { fila, segmento } = abierto;
+    try {
+      await anotarContacto({
+        empresaId, clienteId: fila.clienteId, motivo: segmento, canal, texto,
+      });
+      if (canal === "whatsapp") {
+        const url = linkWhatsapp(fila.tel, texto);
+        if (url) window.open(url, "_blank", "noopener");
+        else toast("Anotado, pero el teléfono no sirve para WhatsApp.");
+      }
+      setAbierto(null);
+      await releer();
+      if (canal !== "whatsapp") toast("Anotado.");
+    } catch (e) {
+      toast(e.message || "No se pudo anotar.");
+    }
+  }
+
+  async function silenciar() {
+    const { fila } = abierto;
+    try {
+      await noContactar(empresaId, fila.clienteId, true);
+      setAbierto(null);
+      await releer();
+      toast(`${fila.cliente} no va a aparecer más en estas listas.`);
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.");
+    }
+  }
+
+  async function cambiarResultado(id, resultado) {
+    try {
+      await marcarResultado(id, resultado);
+      await releer();
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.");
+    }
+  }
+
+  if (error) return <ErrorEstado onReintentar={releer}>{error}</ErrorEstado>;
+  if (cargando && !segmentos.length) return <Cargando>Buscando a quién escribirle…</Cargando>;
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Kpi label="Para escribirles" valor={nf.format(pendientes)}
+          icono={MessageCircle}
+          sub={pendientes ? "en cinco motivos distintos" : "lista al día"} />
+        <Kpi label="Mensajes en 30 días" valor={nf.format(ultimos30)} />
+        <Kpi label="Volvieron" valor={nf.format(volvieron)} tono={volvieron ? "bien" : "neutro"}
+          sub="marcado a mano, sobre 90 días" />
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "hacer", n: "Para hacer", badge: pendientes },
+        { k: "hecho", n: "Lo que se mandó", badge: contactos.length },
+      ]} />
+
+      {pestana === "hacer" && (
+        pendientes === 0 ? (
+          <Card className="p-6">
+            <Vacio>
+              No hay nadie a quien escribirle. O ya está todo hecho, o todavía
+              no hay historia suficiente para que el sistema note un patrón.
+            </Vacio>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {segmentos.filter((s) => s.gente.length > 0).map((s) => (
+              <Card key={s.k} className="overflow-hidden">
+                <div className="px-5 py-4 border-b border-borde flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <h3 className="f-d flex items-center gap-2">
+                      {s.n}
+                      <Sello tono={s.tono}>{nf.format(s.gente.length)}</Sello>
+                    </h3>
+                    <p className="text-xs text-texto-suave mt-1">{s.d}</p>
+                  </div>
+                </div>
+                <ul className="divide-y divide-borde">
+                  {s.gente.map((f) => (
+                    <li key={f.clienteId} className="px-5 py-3 flex items-center gap-4 hover:bg-superficie-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="font-medium truncate">{f.cliente}</div>
+                        <div className="text-xs text-texto-suave truncate">{f.motivo}</div>
+                      </div>
+                      <div className="text-right shrink-0 hidden sm:block">
+                        <div className={`${ROTULO} font-normal`}>Gastó</div>
+                        <div className="f-m text-sm">{money(f.valor)}</div>
+                      </div>
+                      <Boton size="sm" variant="ghost" onClick={() => abrir(f, s.k)}>
+                        <MessageCircle size={15} /> Escribir
+                      </Boton>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </div>
+        )
+      )}
+
+      {pestana === "hecho" && (
+        <Card className="overflow-hidden">
+          <div className="px-5 py-4 border-b border-borde">
+            <h3 className="f-d">Lo que se mandó</h3>
+            <p className="text-xs text-texto-suave mt-1">
+              Marcar "Volvió" es lo único que dice si esto sirve. Nadie lo puede
+              deducir por el sistema: lo sabe quien la vio entrar.
+            </p>
+          </div>
+          <TablaSimple
+            cols={["Cliente", "Motivo", "Cuándo", "Cómo", "Qué pasó"]}
+            filas={contactos.map((c) => [
+              <span key="a" className="font-medium">{c.cliente || "—"}</span>,
+              <span className="text-texto-suave">{segmentoPorK(c.motivo).n}</span>,
+              <span className="f-m text-texto-suave">{fecha(c.fecha)}</span>,
+              <span className="text-texto-suave">{c.canal === "whatsapp" ? "WhatsApp" : c.canal}</span>,
+              <select value={c.resultado} onChange={(e) => cambiarResultado(c.id, e.target.value)}
+                className="bg-superficie border border-borde rounded-md px-2 py-1 text-xs outline-none focus:border-acento">
+                {RESULTADOS.map((r) => <option key={r.k} value={r.k}>{r.n}</option>)}
+              </select>,
+            ])}
+            vacio="Todavía no se le escribió a nadie desde acá."
+          />
+        </Card>
+      )}
+
+      <Modal open={!!abierto} onClose={() => setAbierto(null)}>
+        {abierto && (
+          <div className="p-6 space-y-4">
+            <div>
+              <div className={ROTULO}>{segmentoPorK(abierto.segmento).n}</div>
+              <h3 className="f-d text-lg mt-1">{abierto.fila.cliente}</h3>
+              <p className="text-sm text-texto-suave">{abierto.fila.motivo}</p>
+              {abierto.fila.ultimoContacto && (
+                <p className="text-xs text-texto-tenue mt-1">
+                  Ya se le escribió por esto el {fecha(abierto.fila.ultimoContacto)}.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className={ROTULO}>El mensaje</label>
+              <textarea value={texto} onChange={(e) => setTexto(e.target.value)} rows={6}
+                className={`${inputCls} resize-y leading-relaxed`} />
+              <p className="text-xs text-texto-tenue mt-1.5">
+                Se abre WhatsApp con esto cargado. Todavía lo podés cambiar ahí antes de enviar.
+              </p>
+            </div>
+
+            {!abierto.fila.tel && (
+              <p className="text-xs text-mal">
+                Este {palabras.cliente} no tiene teléfono cargado. Se puede anotar el llamado igual.
+              </p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <Boton onClick={() => escribir("whatsapp")} disabled={!abierto.fila.tel}>
+                <MessageCircle size={15} /> Abrir WhatsApp
+              </Boton>
+              <Boton variant="ghost" onClick={() => escribir("telefono")}>
+                <Phone size={15} /> Lo llamé
+              </Boton>
+              <Boton variant="ghost" className="ml-auto text-texto-tenue" onClick={silenciar}
+                title="No vuelve a aparecer en ninguna lista de seguimiento">
+                <BellOff size={15} /> No contactar
+              </Boton>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/modulos/Equipo.jsx
+++ b/src/modulos/Equipo.jsx
@@ -17,10 +17,13 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Plus, Check, Search, Clock, Trash2, UserCog } from "lucide-react";
 import {
-  cargarEquipo, cargarServicios, crearPersona, guardarPersona,
+  cargarEquipo, crearPersona, guardarPersona,
   desactivarPersona, guardarHorarios, guardarServicios,
   DIAS, MODALIDADES, TIPOS,
 } from "../datos/equipo.js";
+/* El catálogo de prestaciones vive en su propio módulo desde que existe la
+   pantalla de Servicios: es el mismo dato leído desde los dos lados. */
+import { cargarServicios } from "../datos/servicios.js";
 import { money, nf } from "../utils/helpers.js";
 import { Card, Boton, Modal, Vacio, Tabs } from "../ui/Base.jsx";
 import { Campo, inputCls } from "../ui/Campos.jsx";

--- a/src/modulos/FichaCliente.jsx
+++ b/src/modulos/FichaCliente.jsx
@@ -1,0 +1,291 @@
+/* ============================================================
+   9 quater. LA FICHA DEL CLIENTE
+   ============================================================
+
+   En una estética esto es la mitad del valor del sistema: qué se le hizo,
+   cuándo, con qué y si hay algo que no se le puede hacer.
+
+   Ocupa la pantalla entera en vez de ir en un panel al costado. No es
+   capricho: son cinco listas —turnos, abonos, pagos, notas— y en un
+   drawer hay que desplazar para ver cualquier cosa, que es justo lo
+   contrario de lo que se le pide a una ficha.
+
+   Las alertas van arriba de todo y fuera de las pestañas. Una
+   contraindicación adentro de una pestaña es una contraindicación que
+   nadie ve.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  ChevronLeft, Plus, AlertTriangle, Trash2, Calendar, Ticket,
+  Receipt, StickyNote, Phone, Mail, MapPin,
+} from "lucide-react";
+import { cargarFicha, anotarEnFicha, borrarNota } from "../datos/clientes.js";
+import { estadoDe } from "../datos/agenda.js";
+import { estadoAbono } from "../datos/abonos.js";
+import { money, nf, pct } from "../utils/helpers.js";
+import { Card, Kpi, Boton, Vacio, Tabs, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
+import { inputCls } from "../ui/Campos.jsx";
+
+const fecha = (d) => (d ? d.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit", year: "2-digit" }) : "—");
+const fechaHora = (d) => `${fecha(d)} ${d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false })}`;
+
+const iniciales = (nombre) =>
+  String(nombre || "?").trim().split(/\s+/).map((p) => p[0]).slice(0, 2).join("").toUpperCase();
+
+const haceCuanto = (d) => {
+  if (!d) return "nunca vino";
+  const dias = Math.floor((Date.now() - d) / 86400000);
+  if (dias <= 0) return "hoy";
+  if (dias === 1) return "ayer";
+  if (dias < 30) return `hace ${dias} días`;
+  const meses = Math.floor(dias / 30);
+  return `hace ${meses} ${meses === 1 ? "mes" : "meses"}`;
+};
+
+export function FichaCliente({ empresaId, clienteId, onVolver, onEditar, permisos, toast }) {
+  const [datos, setDatos] = useState(null);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [pestana, setPestana] = useState("historial");
+  const [nota, setNota] = useState("");
+  const [alerta, setAlerta] = useState(false);
+
+  const releer = useCallback(async () => {
+    const d = await cargarFicha(empresaId, clienteId);
+    setDatos(d);
+  }, [empresaId, clienteId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar la ficha."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  if (cargando) return <Card><Cargando /></Card>;
+  if (error) return <Card><ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado></Card>;
+  if (!datos) return null;
+
+  const { cliente: c, turnos, abonos, ventas, notas } = datos;
+  const alertas = notas.filter((n) => n.destacada);
+  const debe = ventas.reduce((s, v) => s + Math.max(0, v.falta), 0);
+
+  async function anotar() {
+    if (!nota.trim()) return;
+    try {
+      await anotarEnFicha(empresaId, clienteId, nota.trim(), alerta);
+      setNota("");
+      setAlerta(false);
+      await releer();
+    } catch (e) {
+      toast(e.message || "No se pudo anotar.", "mal");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onVolver}
+        className="inline-flex items-center gap-1.5 text-sm font-semibold text-texto-suave hover:text-texto">
+        <ChevronLeft size={16} /> Volver a clientes
+      </button>
+
+      {/* ---------- Encabezado ---------- */}
+      <Card className="p-5">
+        <div className="flex flex-wrap items-start gap-4">
+          <span className="w-14 h-14 shrink-0 rounded-full bg-superficie-2 flex items-center justify-center text-lg font-bold text-texto-suave">
+            {iniciales(c.razonSocial)}
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="f-d text-xl">{c.razonSocial}</h2>
+            <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1.5 text-sm text-texto-suave">
+              {c.tel && <span className="inline-flex items-center gap-1.5"><Phone size={13} /> {c.tel}</span>}
+              {c.email && <span className="inline-flex items-center gap-1.5"><Mail size={13} /> {c.email}</span>}
+              {c.domicilio && <span className="inline-flex items-center gap-1.5"><MapPin size={13} /> {c.domicilio}</span>}
+            </div>
+            <p className="text-[11px] text-texto-tenue mt-1.5">
+              Cliente desde {fecha(c.alta)} · {haceCuanto(c.ultima)}
+              {c.proxima && ` · próximo turno ${fechaHora(c.proxima)}`}
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            {c.tel && (
+              <a href={`https://wa.me/${c.tel.replace(/\D/g, "")}`} target="_blank" rel="noreferrer"
+                className="text-xs font-semibold px-3 py-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2">
+                WhatsApp
+              </a>
+            )}
+            <Boton size="sm" variant="ghost" onClick={() => onEditar(c)}>Editar datos</Boton>
+          </div>
+        </div>
+      </Card>
+
+      {/* ---------- Las alertas, fuera de las pestañas ---------- */}
+      {alertas.length > 0 && (
+        <Card className="p-4 border-mal">
+          <div className="flex gap-3">
+            <AlertTriangle size={18} className="text-mal shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <div className="text-[10px] uppercase tracking-widest text-mal font-bold">
+                {alertas.length === 1 ? "Atención" : "Atención"}
+              </div>
+              <ul className="mt-1.5 space-y-1">
+                {alertas.map((a) => (
+                  <li key={a.id} className="text-sm text-texto">{a.texto}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* ---------- Las cuentas ---------- */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <Kpi label="Turnos" icono={Calendar} valor={nf.format(c.turnos)}
+          sub={`${nf.format(c.asistio)} asistió · ${nf.format(c.ausencias)} faltó`} />
+        <Kpi label="Asistencia" valor={c.asistencia === null ? "—" : pct(c.asistencia)}
+          tono={c.asistencia === null ? "neutro" : c.asistencia >= 0.8 ? "bien" : c.asistencia >= 0.6 ? "neutro" : "mal"}
+          sub={c.asistencia === null ? "sin turnos pasados" : "de los que ya pasaron"} />
+        <Kpi label="Gastado" icono={Receipt} valor={money(c.gastado)}
+          sub={`${nf.format(c.compras)} ${c.compras === 1 ? "operación" : "operaciones"}`} />
+        <Kpi label="Debe" valor={money(debe)} tono={debe > 0 ? "mal" : "neutro"}
+          icono={Ticket} sub={c.abonosActivos > 0 ? `${nf.format(c.abonosActivos)} abonos activos` : "sin abonos activos"} />
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "historial", n: "Historial", badge: turnos.length || null },
+        { k: "abonos", n: "Abonos", badge: abonos.length || null },
+        { k: "pagos", n: "Pagos", badge: ventas.length || null },
+        { k: "notas", n: "Notas", badge: notas.length || null },
+      ]} />
+
+      <Card className="overflow-hidden">
+        {/* ---------- Historial ---------- */}
+        {pestana === "historial" && (
+          turnos.length === 0 ? (
+            <Vacio>Todavía no tuvo ningún turno.</Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {turnos.map((t) => (
+                <li key={t.id} className="px-4 py-3 flex flex-wrap items-center gap-3">
+                  <span className="f-m text-xs text-texto-tenue w-20 shrink-0">{fecha(t.desde)}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-texto truncate">{t.servicio || "Turno"}</div>
+                    <div className="text-[11px] text-texto-tenue truncate">
+                      {[t.profesional, t.sala].filter(Boolean).join(" · ") || "sin detalle"}
+                      {t.conAbono && " · con abono"}
+                    </div>
+                  </div>
+                  {t.precio > 0 && !t.conAbono && (
+                    <span className="f-m text-xs text-texto-tenue shrink-0">{money(t.precio)}</span>
+                  )}
+                  <Sello tono={estadoDe(t.estado).tono}>{estadoDe(t.estado).n}</Sello>
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+
+        {/* ---------- Abonos ---------- */}
+        {pestana === "abonos" && (
+          abonos.length === 0 ? (
+            <Vacio>Nunca compró un abono.</Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {abonos.map((a) => (
+                <li key={a.id} className="px-4 py-3 flex flex-wrap items-center gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-texto">{a.nombre}</div>
+                    <div className="f-m text-[11px] text-texto-tenue">
+                      {a.clases === null ? "libre" : `${a.usadas} de ${a.clases} usadas`}
+                      {a.vence && ` · vence ${fecha(a.vence)}`}
+                    </div>
+                  </div>
+                  {a.clases !== null && a.estado === "activo" && (
+                    <span className="f-m text-sm text-texto shrink-0">{a.restantes} restantes</span>
+                  )}
+                  <Sello tono={estadoAbono(a.estado).tono}>{estadoAbono(a.estado).n}</Sello>
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+
+        {/* ---------- Pagos ---------- */}
+        {pestana === "pagos" && (
+          ventas.length === 0 ? (
+            <Vacio>Todavía no se le facturó nada.</Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {ventas.map((v) => (
+                <li key={v.id} className="px-4 py-3 flex flex-wrap items-center gap-3">
+                  <span className="f-m text-xs text-texto-tenue w-20 shrink-0">{fecha(v.fecha)}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-texto">{v.numero || "Sin número"}</div>
+                    <div className="f-m text-[11px] text-texto-tenue">
+                      pagó {money(v.pagado)} de {money(v.total)}
+                    </div>
+                  </div>
+                  {v.falta > 1 && <Sello tono="mal">Debe {money(v.falta)}</Sello>}
+                  <span className="f-m text-sm text-texto shrink-0">{money(v.total)}</span>
+                </li>
+              ))}
+            </ul>
+          )
+        )}
+
+        {/* ---------- Notas ---------- */}
+        {pestana === "notas" && (
+          <div className="p-4 space-y-4">
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <input value={nota} onChange={(e) => setNota(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") anotar(); }}
+                  placeholder="Prefiere a Carla · alérgica al glicólico · consulta por reformer avanzado"
+                  className={inputCls} />
+                <Boton size="sm" disabled={!nota.trim()} onClick={anotar}><Plus size={14} /> Anotar</Boton>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-texto-suave">
+                <input type="checkbox" checked={alerta} onChange={(e) => setAlerta(e.target.checked)} />
+                Es algo que hay que ver antes de atenderla
+              </label>
+              {alerta && (
+                <p className="text-xs text-texto-suave">
+                  Las alertas se muestran arriba de todo y también al agendarle un turno. Es para lo que no se puede descubrir tarde.
+                </p>
+              )}
+            </div>
+
+            {notas.length === 0 ? (
+              <Vacio>Sin notas. Acá va lo que conviene recordar de esta persona.</Vacio>
+            ) : (
+              <ul className="space-y-2.5">
+                {notas.map((x) => (
+                  <li key={x.id} className="flex gap-3 items-start">
+                    {x.destacada
+                      ? <AlertTriangle size={15} className="text-mal shrink-0 mt-0.5" />
+                      : <StickyNote size={15} className="text-texto-tenue shrink-0 mt-0.5" />}
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm text-texto">{x.texto}</p>
+                      <span className="f-m text-[11px] text-texto-tenue">{fecha(x.fecha)}</span>
+                    </div>
+                    <button onClick={async () => {
+                      try { await borrarNota(x.id); await releer(); }
+                      catch (e) { toast(e.message || "No se pudo borrar.", "mal"); }
+                    }} title="Borrar"
+                      className="shrink-0 p-1.5 rounded-lg text-texto-tenue hover:text-mal hover:bg-superficie-2">
+                      <Trash2 size={14} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/modulos/FichaCliente.jsx
+++ b/src/modulos/FichaCliente.jsx
@@ -23,7 +23,7 @@ import {
 import { cargarFicha, anotarEnFicha, borrarNota } from "../datos/clientes.js";
 import { estadoDe } from "../datos/agenda.js";
 import { estadoAbono } from "../datos/abonos.js";
-import { money, nf, pct } from "../utils/helpers.js";
+import { money, nf, pct, linkWhatsapp } from "../utils/helpers.js";
 import { Card, Kpi, Boton, Vacio, Tabs, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
 import { inputCls } from "../ui/Campos.jsx";
 
@@ -112,8 +112,8 @@ export function FichaCliente({ empresaId, clienteId, onVolver, onEditar, permiso
             </p>
           </div>
           <div className="flex gap-2 shrink-0">
-            {c.tel && (
-              <a href={`https://wa.me/${c.tel.replace(/\D/g, "")}`} target="_blank" rel="noreferrer"
+            {linkWhatsapp(c.tel) && (
+              <a href={linkWhatsapp(c.tel)} target="_blank" rel="noreferrer"
                 className="text-xs font-semibold px-3 py-2 rounded-lg border border-borde text-texto-suave hover:bg-superficie-2">
                 WhatsApp
               </a>

--- a/src/modulos/Informes.jsx
+++ b/src/modulos/Informes.jsx
@@ -1,0 +1,375 @@
+/* ============================================================
+   20. INFORMES · para un negocio que vende horas
+   ============================================================
+
+   El informe que había —y que sigue vivo para el minimercado y el bar—
+   responde "qué se vende y qué margen deja". Un negocio de turnos no
+   tiene margen por unidad: tiene horas, y las horas que no se vendieron
+   no se recuperan. Por eso el orden de esta pantalla es otro.
+
+   ARRIBA VA LA PLATA, DESPUÉS LA CAPACIDAD
+   ----------------------------------------
+   Cuánto entró es lo que todos vienen a mirar. Pero lo que hace que ese
+   número cambie el mes que viene es la ocupación, así que va segunda y no
+   escondida abajo.
+
+   Y se muestran las horas además del porcentaje. "Sala Mat 2: 0%" no dice
+   nada; "0 de 305 horas" dice que hay una sala que no se está usando.
+
+   LOS COLORES SALEN DE LAS VARIABLES
+   ----------------------------------
+   Los gráficos también. `rgb(var(--acento))` funciona como cualquier
+   color en un atributo SVG, así que un gráfico no queda con el naranja
+   escrito a mano y encima cambia solo entre el tema claro y el oscuro.
+   ============================================================ */
+
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from "recharts";
+import { CalendarClock, Wallet, Users, UserCheck } from "lucide-react";
+import { cargarInforme, PERIODOS } from "../datos/informes.js";
+import { money, moneyk, pct, nf } from "../utils/helpers.js";
+import { Kpi, Card, Vacio, Cargando, ErrorEstado, TablaSimple, Sello } from "../ui/Base.jsx";
+
+const ROTULO = "text-[11px] uppercase tracking-[0.1em] text-texto-tenue font-bold";
+
+function Rotulo({ children, ayuda }) {
+  return (
+    <div className="mb-3">
+      <div className={ROTULO}>{children}</div>
+      {ayuda && <p className="text-xs text-texto-suave mt-1">{ayuda}</p>}
+    </div>
+  );
+}
+
+/* Una fila con barra. Se repite en cuatro bloques y en todos significa lo
+   mismo: esto es cuánto, comparado con el más grande de la lista. */
+function Barra({ nombre, sub, valor, proporcion, tono = "acento" }) {
+  const color = tono === "bien" ? "bg-bien" : tono === "mal" ? "bg-mal" : "bg-acento";
+  return (
+    <li>
+      <div className="flex justify-between text-sm gap-3">
+        <span className="truncate text-texto">{nombre}</span>
+        <span className="f-m shrink-0 text-texto-suave">{valor}</span>
+      </div>
+      <div className="h-1.5 bg-superficie-2 rounded-full mt-1.5 overflow-hidden">
+        <div className={`h-full rounded-full ${color}`}
+          style={{ width: `${Math.max(2, Math.round((proporcion || 0) * 100))}%` }} />
+      </div>
+      {sub && <div className="text-[11px] text-texto-tenue mt-1">{sub}</div>}
+    </li>
+  );
+}
+
+const fechaCorta = (d) => d.toLocaleDateString("es-AR", { day: "2-digit", month: "short" });
+
+export function Informes({ empresaId }) {
+  const [dias, setDias] = useState(30);
+  const [d, setD] = useState(null);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [intento, setIntento] = useState(0);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    cargarInforme(empresaId, dias)
+      .then((r) => { if (vigente) setD(r); })
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos armar el informe."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [empresaId, dias, intento]);
+
+  const serie = useMemo(() => {
+    if (!d) return [];
+    const fin = new Date(d.hasta);
+    return d.ingresos.serie.map((v, i) => {
+      const f = new Date(fin.getTime() - (d.ingresos.serie.length - 1 - i) * 86400000);
+      return { label: fechaCorta(f), ingresos: v };
+    });
+  }, [d]);
+
+  if (error) return <ErrorEstado onReintentar={() => setIntento((x) => x + 1)}>{error}</ErrorEstado>;
+  if (cargando && !d) return <Cargando>Armando el informe…</Cargando>;
+  if (!d) return null;
+
+  const { ingresos, ocupacion, asistencia, clientes } = d;
+  const sinNada = ingresos.total === 0 && asistencia.total === 0;
+
+  const maxArea = Math.max(1, ...ingresos.porArea.map((a) => a.total));
+  const maxServicio = Math.max(1, ...ingresos.porServicio.map((s) => s.total));
+  const maxSala = Math.max(1, ...ocupacion.salas.map((s) => s.horasOcupadas));
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-1.5">
+        {PERIODOS.map((p) => (
+          <button key={p.k} onClick={() => setDias(p.k)}
+            className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+              dias === p.k
+                ? "bg-superficie-3 text-texto border-superficie-3"
+                : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
+            {p.n}
+          </button>
+        ))}
+        {cargando && <span className="text-xs text-texto-tenue ml-2">actualizando…</span>}
+      </div>
+
+      {sinNada ? (
+        <Card className="p-6">
+          <Vacio>
+            Todavía no hay turnos dictados ni ventas en este período. Cuando
+            empiecen a cargarse, el informe se arma solo.
+          </Vacio>
+        </Card>
+      ) : (
+        <>
+          {/* ---------------------------------------------------------
+              1 · La plata
+              --------------------------------------------------------- */}
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+            <Kpi label={`Ingresos ${dias} días`} valor={money(ingresos.total)}
+              delta={ingresos.delta} icono={Wallet}
+              sub={`${money(ingresos.promedioDiario)} por día`} />
+            <Kpi label="Ticket promedio" valor={money(ingresos.ticket)}
+              sub={`${nf.format(ingresos.operaciones)} ventas`} />
+            <Kpi label="Ocupación del equipo"
+              valor={ocupacion.profesionales.length ? pct(promedio(ocupacion.profesionales), 0) : "—"}
+              icono={CalendarClock}
+              sub="de las horas que tienen cargadas" />
+            <Kpi label="Asistencia"
+              valor={asistencia.pct === null ? "—" : pct(asistencia.pct, 0)}
+              tono={asistencia.pct !== null && asistencia.pct < 0.8 ? "mal" : "bien"}
+              icono={UserCheck}
+              sub={`${nf.format(asistencia.cumplidas)} de ${nf.format(asistencia.cumplidas + asistencia.ausentes)}`} />
+          </div>
+
+          <Card className="p-5">
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+              <Rotulo ayuda="Turnos cobrados y abonos vendidos, por día.">Ingresos</Rotulo>
+              {/* Un abono es plata que entró hoy por horas que se van a dar
+                  en las próximas ocho semanas. Sin este corte, un mes de
+                  muchas renovaciones parece un mes de mucha actividad. */}
+              <div className="flex items-center gap-5 text-right">
+                <div>
+                  <div className={ROTULO}>Turnos</div>
+                  <div className="f-m text-sm mt-0.5">{money(ingresos.sueltos)}</div>
+                </div>
+                <div>
+                  <div className={ROTULO}>Abonos y packs</div>
+                  <div className="f-m text-sm mt-0.5">{money(ingresos.abonos)}</div>
+                </div>
+              </div>
+            </div>
+            <ResponsiveContainer width="100%" height={230}>
+              <AreaChart data={serie} margin={{ top: 4, right: 8, left: -14, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="gIngresos" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="rgb(var(--acento))" stopOpacity={0.3} />
+                    <stop offset="100%" stopColor="rgb(var(--acento))" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="2 4" stroke="rgb(var(--borde))" vertical={false} />
+                <XAxis dataKey="label" tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
+                  interval={Math.max(0, Math.floor(dias / 8))} axisLine={false} tickLine={false} />
+                <YAxis tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
+                  tickFormatter={moneyk} axisLine={false} tickLine={false} width={60} />
+                <Tooltip formatter={(v) => [money(v), "Ingresos"]}
+                  contentStyle={{ fontSize: 12, borderRadius: 10, border: "1px solid rgb(var(--borde))", background: "rgb(var(--superficie))" }} />
+                <Area type="monotone" dataKey="ingresos" stroke="rgb(var(--acento))" strokeWidth={2} fill="url(#gIngresos)" />
+              </AreaChart>
+            </ResponsiveContainer>
+          </Card>
+
+          <div className="grid lg:grid-cols-2 gap-4">
+            <Card className="p-5">
+              <Rotulo ayuda="De qué parte del negocio viene cada peso.">Por área</Rotulo>
+              {!ingresos.porArea.length ? <Vacio>Nada facturado en el período.</Vacio> : (
+                <ul className="space-y-3">
+                  {ingresos.porArea.map((a) => (
+                    <Barra key={a.nombre} nombre={a.nombre} valor={money(a.total)}
+                      proporcion={a.total / maxArea}
+                      sub={pct(a.total / (ingresos.total || 1), 0) + " del total"} />
+                  ))}
+                </ul>
+              )}
+            </Card>
+
+            <Card className="p-5">
+              <Rotulo ayuda="Lo que más entra, contando cuántas veces se vendió.">Prestaciones y planes</Rotulo>
+              {!ingresos.porServicio.length ? <Vacio>Nada facturado en el período.</Vacio> : (
+                <ul className="space-y-3">
+                  {ingresos.porServicio.map((s) => (
+                    <Barra key={s.nombre} nombre={s.nombre} valor={money(s.total)}
+                      proporcion={s.total / maxServicio}
+                      sub={`${nf.format(s.cantidad)} ${s.plan ? "vendidos" : "turnos"}`} />
+                  ))}
+                </ul>
+              )}
+            </Card>
+          </div>
+
+          {/* ---------------------------------------------------------
+              2 · La capacidad
+              --------------------------------------------------------- */}
+          <div className="grid lg:grid-cols-2 gap-4">
+            <Card className="p-5">
+              <Rotulo ayuda="Horas agendadas sobre las horas que cada uno tiene cargadas en su horario.">
+                Ocupación del equipo
+              </Rotulo>
+              {!ocupacion.profesionales.length ? (
+                <Vacio>Nadie tiene horarios cargados todavía.</Vacio>
+              ) : (
+                <ul className="space-y-3">
+                  {ocupacion.profesionales.map((p) => (
+                    <Barra key={p.id} nombre={p.nombre}
+                      valor={p.pct === null ? "sin horario" : pct(p.pct, 0)}
+                      proporcion={p.pct || 0}
+                      tono={p.pct !== null && p.pct < 0.4 ? "mal" : "acento"}
+                      sub={`${p.horasOcupadas.toFixed(1)} de ${p.horasOfrecidas.toFixed(0)} hs · ${p.detalle}`} />
+                  ))}
+                </ul>
+              )}
+            </Card>
+
+            <Card className="p-5">
+              <Rotulo ayuda="Sobre las horas que abre el local. Una sala vacía no cuesta un sueldo, pero sí un alquiler.">
+                Uso de los espacios
+              </Rotulo>
+              {!ocupacion.salas.length ? <Vacio>No hay espacios cargados.</Vacio> : (
+                <ul className="space-y-3">
+                  {ocupacion.salas.map((s) => (
+                    <Barra key={s.id} nombre={s.nombre}
+                      valor={`${s.horasOcupadas.toFixed(1)} hs`}
+                      proporcion={s.horasOcupadas / maxSala}
+                      tono={s.horasOcupadas === 0 ? "mal" : "acento"}
+                      sub={s.horasOcupadas === 0
+                        ? "sin usar en todo el período"
+                        : `${pct(s.pct || 0, 0)} de las ${s.horasOfrecidas.toFixed(0)} hs que abre el local`} />
+                  ))}
+                </ul>
+              )}
+            </Card>
+          </div>
+
+          {ocupacion.clases.lugares > 0 && (
+            <Card className="p-5">
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <Rotulo ayuda="Una sala llena de tiempo puede estar medio vacía de gente: son dos cosas distintas y las dos deciden si conviene abrir otra clase.">
+                  Lugares de clase
+                </Rotulo>
+                <div className="text-right">
+                  <div className="f-d text-3xl tabular-nums">{pct(ocupacion.clases.pct || 0, 0)}</div>
+                  <div className="text-xs text-texto-tenue">
+                    {nf.format(ocupacion.clases.tomados)} de {nf.format(ocupacion.clases.lugares)} lugares
+                  </div>
+                </div>
+              </div>
+              <ul className="space-y-3 mt-1">
+                {ocupacion.profesionales.filter((p) => p.lugares > 0).map((p) => (
+                  <Barra key={p.id} nombre={p.nombre}
+                    valor={pct(p.pctCupo || 0, 0)}
+                    proporcion={p.pctCupo || 0}
+                    tono={p.pctCupo !== null && p.pctCupo < 0.5 ? "mal" : "bien"}
+                    sub={`${nf.format(p.tomados)} de ${nf.format(p.lugares)} lugares ofrecidos`} />
+                ))}
+              </ul>
+            </Card>
+          )}
+
+          {/* ---------------------------------------------------------
+              3 · La asistencia
+              --------------------------------------------------------- */}
+          <Card className="p-5">
+            <div className="flex items-start justify-between gap-4 flex-wrap">
+              <Rotulo ayuda="Solo sobre turnos que ya pasaron. Contar los de la semana que viene como faltas hunde el número sin motivo.">
+                Asistencia
+              </Rotulo>
+              <div className="flex flex-wrap items-center gap-2">
+                {asistencia.porEstado.map((e) => (
+                  <Sello key={e.k} tono={e.tono}>{e.n} {nf.format(e.v)}</Sello>
+                ))}
+              </div>
+            </div>
+
+            {!asistencia.porServicio.length ? (
+              <Vacio>Todavía no hay suficientes turnos cumplidos para sacar conclusiones por prestación.</Vacio>
+            ) : (
+              <>
+                <p className="text-xs text-texto-suave mb-3">
+                  Dónde más se falta. Es por acá por donde se va la agenda de una semana.
+                </p>
+                <TablaSimple
+                  cols={["Prestación", "Turnos", "Vinieron", "Faltaron", "Asistencia"]}
+                  filas={asistencia.porServicio.map((s) => [
+                    <div key="a">
+                      <div className="font-medium">{s.nombre}</div>
+                      <div className="text-[11px] text-texto-tenue">{s.area}</div>
+                    </div>,
+                    <span className="f-m text-texto-tenue">{nf.format(s.total)}</span>,
+                    <span className="f-m">{nf.format(s.vino)}</span>,
+                    <span className="f-m">{nf.format(s.falto)}</span>,
+                    <span className={`f-m font-semibold ${s.pct < 0.8 ? "text-mal" : "text-bien"}`}>
+                      {pct(s.pct, 0)}
+                    </span>,
+                  ])}
+                  vacio="Sin datos."
+                />
+              </>
+            )}
+          </Card>
+
+          {/* ---------------------------------------------------------
+              4 · La gente
+              --------------------------------------------------------- */}
+          <div className="grid lg:grid-cols-3 gap-3">
+            <Kpi label="Clientes nuevos" valor={nf.format(clientes.nuevos)}
+              delta={clientes.deltaNuevos} icono={Users}
+              sub={`en ${dias} días`} />
+            <Kpi label="Vinieron al menos una vez" valor={nf.format(clientes.activos)} />
+            <Kpi label="Volvieron" valor={nf.format(clientes.recurrentes)}
+              sub={clientes.activos ? `${pct(clientes.recurrentes / clientes.activos, 0)} de los que vinieron` : null} />
+          </div>
+
+          <Card className="p-5">
+            <Rotulo ayuda="Vinieron alguna vez y hace más de 45 días que no aparecen. No están perdidos: están sin llamar.">
+              Hace rato que no vienen
+            </Rotulo>
+            {!clientes.dormidos.length ? (
+              <Vacio>Nadie se quedó sin volver. Poco común y buena señal.</Vacio>
+            ) : (
+              <>
+                <TablaSimple
+                  cols={["Cliente", "Veces que vino", "Última vez", "Hace"]}
+                  filas={clientes.dormidos.map((c) => [
+                    <span key="a" className="font-medium">{c.nombre || "Sin nombre"}</span>,
+                    <span className="f-m">{nf.format(c.veces)}</span>,
+                    <span className="f-m text-texto-suave">{fechaCorta(c.ultima)}</span>,
+                    <span className="f-m">{nf.format(c.dias)} días</span>,
+                  ])}
+                  vacio="Sin datos."
+                />
+                {clientes.dormidosTotal > clientes.dormidos.length && (
+                  <p className="text-xs text-texto-tenue mt-3">
+                    Y {nf.format(clientes.dormidosTotal - clientes.dormidos.length)} más.
+                  </p>
+                )}
+              </>
+            )}
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* El promedio se pondera por horas ofrecidas y no por persona: alguien
+   que trabaja cuatro horas por semana no puede mover el número del equipo
+   igual que alguien de tiempo completo. */
+function promedio(profesionales) {
+  const ofrecidas = profesionales.reduce((s, p) => s + p.horasOfrecidas, 0);
+  if (!ofrecidas) return 0;
+  return profesionales.reduce((s, p) => s + p.horasOcupadas, 0) / ofrecidas;
+}

--- a/src/modulos/Permisos.jsx
+++ b/src/modulos/Permisos.jsx
@@ -1,0 +1,341 @@
+/* ============================================================
+   23. PERMISOS Y AUDITORÍA
+   ============================================================
+
+   Lo último del encargo y lo que más cuidado pide, porque es el único
+   módulo cuyo error no se ve: una pantalla mal hecha se nota, un permiso
+   mal dado no se nota hasta que alguien hizo algo que no tenía que hacer.
+
+   LO QUE SE VE ACÁ TIENE SU POLÍTICA ATRÁS
+   ----------------------------------------
+   Es la regla del proyecto: un permiso de interfaz que no tenga RLS
+   detrás no protege nada. Los dos pesados —ver la auditoría y configurar
+   el comercio— los verifica la base, no el navegador. Los otros seis son
+   de pantalla y están dichos como tales: apagan botones, no cierran
+   puertas.
+
+   Esa distinción está a la vista y no escondida en un comentario. Quien
+   configura tiene que saber cuál de las dos cosas está apagando.
+
+   NO SE PUEDE UNO DEJAR AFUERA
+   ----------------------------
+   Sacarle "configurar" al rol propio lo rechaza la base. La pantalla lo
+   avisa antes, pero el que manda es el disparador: una validación acá se
+   la saltea cualquier otro camino.
+
+   VOLVER AL ORIGINAL ES BORRAR, NO COPIAR
+   ---------------------------------------
+   Un rol sin cambios no existe en la tabla de cambios. Así, el día que se
+   corrija un valor de fábrica, el comercio que nunca lo tocó se lleva la
+   corrección.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Shield, RotateCcw, Lock } from "lucide-react";
+import {
+  cargarRoles, guardarRol, restaurarRol, cargarBitacora,
+  BANDERAS, FAMILIAS, nombreAccion,
+} from "../datos/permisos.js";
+import { nf } from "../utils/helpers.js";
+import {
+  Card, Boton, Tabs, Vacio, Cargando, ErrorEstado, Sello, TablaSimple,
+} from "../ui/Base.jsx";
+
+const ROTULO = "text-[11px] uppercase tracking-[0.1em] text-texto-tenue font-bold";
+
+const fechaHora = (d) =>
+  d.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit" }) + " · " +
+  d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+/* Un interruptor. No es un checkbox porque un permiso no es un campo de
+   formulario: se prende y se apaga, y se tiene que leer prendido o
+   apagado de un vistazo y de lejos. */
+function Interruptor({ activo, onChange, disabled }) {
+  return (
+    <button type="button" onClick={() => !disabled && onChange(!activo)} disabled={disabled}
+      className={`w-9 h-5 rounded-full border transition-colors shrink-0 relative ${
+        activo ? "bg-acento border-acento" : "bg-superficie-2 border-borde"
+      } ${disabled ? "opacity-40 cursor-not-allowed" : ""}`}>
+      <span className={`block w-3.5 h-3.5 rounded-full bg-superficie absolute top-0.5 transition-all ${
+        activo ? "left-[18px]" : "left-0.5"}`} />
+    </button>
+  );
+}
+
+export function Permisos({ empresaId, modulosComercio, catalogoModulos, miRol, esPlataforma, toast }) {
+  const [pestana, setPestana] = useState("roles");
+  const [roles, setRoles] = useState([]);
+  const [bitacora, setBitacora] = useState([]);
+  const [familia, setFamilia] = useState("");
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [borrador, setBorrador] = useState(null);   // { k, modulos, permisos }
+
+  const releer = useCallback(async () => {
+    const [r, b] = await Promise.all([
+      cargarRoles(empresaId),
+      cargarBitacora(empresaId, { familia: familia || null, dias: 60 }),
+    ]);
+    setRoles(r);
+    setBitacora(b);
+  }, [empresaId, familia]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar los permisos."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  /* Solo las familias que este comercio tiene registradas: un negocio de
+     turnos no tiene pedidos y no tiene por qué ver ese filtro. */
+  const familias = useMemo(() => {
+    const hay = new Set(bitacora.map((b) => String(b.accion).split(".")[0]));
+    return FAMILIAS.filter((f) => hay.has(f.k) || f.k === familia);
+  }, [bitacora, familia]);
+
+  function editar(rol) {
+    setBorrador({
+      k: rol.k,
+      modulos: rol.todos ? null : [...(rol.modulos || [])],
+      permisos: { ...rol.permisos },
+    });
+  }
+
+  async function guardar(rol) {
+    try {
+      await guardarRol(empresaId, rol, borrador);
+      setBorrador(null);
+      await releer();
+      toast("Permisos guardados.");
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.", "mal");
+    }
+  }
+
+  async function restaurar(rol) {
+    try {
+      await restaurarRol(empresaId, rol.k);
+      setBorrador(null);
+      await releer();
+      toast(`${rol.n} volvió a los valores de fábrica.`);
+    } catch (e) {
+      toast(e.message || "No se pudo restaurar.", "mal");
+    }
+  }
+
+  if (error) return <ErrorEstado onReintentar={releer}>{error}</ErrorEstado>;
+  if (cargando && !roles.length) return <Cargando>Cargando los permisos…</Cargando>;
+
+  const cambiados = roles.filter((r) => r.propio).length;
+
+  return (
+    <div className="space-y-5">
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "roles", n: "Roles", badge: cambiados || undefined },
+        { k: "auditoria", n: "Auditoría", badge: bitacora.length },
+      ]} />
+
+      {pestana === "roles" && (
+        <div className="space-y-4">
+          <Card className="p-5">
+            <div className={ROTULO}>Cómo leer esta pantalla</div>
+            <p className="text-sm text-texto-suave mt-2 leading-relaxed">
+              Lo que ve una persona es el cruce de tres cosas: los módulos que el
+              comercio contrató, los que su rol alcanza y lo que estas banderas
+              habilitan. Un módulo no contratado no lo ve ni el dueño.
+            </p>
+            <p className="text-sm text-texto-suave mt-2 leading-relaxed">
+              Los dos permisos marcados con <Lock size={11} className="inline mb-0.5" /> los
+              verifica la base de datos. El resto apaga botones en la pantalla:
+              sirve para evitar errores, no para frenar a alguien decidido.
+            </p>
+          </Card>
+
+          {roles.map((rol) => {
+            const editando = borrador && borrador.k === rol.k;
+            const d = editando ? borrador : rol;
+            const esMiRol = !esPlataforma && miRol === rol.k;
+
+            return (
+              <Card key={rol.k} className="overflow-hidden">
+                <div className="px-5 py-4 border-b border-borde flex items-start justify-between gap-4 flex-wrap">
+                  <div className="min-w-0">
+                    <h3 className="f-d flex items-center gap-2">
+                      {rol.n}
+                      {rol.propio && <Sello tono="acento">Cambiado</Sello>}
+                      {esMiRol && <Sello tono="info">Es tu rol</Sello>}
+                    </h3>
+                    <p className="text-xs text-texto-suave mt-1">{rol.d}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {editando ? (
+                      <>
+                        <Boton size="sm" onClick={() => guardar(rol)}>Guardar</Boton>
+                        <Boton size="sm" variant="ghost" onClick={() => setBorrador(null)}>Cancelar</Boton>
+                      </>
+                    ) : (
+                      <>
+                        {rol.propio && (
+                          <Boton size="sm" variant="ghost" onClick={() => restaurar(rol)}
+                            title="Vuelve a los valores de fábrica">
+                            <RotateCcw size={14} /> Volver al original
+                          </Boton>
+                        )}
+                        <Boton size="sm" variant="ghost" onClick={() => editar(rol)}>Editar</Boton>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                <div className="p-5 grid lg:grid-cols-2 gap-6">
+                  <div>
+                    <div className={ROTULO}>Qué puede hacer</div>
+                    <ul className="mt-3 space-y-3">
+                      {BANDERAS.map((b) => (
+                        <li key={b.k} className="flex items-start gap-3">
+                          <Interruptor
+                            activo={!!d.permisos[b.k]}
+                            disabled={!editando}
+                            onChange={(v) => setBorrador({ ...borrador, permisos: { ...borrador.permisos, [b.k]: v } })} />
+                          <div className="min-w-0">
+                            <div className="text-sm flex items-center gap-1.5">
+                              {b.n}
+                              {b.pesado && <Lock size={11} className="text-texto-tenue" />}
+                            </div>
+                            <div className="text-[11px] text-texto-tenue leading-relaxed">{b.d}</div>
+                            {editando && esMiRol && b.k === "configurar" && d.permisos[b.k] === false && (
+                              <div className="text-[11px] text-mal mt-1">
+                                Es tu propio rol: si lo apagás te quedás afuera, y la base lo va a rechazar.
+                              </div>
+                            )}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div>
+                    <div className={ROTULO}>Qué secciones alcanza</div>
+                    {rol.todos && !editando ? (
+                      <p className="text-sm text-texto-suave mt-3">
+                        Todas las que el comercio tenga contratadas, incluidas las que
+                        se agreguen más adelante.
+                      </p>
+                    ) : (
+                      <div className="flex flex-wrap gap-2 mt-3">
+                        {catalogoModulos.map((m) => {
+                          const alcanza = d.modulos === null || d.modulos.includes(m.k);
+                          const contratado = modulosComercio.includes(m.k);
+                          return (
+                            <button key={m.k} type="button" disabled={!editando}
+                              title={contratado ? m.d : "El comercio no tiene contratado este módulo"}
+                              onClick={() => {
+                                const xs = borrador.modulos === null
+                                  ? catalogoModulos.map((x) => x.k)
+                                  : [...borrador.modulos];
+                                setBorrador({
+                                  ...borrador,
+                                  modulos: alcanza ? xs.filter((k) => k !== m.k) : [...xs, m.k],
+                                });
+                              }}
+                              className={`text-xs px-2.5 py-1.5 rounded-md border transition-colors ${
+                                alcanza
+                                  ? "border-acento text-acento bg-acento-suave"
+                                  : "border-borde text-texto-tenue"
+                              } ${!contratado ? "opacity-40" : ""} ${editando ? "hover:bg-superficie-2" : "cursor-default"}`}>
+                              {m.n}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                    {editando && rol.todos && (
+                      <p className="text-[11px] text-texto-tenue mt-3">
+                        Este rol alcanzaba todo. Al tocar una sección pasa a ser una
+                        lista, y las que se agreguen más adelante ya no entran solas.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {pestana === "auditoria" && (
+        <>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <button onClick={() => setFamilia("")}
+              className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                familia === ""
+                  ? "bg-superficie-3 text-texto border-superficie-3"
+                  : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
+              Todo
+            </button>
+            {familias.map((f) => (
+              <button key={f.k} onClick={() => setFamilia(f.k)}
+                className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+                  familia === f.k
+                    ? "bg-superficie-3 text-texto border-superficie-3"
+                    : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
+                {f.n}
+              </button>
+            ))}
+          </div>
+
+          <Card className="overflow-hidden">
+            <div className="px-5 py-4 border-b border-borde">
+              <h3 className="f-d flex items-center gap-2"><Shield size={16} className="text-acento" /> Lo que se hizo</h3>
+              <p className="text-xs text-texto-suave mt-1">
+                Últimos 60 días. La bitácora solo admite escribir y leer: nada de
+                esto se puede corregir ni borrar, que es la única forma de que
+                sirva para algo.
+              </p>
+            </div>
+            {!bitacora.length ? (
+              <div className="p-6"><Vacio>No hay nada registrado en este período.</Vacio></div>
+            ) : (
+              <TablaSimple
+                cols={["Qué se hizo", "Quién", "Cuándo", "Detalle"]}
+                filas={bitacora.map((b) => [
+                  <span key="a" className="font-medium">{nombreAccion(b.accion)}</span>,
+                  <span className="text-texto-suave">{b.usuario}</span>,
+                  <span className="f-m text-texto-suave">{fechaHora(b.fecha)}</span>,
+                  <span className="text-[11px] text-texto-tenue block max-w-sm truncate f-m"
+                    title={JSON.stringify(b.detalle)}>
+                    {resumen(b)}
+                  </span>,
+                ])}
+                vacio="Sin registros."
+              />
+            )}
+          </Card>
+
+          <p className="text-xs text-texto-tenue">
+            {nf.format(bitacora.length)} registro{bitacora.length === 1 ? "" : "s"}.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* El detalle en una línea. Un JSON crudo en una tabla no lo lee nadie, y
+   esconderlo del todo deja la auditoría sin lo único que importa: qué
+   cambió exactamente. */
+function resumen(b) {
+  const d = b.detalle || {};
+  if (b.accion.startsWith("permisos.")) {
+    const cambios = Object.keys(d.despues || {});
+    return d.rol + (cambios.length ? " · " + cambios.join(", ") : " · volvió al original");
+  }
+  if (d.monto != null) return "$" + d.monto;
+  if (d.motivo) return String(d.motivo);
+  const claves = Object.keys(d);
+  return claves.length ? claves.map((k) => `${k}: ${d[k]}`).join(" · ") : "—";
+}

--- a/src/modulos/Servicios.jsx
+++ b/src/modulos/Servicios.jsx
@@ -1,0 +1,464 @@
+/* ============================================================
+   20. SERVICIOS Y RECURSOS
+   ============================================================
+
+   Qué se ofrece, cuánto dura, cuánto sale y dónde se hace. Es la pantalla
+   más barata de todas porque los datos ya estaban: una prestación es un
+   `item` con `tipo = 'servicio'` y una sala es un `recurso`. Lo único que
+   faltaba era poder verlos y tocarlos sin pasar por SQL.
+
+   Quién da cada cosa se puede editar desde acá y desde Equipo. Es la
+   misma tabla vista de los dos lados, porque en la práctica se piensa de
+   las dos maneras: "qué hace Carla" y "quién puede dar esto".
+
+   Los campos que no hacen nada todavía no están. Anticipación mínima,
+   política de cancelación y comisión por servicio aparecen en las
+   maquetas, pero hoy nadie los lee: ponerlos sería inventar una
+   configuración que no configura nada.
+   ============================================================ */
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Plus, Check, Search, Users, DoorOpen, Clock } from "lucide-react";
+import {
+  cargarServicios, guardarServicio, desactivarServicio,
+  cargarEspacios, guardarEspacio, desactivarEspacio,
+  cargarQuienDaQue, guardarQuienLoDa, usoProximo,
+  TIPOS_RECURSO, nombreTipo,
+} from "../datos/servicios.js";
+import { cargarEquipo } from "../datos/equipo.js";
+import { money, nf } from "../utils/helpers.js";
+import { Card, Boton, Modal, Vacio, Tabs, Sello, Cargando, ErrorEstado } from "../ui/Base.jsx";
+import { Campo, inputCls } from "../ui/Campos.jsx";
+
+/* ------------------------------------------------------------
+   Una prestación
+   ------------------------------------------------------------ */
+
+function FormServicio({ abierto, inicial, equipo, quienLoDa, onGuardar, onCerrar, onBaja }) {
+  const [d, setD] = useState({});
+  const [dan, setDan] = useState([]);
+  const [guardando, setGuardando] = useState(false);
+
+  useEffect(() => {
+    if (!abierto) return;
+    const base = inicial || {};
+    setD({ modalidad: "individual", capacidad: 1, duracion: 60, precio: 0, activo: true, ...base });
+    setDan([...(quienLoDa || [])]);
+  }, [abierto, inicial, quienLoDa]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+  const profesionales = equipo.filter((p) => p.tipo === "profesional");
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-lg">
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="f-d text-lg">{d.id ? d.nombre : "Nueva prestación"}</h3>
+          {d.id && (
+            <button onClick={() => onBaja(d)}
+              className="text-xs font-semibold text-mal hover:underline shrink-0">Dar de baja</button>
+          )}
+        </div>
+
+        <div className="space-y-3 mt-4">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2">
+              <Campo label="Nombre">
+                <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)}
+                  autoFocus placeholder="Limpieza facial" className={inputCls} />
+              </Campo>
+            </div>
+            <Campo label="Área">
+              <input value={d.categoria || ""} onChange={(e) => set("categoria", e.target.value)}
+                placeholder="Estética" className={inputCls} />
+            </Campo>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <Campo label="Duración (min)">
+              <input type="number" step="5" min="5" value={d.duracion}
+                onChange={(e) => set("duracion", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Precio">
+              <input type="number" value={d.precio} onChange={(e) => set("precio", e.target.value)} className={inputCls} />
+            </Campo>
+            <Campo label="Modalidad">
+              <select value={d.modalidad} onChange={(e) => set("modalidad", e.target.value)} className={inputCls}>
+                <option value="individual">Individual</option>
+                <option value="grupal">Grupal</option>
+              </select>
+            </Campo>
+          </div>
+
+          {d.modalidad === "grupal" && (
+            <Campo label="Cuánta gente entra">
+              <input type="number" min="2" value={d.capacidad}
+                onChange={(e) => set("capacidad", e.target.value)} className={inputCls} />
+            </Campo>
+          )}
+          {d.modalidad === "grupal" && (
+            <p className="text-xs text-texto-suave -mt-1">
+              Es el cupo de referencia. Cada clase puede abrirse con menos —una de principiantes, por ejemplo—
+              pero nunca con más de lo que entra en la sala.
+            </p>
+          )}
+
+          <div>
+            <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-bold mb-1.5">
+              Quién lo da
+            </div>
+            {profesionales.length === 0 ? (
+              <p className="text-sm text-texto-tenue">Todavía no hay nadie en el equipo.</p>
+            ) : (
+              <div className="grid sm:grid-cols-2 gap-1">
+                {profesionales.map((p) => {
+                  const puesto = dan.includes(p.id);
+                  return (
+                    <label key={p.id} className="flex items-center gap-2 text-sm py-1.5 px-2 rounded-lg hover:bg-superficie-2 cursor-pointer">
+                      <input type="checkbox" checked={puesto}
+                        onChange={() => setDan((xs) => puesto ? xs.filter((x) => x !== p.id) : [...xs, p.id])} />
+                      <span className="truncate flex-1 text-texto">{p.nombre}</span>
+                      <span className="text-[11px] text-texto-tenue shrink-0">{p.especialidad}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            <p className="text-xs text-texto-suave mt-1.5">
+              La agenda usa esto para no ofrecer a alguien para algo que no hace.
+            </p>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-texto-suave">
+            <input type="checkbox" checked={d.activo !== false} onChange={(e) => set("activo", e.target.checked)} />
+            Se puede agendar
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={!d.nombre || guardando} onClick={async () => {
+            setGuardando(true);
+            const ok = await onGuardar(d, dan);
+            setGuardando(false);
+            if (ok) onCerrar();
+          }}><Check size={15} /> Guardar</Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   Un espacio
+   ------------------------------------------------------------ */
+
+function FormEspacio({ abierto, inicial, enUso, onGuardar, onCerrar, onBaja }) {
+  const [d, setD] = useState({});
+  const [guardando, setGuardando] = useState(false);
+
+  useEffect(() => {
+    if (abierto) setD({ tipo: "sala", capacidad: 1, orden: 0, activo: true, ...(inicial || {}) });
+  }, [abierto, inicial]);
+
+  if (!abierto) return null;
+  const set = (c, v) => setD((x) => ({ ...x, [c]: v }));
+  const tipo = TIPOS_RECURSO.find((t) => t.k === d.tipo);
+
+  return (
+    <Modal open onClose={onCerrar} ancho="max-w-md">
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="f-d text-lg">{d.id ? d.nombre : "Nuevo espacio"}</h3>
+          {d.id && (
+            <button onClick={() => onBaja(d)}
+              className="text-xs font-semibold text-mal hover:underline shrink-0">Dar de baja</button>
+          )}
+        </div>
+
+        <div className="space-y-3 mt-4">
+          <Campo label="Nombre">
+            <input value={d.nombre || ""} onChange={(e) => set("nombre", e.target.value)}
+              autoFocus placeholder="Sala Reformer 1" className={inputCls} />
+          </Campo>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Qué es">
+              <select value={d.tipo} onChange={(e) => set("tipo", e.target.value)} className={inputCls}>
+                {TIPOS_RECURSO.map((t) => <option key={t.k} value={t.k}>{t.n}</option>)}
+              </select>
+            </Campo>
+            <Campo label="Cuánta gente entra">
+              <input type="number" min="1" value={d.capacidad}
+                onChange={(e) => set("capacidad", e.target.value)} className={inputCls} />
+            </Campo>
+          </div>
+          {tipo && tipo.d && <p className="text-xs text-texto-suave -mt-1">{tipo.d}</p>}
+
+          <div className="grid grid-cols-2 gap-3">
+            <Campo label="Sector">
+              <input value={d.sector || ""} onChange={(e) => set("sector", e.target.value)}
+                placeholder="Pilates, Estética…" className={inputCls} />
+            </Campo>
+            <Campo label="Orden">
+              <input type="number" value={d.orden} onChange={(e) => set("orden", e.target.value)} className={inputCls} />
+            </Campo>
+          </div>
+
+          <p className="text-xs text-texto-suave">
+            La capacidad es un dato físico: es el techo del cupo de cualquier clase que se abra acá.
+          </p>
+
+          {enUso > 0 && (
+            <p className="text-xs text-ojo">
+              Tiene {nf.format(enUso)} {enUso === 1 ? "turno" : "turnos"} en los próximos 30 días.
+            </p>
+          )}
+
+          <label className="flex items-center gap-2 text-sm text-texto-suave">
+            <input type="checkbox" checked={d.activo !== false} onChange={(e) => set("activo", e.target.checked)} />
+            Se puede reservar
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-5 pt-4 border-t border-borde">
+          <Boton variant="ghost" onClick={onCerrar}>Cancelar</Boton>
+          <Boton disabled={!d.nombre || guardando} onClick={async () => {
+            setGuardando(true);
+            const ok = await onGuardar(d);
+            setGuardando(false);
+            if (ok) onCerrar();
+          }}><Check size={15} /> Guardar</Boton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/* ------------------------------------------------------------
+   La pantalla
+   ------------------------------------------------------------ */
+
+export function Servicios({ empresaId, permisos, toast }) {
+  const [pestana, setPestana] = useState("servicios");
+  const [servicios, setServicios] = useState([]);
+  const [espacios, setEspacios] = useState([]);
+  const [equipo, setEquipo] = useState([]);
+  const [quienDa, setQuienDa] = useState(new Map());
+  const [uso, setUso] = useState({ porRecurso: new Map(), porItem: new Map() });
+
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [q, setQ] = useState("");
+  const [editando, setEditando] = useState(null);
+  const [editandoEspacio, setEditandoEspacio] = useState(null);
+
+  const releer = useCallback(async () => {
+    const [s, e, eq, qd, u] = await Promise.all([
+      cargarServicios(empresaId, { soloActivos: false }),
+      cargarEspacios(empresaId, { soloActivos: false }),
+      cargarEquipo(empresaId),
+      cargarQuienDaQue(empresaId),
+      usoProximo(empresaId),
+    ]);
+    setServicios(s);
+    setEspacios(e);
+    setEquipo(eq);
+    setQuienDa(qd);
+    setUso(u);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    releer()
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos cargar el catálogo."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [releer]);
+
+  const norm = (t) => String(t || "").toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  const listaServicios = useMemo(() => (
+    q.trim().length >= 2
+      ? servicios.filter((s) => norm(s.nombre).includes(norm(q)) || norm(s.categoria).includes(norm(q)))
+      : servicios
+  ), [servicios, q]);
+
+  const porArea = useMemo(() => {
+    const m = new Map();
+    for (const s of listaServicios) {
+      const k = s.categoria || "Sin área";
+      if (!m.has(k)) m.set(k, []);
+      m.get(k).push(s);
+    }
+    return [...m.entries()];
+  }, [listaServicios]);
+
+  const sinNadie = servicios.filter((s) => s.activo && !(quienDa.get(s.id) || []).length);
+
+  async function grabarServicio(d, dan) {
+    try {
+      const id = await guardarServicio(empresaId, d);
+      await guardarQuienLoDa(empresaId, id, dan);
+      await releer();
+      toast(`${d.nombre} guardado.`);
+      return true;
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.", "mal");
+      return false;
+    }
+  }
+
+  async function grabarEspacio(d) {
+    try {
+      await guardarEspacio(empresaId, d);
+      await releer();
+      toast(`${d.nombre} guardado.`);
+      return true;
+    } catch (e) {
+      toast(e.message || "No se pudo guardar.", "mal");
+      return false;
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {pestana === "servicios" && (
+          <div className="relative flex-1 min-w-[220px]">
+            <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-texto-tenue" />
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Buscar por nombre o área"
+              className="w-full pl-9 pr-3 py-2 text-sm border border-borde rounded-xl outline-none focus:border-acento bg-superficie" />
+          </div>
+        )}
+        <div className="ml-auto">
+          {pestana === "servicios"
+            ? <Boton size="sm" onClick={() => setEditando({})}><Plus size={14} /> Nueva prestación</Boton>
+            : <Boton size="sm" onClick={() => setEditandoEspacio({})}><Plus size={14} /> Nuevo espacio</Boton>}
+        </div>
+      </div>
+
+      <Tabs value={pestana} onChange={setPestana} items={[
+        { k: "servicios", n: "Servicios", badge: servicios.filter((s) => s.activo).length || null },
+        { k: "espacios", n: "Salas y recursos", badge: espacios.filter((e) => e.activo).length || null },
+      ]} />
+
+      {pestana === "servicios" && sinNadie.length > 0 && (
+        <Card className="p-3.5 flex items-center gap-3">
+          <Users size={16} className="text-ojo shrink-0" />
+          <p className="text-sm text-texto-suave">
+            {sinNadie.length === 1
+              ? `${sinNadie[0].nombre} no lo tiene habilitado nadie del equipo.`
+              : `Hay ${sinNadie.length} prestaciones que no las tiene habilitadas nadie.`}{" "}
+            La agenda no las va a poder asignar.
+          </p>
+        </Card>
+      )}
+
+      <Card className="overflow-hidden">
+        {error ? (
+          <ErrorEstado onReintentar={() => releer().catch((e) => setError(e.message))}>{error}</ErrorEstado>
+        ) : cargando ? (
+          <Cargando />
+        ) : pestana === "espacios" ? (
+          espacios.length === 0 ? (
+            <Vacio>Todavía no hay salas ni recursos. La agenda los necesita para saber dónde se atiende.</Vacio>
+          ) : (
+            <ul className="divide-y divide-borde">
+              {espacios.map((e) => (
+                <li key={e.id}>
+                  <button onClick={() => setEditandoEspacio(e)}
+                    className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                    <span className="w-9 h-9 shrink-0 rounded-xl bg-superficie-2 flex items-center justify-center">
+                      <DoorOpen size={16} className="text-texto-suave" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium text-texto">{e.nombre}</div>
+                      <div className="f-m text-[11px] text-texto-tenue">
+                        {nombreTipo(e.tipo)}{e.sector && ` · ${e.sector}`} · entran {e.capacidad}
+                      </div>
+                    </div>
+                    {!e.activo && <Sello tono="tenue">De baja</Sello>}
+                    {uso.porRecurso.get(e.id) > 0 && (
+                      <span className="f-m text-[11px] text-texto-tenue shrink-0">
+                        {nf.format(uso.porRecurso.get(e.id))} turnos
+                      </span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : listaServicios.length === 0 ? (
+          <Vacio>
+            {servicios.length === 0
+              ? "Todavía no hay prestaciones. Son lo que se agenda y lo que se cobra."
+              : "Ninguna coincide con esa búsqueda."}
+          </Vacio>
+        ) : (
+          <div>
+            {porArea.map(([area, xs]) => (
+              <div key={area}>
+                <div className="px-4 py-2 bg-superficie-2/50 text-[10px] uppercase tracking-widest text-texto-tenue font-bold">
+                  {area}
+                </div>
+                <ul className="divide-y divide-borde">
+                  {xs.map((s) => {
+                    const dan = quienDa.get(s.id) || [];
+                    return (
+                      <li key={s.id}>
+                        <button onClick={() => setEditando(s)}
+                          className="w-full text-left px-4 py-3 hover:bg-superficie-2 flex flex-wrap items-center gap-3">
+                          <div className="min-w-0 flex-1">
+                            <div className="font-medium text-texto flex items-center gap-2">
+                              {s.nombre}
+                              {s.modalidad === "grupal" && <Sello tono="info">Grupal · {s.capacidad}</Sello>}
+                            </div>
+                            <div className="f-m text-[11px] text-texto-tenue flex items-center gap-1">
+                              <Clock size={11} /> {s.duracion} min
+                              {dan.length > 0
+                                ? ` · ${dan.length} ${dan.length === 1 ? "profesional" : "profesionales"}`
+                                : " · sin nadie habilitado"}
+                            </div>
+                          </div>
+                          {!s.activo && <Sello tono="tenue">De baja</Sello>}
+                          <span className="f-m text-sm text-texto shrink-0">{money(s.precio)}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <FormServicio abierto={!!editando} inicial={editando} equipo={equipo}
+        quienLoDa={editando && editando.id ? quienDa.get(editando.id) : []}
+        onGuardar={grabarServicio} onCerrar={() => setEditando(null)}
+        onBaja={async (s) => {
+          try {
+            await desactivarServicio(s.id);
+            await releer();
+            setEditando(null);
+            toast(`${s.nombre} dado de baja.`);
+          } catch (e) { toast(e.message || "No se pudo.", "mal"); }
+        }} />
+
+      <FormEspacio abierto={!!editandoEspacio} inicial={editandoEspacio}
+        enUso={editandoEspacio && editandoEspacio.id ? (uso.porRecurso.get(editandoEspacio.id) || 0) : 0}
+        onGuardar={grabarEspacio} onCerrar={() => setEditandoEspacio(null)}
+        onBaja={async (e) => {
+          try {
+            await desactivarEspacio(e.id);
+            await releer();
+            setEditandoEspacio(null);
+            toast(`${e.nombre} dado de baja.`);
+          } catch (err) { toast(err.message || "No se pudo.", "mal"); }
+        }} />
+    </div>
+  );
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -242,3 +242,39 @@ export function conRecargo(base, medio) {
   const r = Math.round(base * (medio.tasa / 100));
   return { total: base + r, recargo: r };
 }
+
+/* ------------------------------------------------------------
+   El número para WhatsApp
+
+   `wa.me` necesita el número completo con código de país y sin nada más.
+   Los teléfonos se cargan como los dicta la gente —"11 5555 5555",
+   "15 5555 5555"— y así, tal cual, el link abre un chat con nadie.
+
+   Se asume Argentina porque es el país del sistema entero: los precios
+   son pesos, la condición fiscal es de ARCA y la factura lleva CUIT. El
+   día que haya un comercio de otro lado, el código de país sale de la
+   configuración del comercio y esta función lo recibe.
+
+   El `9` va después del 54 y antes del área: es lo que le dice a WhatsApp
+   que es un celular, y sin él tampoco abre.
+   ------------------------------------------------------------ */
+export function telWhatsapp(tel) {
+  const d = String(tel || "").replace(/\D/g, "");
+  if (!d) return null;
+
+  /* Ya viene con país: se respeta, incluso si es de otro lado. */
+  if (d.startsWith("54")) return d.startsWith("549") ? d : "549" + d.slice(2);
+  if (d.length > 11 && !d.startsWith("0")) return d;
+
+  /* El 0 de larga distancia y el 15 de celular son de la telefonía de
+     acá y sobran en un número internacional. */
+  let n = d.replace(/^0/, "");
+  n = n.replace(/^(\d{2,4})15(\d{6,8})$/, "$1$2");
+  return n.length >= 10 ? "549" + n : null;
+}
+
+export const linkWhatsapp = (tel, texto) => {
+  const n = telWhatsapp(tel);
+  if (!n) return null;
+  return `https://wa.me/${n}${texto ? "?text=" + encodeURIComponent(texto) : ""}`;
+};

--- a/supabase/migrations/0039_servicios_y_recursos.sql
+++ b/supabase/migrations/0039_servicios_y_recursos.sql
@@ -1,0 +1,64 @@
+/* ============================================================
+   0039 · SERVICIOS Y RECURSOS
+   ============================================================
+
+   Esta sección no necesita tablas nuevas: las prestaciones ya son `items`
+   con `tipo = 'servicio'` y las salas ya son `recursos`. Lo que faltaba
+   era la pantalla, y dos cosas chicas de acá.
+
+   Se agrega `equipamiento` a los tipos de recurso. Una camilla es un
+   lugar donde alguien se acuesta; un reformer o una máquina de rayos es
+   una cosa que se reserva y puede moverse de sala. Distinguirlos importa
+   el día que haya que decir "el reformer 2 está en mantenimiento" sin
+   bloquear la sala entera.
+   ============================================================ */
+
+alter table recursos drop constraint recursos_tipo_valido;
+
+alter table recursos add constraint recursos_tipo_valido check (
+  tipo in ('mesa', 'habitacion', 'sillon', 'bahia', 'cancha',
+           'sala', 'camilla', 'equipamiento', 'otro')
+);
+
+comment on column recursos.tipo is
+  'Qué se reserva. Mesa en gastronomía; sala, camilla o equipamiento en servicios; cancha en un club.';
+
+/* ------------------------------------------------------------
+   La sección se enciende
+   ------------------------------------------------------------ */
+
+update rubros set menu = jsonb_set(
+  menu, '{3}',
+  '{
+    "clave":"catalogo", "nombre":"Servicios y recursos", "i":"tuerca",
+    "modulos":[
+      {"k":"servicios","n":"Servicios y recursos","i":"tuerca","d":"Qué se ofrece, cuánto dura, cuánto sale y dónde se hace"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 3 ->> 'clave' = 'catalogo';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['servicios']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  g ->> 'clave' as seccion,
+  coalesce(g ->> 'nombre', '(sin rótulo)') as rotulo,
+  jsonb_array_length(g -> 'modulos') as modulos,
+  coalesce(g ->> 'proximo', 'false') as proximo
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios'
+order by x.orden;

--- a/supabase/migrations/0040_ficha_del_cliente.sql
+++ b/supabase/migrations/0040_ficha_del_cliente.sql
@@ -1,0 +1,112 @@
+/* ============================================================
+   0040 · LA FICHA DEL CLIENTE
+   ============================================================
+
+   En una estética la ficha es la mitad del valor del sistema: importa qué
+   se le hizo, cuándo, con qué, y si hay algo que no se le puede hacer.
+
+   Casi todo estaba: los turnos, los abonos y las ventas ya apuntan al
+   cliente. Faltaban dos cosas.
+
+   EL CUADERNO
+   -----------
+   Una nota fechada y firmada, no un campo de texto que se pisa. "Alérgica
+   al ácido glicólico" y "prefiere a Carla" son dos cosas distintas de una
+   misma persona, escritas en momentos distintos por gente distinta, y
+   aplastarlas en un solo campo pierde las dos.
+
+   Una nota puede ir **destacada**: eso la saca de la ficha y la pone
+   delante de quien esté por atenderla. Es para lo que no se puede
+   descubrir tarde —una alergia, una contraindicación— y por eso no es un
+   tipo más de nota sino una marca aparte.
+
+   LAS CUENTAS
+   -----------
+   Cuántas veces vino, cuántas faltó, cuándo fue la última y cuánto gastó.
+   Se calculan en la vista y no en la pantalla, por lo mismo que el estado
+   de una mesa: si cada lugar las dedujera por su cuenta, un día dejan de
+   coincidir.
+   ============================================================ */
+
+create table cliente_notas (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  cliente_id  uuid not null references clientes(id) on delete cascade,
+
+  texto       text not null,
+  /* Delante de los ojos de quien la atienda, no adentro de una pestaña. */
+  destacada   boolean not null default false,
+
+  creada_en   timestamptz not null default now(),
+  usuario_id  uuid references perfiles(id) on delete set null
+);
+
+create index on cliente_notas (cliente_id, creada_en desc);
+create index on cliente_notas (empresa_id) where destacada;
+
+comment on column cliente_notas.destacada is
+  'Lo que no se puede descubrir tarde: una alergia, una contraindicación. Se muestra al agendar, no adentro de la ficha.';
+
+alter table cliente_notas enable row level security;
+
+create policy cliente_notas_todo on cliente_notas
+  for all using (public.puede_ver(empresa_id)) with check (public.puede_ver(empresa_id));
+
+/* ------------------------------------------------------------
+   El cliente, con sus cuentas hechas
+
+   Los turnos se cuentan sin las clases: una clase no tiene cliente, y sus
+   inscripciones sí, así que contar las dos duplicaría.
+   ------------------------------------------------------------ */
+
+create or replace view clientes_vista
+with (security_invoker = true) as
+select
+  c.*,
+  coalesce(t.turnos, 0)     as turnos,
+  coalesce(t.asistio, 0)    as asistio,
+  coalesce(t.ausencias, 0)  as ausencias,
+  coalesce(t.cancelados, 0) as cancelados,
+  t.ultima,
+  t.proxima,
+  /* Sobre los turnos que ya pasaron: contra los futuros no hay asistencia
+     que medir todavía, y meterlos hunde el porcentaje sin motivo. */
+  case when coalesce(t.asistio, 0) + coalesce(t.ausencias, 0) = 0 then null
+       else t.asistio::numeric / (t.asistio + t.ausencias)
+  end as asistencia,
+
+  coalesce(v.gastado, 0)  as gastado,
+  coalesce(v.compras, 0)  as compras,
+  coalesce(a.abonos, 0)   as abonos_activos,
+  coalesce(n.notas, 0)    as notas,
+  coalesce(n.alertas, 0)  as alertas
+from clientes c
+left join lateral (
+  select
+    count(*)                                            as turnos,
+    count(*) filter (where r.estado = 'cumplida')       as asistio,
+    count(*) filter (where r.estado = 'ausente')        as ausencias,
+    count(*) filter (where r.estado = 'cancelada')      as cancelados,
+    max(r.desde) filter (where r.desde < now() and r.estado <> 'cancelada') as ultima,
+    min(r.desde) filter (where r.desde >= now() and r.estado not in ('cancelada', 'ausente')) as proxima
+  from reservas r
+  where r.cliente_id = c.id and r.cupo is null
+) t on true
+left join lateral (
+  select sum(o.total) as gastado, count(*) as compras
+  from operaciones o
+  where o.cliente_id = c.id and o.estado = 'confirmada'
+) v on true
+left join lateral (
+  select count(*) as abonos
+  from abonos_vista av
+  where av.cliente_id = c.id and av.estado = 'activo'
+) a on true
+left join lateral (
+  select count(*) as notas, count(*) filter (where destacada) as alertas
+  from cliente_notas cn
+  where cn.cliente_id = c.id
+) n on true;
+
+comment on view clientes_vista is
+  'El cliente con sus cuentas hechas: cuántas veces vino, cuántas faltó, cuándo fue la última y cuánto gastó. Se calculan acá y no en la pantalla para que la lista y la ficha no puedan discrepar.';

--- a/supabase/migrations/0041_marca_en_las_reservas.sql
+++ b/supabase/migrations/0041_marca_en_las_reservas.sql
@@ -1,0 +1,34 @@
+/* ============================================================
+   0041 · UNA MARCA EN LAS RESERVAS
+   ============================================================
+
+   `reservas` es la única tabla operativa que no tiene `campos_extra`.
+   `items`, `clientes`, `operaciones` y `operacion_lineas` la tienen desde
+   el principio, y es por donde el sistema cuelga lo que todavía no
+   merece una columna: la marca de dato de ejemplo, entre otras cosas.
+
+   Sin eso, barrer una semilla de agenda obliga a deducir qué borrar
+   —"las reservas que apuntan a items de ejemplo"— y esa consulta se
+   escribe distinto cada vez que hace falta. Con la marca es la misma
+   línea que ya se usa para el catálogo y para el equipo:
+
+     delete from reservas where empresa_id = (...)
+                            and campos_extra ->> 'demo' = 'true';
+
+   QUÉ PASA CON GASTRONOMÍA
+   ------------------------
+   Nada. Es una columna nueva, anulable, con valor por defecto: en
+   Postgres 11 en adelante `add column ... default` no reescribe la tabla,
+   así que las reservas del Bar Rivadavia no se tocan. Y las dos vistas
+   que leen `reservas` —`agenda_vista` y `salon_vista`— enumeran sus
+   columnas una por una, así que no cambian ni hace falta rehacerlas.
+
+   Más adelante hay dos usos previstos en el encargo que también caen acá
+   sin migrar de nuevo: si la reserva vino del turno online y si dejó
+   seña.
+   ============================================================ */
+
+alter table reservas add column campos_extra jsonb not null default '{}'::jsonb;
+
+comment on column reservas.campos_extra is
+  'Lo que no merece una columna todavía: la marca de dato de ejemplo, el origen de la reserva, la seña.';

--- a/supabase/migrations/0042_informes_de_servicios.sql
+++ b/supabase/migrations/0042_informes_de_servicios.sql
@@ -1,0 +1,220 @@
+/* ============================================================
+   0042 · INFORMES DE UN NEGOCIO QUE VENDE HORAS
+   ============================================================
+
+   El informe que había era el de un minimercado: qué se vende, qué
+   margen deja, qué producto perdió rentabilidad. Nada de eso aplica a
+   una estética. Un negocio de turnos tiene un número propio que el
+   comercio no tiene, y es el que decide casi todo: **cuánto de lo que
+   se puede vender se vendió**.
+
+   Ingresos y asistencia salen de tablas que ya están y se leen de una;
+   la ocupación no. Cruza `reservas`, `horarios`, `excepciones`,
+   `recursos` y `personal` y hay que recorrer día por día el período,
+   así que va acá abajo y no en el navegador. Regla 5.
+
+   DOS OCUPACIONES QUE NO SON LA MISMA
+   -----------------------------------
+   Una sala de mat para ocho con tres personas adentro está ocupada al
+   100% del tiempo y al 37% de su capacidad. Las dos cosas son ciertas y
+   sirven para decisiones distintas: la primera dice si hay lugar para
+   abrir otra clase, la segunda si esa clase conviene que exista. Por eso
+   la función devuelve las dos y la pantalla las muestra separadas.
+
+   LAS HORAS QUE OFRECE UNA SALA
+   -----------------------------
+   `horarios` guarda el horario de una persona o de un recurso, pero en
+   la práctica nadie carga el de una sala: se carga el de la gente. Así
+   que las horas que ofrece un espacio se toman de cuándo abre el local
+   —de la primera hora a la última en que hay alguien trabajando ese
+   día—, que es la definición que usa cualquiera al mirar una grilla. Si
+   algún día se cargan horarios propios de una sala, mandan esos.
+
+   UNA CLASE OCUPA UNA VEZ
+   -----------------------
+   Seis inscripciones a la misma clase de reformer no son seis horas de
+   sala: son una. Por eso todo lo que mide tiempo filtra `clase_id is
+   null` y son las inscripciones las que cuentan para la capacidad. Es el
+   mismo criterio con el que las liquidaciones cuentan las horas del
+   equipo, y tiene que seguir siendo el mismo: si un día dejan de
+   coincidir, la ocupación de una profesora y lo que se le paga van a
+   contar cosas distintas del mismo día de trabajo.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · La ocupación
+   ------------------------------------------------------------ */
+
+create or replace function informe_ocupacion(
+  p_empresa uuid,
+  p_desde   date,
+  p_hasta   date
+)
+returns table (
+  ambito    text,
+  id        uuid,
+  nombre    text,
+  detalle   text,
+  ofrecidos numeric,
+  ocupados  numeric,
+  lugares   numeric,
+  tomados   numeric
+)
+language sql
+stable
+as $$
+  with dias as (
+    select d::date as dia, extract(dow from d)::smallint as dow
+      from generate_series(p_desde, p_hasta, interval '1 day') d
+  ),
+
+  /* Los minutos que cada persona ofreció cada día: su horario de ese día
+     de la semana, menos lo que le pisa una ausencia. La resta es una
+     intersección de intervalos y no un "ese día no trabajó": media
+     jornada de vacaciones tiene que restar media jornada. */
+  turno_persona as (
+    select h.personal_id, d.dia,
+           greatest(0, extract(epoch from (h.hasta - h.desde)) / 60
+             - coalesce((
+                 select sum(greatest(0, extract(epoch from (
+                          least(x.hasta, d.dia + h.hasta) - greatest(x.desde, d.dia + h.desde)
+                        )) / 60))
+                   from excepciones x
+                  where x.empresa_id = p_empresa
+                    and x.personal_id = h.personal_id
+                    and x.desde < d.dia + h.hasta
+                    and x.hasta > d.dia + h.desde
+               ), 0)
+           ) as minutos
+      from horarios h
+      join dias d on d.dow = h.dia
+     where h.empresa_id = p_empresa and h.activo and h.personal_id is not null
+  ),
+
+  /* Cuándo abre el local: de la primera a la última hora en que hay
+     alguien. Es lo que se le puede ofrecer a una sala. */
+  apertura as (
+    select d.dia,
+           coalesce(extract(epoch from (max(h.hasta) - min(h.desde))) / 60, 0) as minutos
+      from dias d
+      left join horarios h on h.dia = d.dow and h.empresa_id = p_empresa and h.activo
+     group by d.dia
+  ),
+
+  /* Lo agendado. Una clase cuenta una vez —por eso `clase_id is null`— y
+     lo cancelado no ocupa nada: el lugar quedó libre. */
+  agendado as (
+    select r.personal_id, r.recurso_id, r.duracion_min, r.cupo, r.id
+      from reservas r
+     where r.empresa_id = p_empresa
+       and r.clase_id is null
+       and r.estado <> 'cancelada'
+       and r.desde >= p_desde
+       and r.desde < (p_hasta + 1)
+  ),
+
+  inscriptos as (
+    select i.clase_id, count(*) as tomados
+      from reservas i
+     where i.empresa_id = p_empresa
+       and i.clase_id is not null
+       and i.estado not in ('cancelada', 'ausente')
+     group by i.clase_id
+  )
+
+  select
+    'profesional'::text,
+    per.id,
+    per.nombre,
+    coalesce(per.especialidad, ''),
+    coalesce((select sum(t.minutos) from turno_persona t where t.personal_id = per.id), 0),
+    coalesce((select sum(a.duracion_min) from agendado a where a.personal_id = per.id), 0),
+    coalesce((select sum(a.cupo) from agendado a where a.personal_id = per.id and a.cupo is not null), 0),
+    coalesce((select sum(ins.tomados) from agendado a
+                join inscriptos ins on ins.clase_id = a.id
+               where a.personal_id = per.id), 0)
+  from personal per
+ where per.empresa_id = p_empresa and per.activo and per.tipo = 'profesional'
+
+  union all
+
+  select
+    'sala'::text,
+    re.id,
+    re.nombre,
+    coalesce(re.tipo, ''),
+    /* Si la sala tiene horario propio cargado, gana sobre la apertura
+       general: alguien se tomó el trabajo de decir que ese box abre
+       distinto. */
+    coalesce(
+      nullif((select sum(extract(epoch from (h.hasta - h.desde)) / 60)
+                from horarios h join dias d on d.dow = h.dia
+               where h.empresa_id = p_empresa and h.activo and h.recurso_id = re.id), 0),
+      (select sum(ap.minutos) from apertura ap), 0),
+    coalesce((select sum(a.duracion_min) from agendado a where a.recurso_id = re.id), 0),
+    coalesce((select sum(a.cupo) from agendado a where a.recurso_id = re.id and a.cupo is not null), 0),
+    coalesce((select sum(ins.tomados) from agendado a
+                join inscriptos ins on ins.clase_id = a.id
+               where a.recurso_id = re.id), 0)
+  from recursos re
+ where re.empresa_id = p_empresa and re.activo
+$$;
+
+comment on function informe_ocupacion is
+  'Cuánto de lo que se podía vender se vendió, por profesional y por sala: minutos ofrecidos contra agendados, y lugares de clase contra tomados. Las dos ocupaciones son distintas y las dos importan.';
+
+/* No es `security definer` a propósito: corre con los permisos de quien
+   llama, así RLS se aplica igual que en una consulta común. El
+   `empresa_id` va como parámetro obligatorio por la regla 6 —RLS contesta
+   si podés ver algo, no de qué comercio es—. */
+grant execute on function informe_ocupacion(uuid, date, date) to authenticated;
+
+
+/* ------------------------------------------------------------
+   2 · La sección en el menú
+
+   El grupo Reportes ya estaba; lo que cambia es el módulo que cuelga de
+   él. `reportes` sigue existiendo para el minimercado y el bar, con su
+   pantalla de siempre: no se toca nada de lo que hoy funciona. Lo que
+   ve una estética es otro módulo, `informes`, porque es otro informe.
+
+   Es la misma decisión que se tomó con Finanzas en 0038: una clave nueva
+   antes que un `if` por rubro adentro de una pantalla compartida.
+   ------------------------------------------------------------ */
+
+update rubros set menu = jsonb_set(
+  menu, '{8}',
+  '{
+    "clave":"reportes", "nombre":"Reportes", "i":"barras",
+    "modulos":[
+      {"k":"informes","n":"Informes","i":"barras","d":"Ingresos, ocupación, asistencia y clientes"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 8 ->> 'clave' = 'reportes';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  /* `reportes` sale y entra `informes`. Dejarlo contratado sería dejar
+     una pantalla de minimercado alcanzable desde una estética. */
+  update empresas
+     set modulos = array(
+           select distinct unnest(array_remove(modulos, 'reportes') || array['informes']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select
+  g ->> 'clave' as seccion,
+  jsonb_array_length(g -> 'modulos') as modulos,
+  g -> 'modulos' -> 0 ->> 'k' as primero
+from rubros r, jsonb_array_elements(r.menu) with ordinality x(g, orden)
+where r.clave = 'servicios' and g ->> 'clave' = 'reportes';

--- a/supabase/migrations/0043_crm.sql
+++ b/supabase/migrations/0043_crm.sql
@@ -1,0 +1,295 @@
+/* ============================================================
+   0043 · CRM · a quién hay que llamar hoy, y por qué
+   ============================================================
+
+   Un CRM de estos negocios no es una base de contactos: eso ya es
+   `clientes`. Es una respuesta a una pregunta que hoy nadie puede
+   contestar mirando el sistema —a quién conviene escribirle esta
+   semana— y que en la práctica se contesta de memoria, o no se contesta.
+
+   LOS SEGMENTOS NO SE GUARDAN, SE DERIVAN
+   ---------------------------------------
+   Misma regla que el stock y que el estado de una mesa. Una columna
+   `es_cliente_dormido` se corrompe el día que la persona vuelve y nadie
+   corre el proceso que la limpia; y sobre todo, el criterio cambia —hoy
+   son 45 días, mañana el comercio decide que son 30— y con la marca
+   guardada habría que recalcular el pasado entero.
+
+   Son cinco, y cada uno existe porque tiene una acción distinta detrás:
+
+     se_van             vino seguido y dejó de venir. Llamar antes de que
+                        se acostumbre a no venir.
+     sin_segunda        vino una sola vez. Es el momento exacto en que un
+                        cliente se pierde y el más barato de recuperar.
+     abono_por_vencer   se le termina el crédito. Renovar es más fácil
+                        antes de que se corte la rutina que después.
+     abono_vencido      se le venció y no renovó. Todavía se acuerda.
+     falta_seguido      viene pero no aparece. Acá no hay nada que
+                        vender: hay algo que preguntar, y si nadie
+                        pregunta el que se va es él.
+
+   LO QUE SE HIZO QUEDA ESCRITO
+   ----------------------------
+   `contactos` no es un registro burocrático: es lo que hace que la lista
+   se vacíe a medida que se trabaja. Sin él, el lunes aparecen los mismos
+   veinte nombres que el viernes y nadie sabe a cuáles ya les escribió.
+   Por eso el segmento excluye a quien recibió un mensaje **por ese mismo
+   motivo** en las últimas tres semanas: que a alguien se le haya avisado
+   que su abono vence no significa que no haya que decirle, dos meses
+   después, que hace rato no viene.
+
+   NO MOLESTAR NO ES UNA TABLA
+   ---------------------------
+   Va en `clientes.campos_extra`, que es exactamente para esto. Una tabla
+   de una columna booleana para algo que se marca cinco veces por año es
+   una tabla que después hay que acordarse de consultar.
+
+   FUERA DE ALCANCE, A PROPÓSITO
+   -----------------------------
+   Nada se manda solo. El encargo lo dice: la única integración de
+   mensajería es abrir WhatsApp con el mensaje ya escrito. Las plantillas
+   guardadas y el envío en tanda son de Comunicaciones, que va después.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · Lo que se le dijo a cada uno
+   ------------------------------------------------------------ */
+
+create table contactos (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  cliente_id  uuid not null references clientes(id) on delete cascade,
+  /* La clave del segmento por el que se lo contactó. Es texto y no una
+     tabla de motivos: los segmentos son código, y un catálogo que hay
+     que mantener en paralelo se desincroniza el primer día. */
+  motivo      text not null,
+  canal       text not null default 'whatsapp',
+  texto       text,
+  resultado   text not null default 'enviado',
+  usuario_id  uuid references perfiles(id) on delete set null,
+  fecha       timestamptz not null default now()
+);
+
+alter table contactos add constraint contactos_canal_valido check (
+  canal in ('whatsapp', 'telefono', 'email', 'presencial')
+);
+
+/* `volvio` se marca a mano y es el único que dice si esto sirvió para
+   algo. Sin él, el módulo no se puede evaluar: se sabe a cuántos se les
+   escribió y a nadie cuántos volvieron. */
+alter table contactos add constraint contactos_resultado_valido check (
+  resultado in ('enviado', 'respondio', 'sin_respuesta', 'volvio')
+);
+
+create index on contactos (empresa_id, cliente_id, fecha desc);
+create index on contactos (empresa_id, motivo, fecha desc);
+
+comment on table contactos is
+  'Lo que se le dijo a cada cliente y por qué. Es lo que hace que la lista de CRM se vacíe a medida que se trabaja en vez de repetir los mismos nombres.';
+
+alter table contactos enable row level security;
+
+create policy contactos_ver on contactos
+  for select using (public.puede_ver(empresa_id));
+
+create policy contactos_anotar on contactos
+  for insert with check (public.puede_ver(empresa_id));
+
+/* Se puede corregir el resultado —"respondió", "volvió"— pero no se
+   puede reescribir qué se dijo ni cuándo. Mismo criterio que la
+   bitácora: lo que pasó, pasó. */
+create policy contactos_corregir on contactos
+  for update using (public.puede_ver(empresa_id));
+
+
+/* ------------------------------------------------------------
+   2 · Los segmentos
+   ------------------------------------------------------------ */
+
+create or replace function crm_segmentos(p_empresa uuid)
+returns table (
+  segmento        text,
+  cliente_id      uuid,
+  cliente         text,
+  tel             text,
+  motivo          text,
+  dias            int,
+  valor           numeric,
+  ultimo_contacto timestamptz
+)
+language sql
+stable
+as $$
+  with base as (
+    select cv.*
+      from clientes_vista cv
+     where cv.empresa_id = p_empresa
+       and cv.activo
+       /* Quien pidió que no lo molesten no aparece en ninguna lista. Es
+          una sola condición y va acá arriba para que no haya forma de
+          agregar un segmento que se la saltee. */
+       and coalesce(cv.campos_extra ->> 'noContactar', 'false') <> 'true'
+  ),
+
+  /* El último mensaje por cliente y motivo. Tres semanas: menos es
+     insistir y más es dejarlo enfriar. */
+  ultimo as (
+    select k.cliente_id, k.motivo, max(k.fecha) as fecha
+      from contactos k
+     where k.empresa_id = p_empresa
+     group by k.cliente_id, k.motivo
+  ),
+
+  credito as (
+    select av.cliente_id, av.estado, av.vence, av.restantes, av.nombre
+      from abonos_vista av
+     where av.empresa_id = p_empresa and not av.anulado
+  )
+
+  /* 1 · Venía seguido y dejó de venir. */
+  select
+    'se_van'::text, b.id, b.razon_social, b.tel,
+    'Vino ' || b.asistio || ' veces y hace ' ||
+      (current_date - b.ultima::date) || ' días que no aparece',
+    (current_date - b.ultima::date)::int,
+    b.gastado,
+    u.fecha
+  from base b
+  left join ultimo u on u.cliente_id = b.id and u.motivo = 'se_van'
+ where b.asistio >= 3
+   and b.ultima is not null
+   and b.ultima < now() - interval '45 days'
+   and b.ultima > now() - interval '180 days'
+   and b.proxima is null
+   and (u.fecha is null or u.fecha < now() - interval '21 days')
+
+  union all
+
+  /* 2 · Vino una sola vez y no volvió. Se le da un margen de quince días
+     antes de darlo por perdido: mucha gente saca el segundo turno en la
+     misma semana y ahí no hay nada que hacer. */
+  select
+    'sin_segunda'::text, b.id, b.razon_social, b.tel,
+    'Vino una sola vez, hace ' || (current_date - b.ultima::date) || ' días',
+    (current_date - b.ultima::date)::int,
+    b.gastado,
+    u.fecha
+  from base b
+  left join ultimo u on u.cliente_id = b.id and u.motivo = 'sin_segunda'
+ where b.asistio = 1
+   and b.ultima is not null
+   and b.ultima < now() - interval '15 days'
+   and b.ultima > now() - interval '120 days'
+   and b.proxima is null
+   and (u.fecha is null or u.fecha < now() - interval '21 days')
+
+  union all
+
+  /* 3 · Se le está por terminar el crédito. Vale igual el que se queda
+     sin clases que el que se queda sin días: para el cliente son la
+     misma cosa —se le acabó— y para el negocio también.
+
+     `distinct on` porque alguien puede tener dos abonos abiertos y en la
+     lista tiene que aparecer una vez: son un mensaje, no dos. Gana el que
+     se le termina primero, que es el que da la conversación. */
+  select * from (
+  select distinct on (b.id)
+    'abono_por_vencer'::text, b.id, b.razon_social, b.tel,
+    cr.nombre || (case
+      when cr.restantes is not null and cr.restantes <= 2
+        then ' · le quedan ' || cr.restantes || ' clases'
+      else ' · vence en ' || (cr.vence - current_date) || ' días' end),
+    coalesce((cr.vence - current_date), 0)::int,
+    b.gastado,
+    u.fecha
+  from base b
+  join credito cr on cr.cliente_id = b.id and cr.estado = 'activo'
+  left join ultimo u on u.cliente_id = b.id and u.motivo = 'abono_por_vencer'
+ where ((cr.vence is not null and cr.vence <= current_date + 10)
+        or (cr.restantes is not null and cr.restantes <= 2))
+   and (u.fecha is null or u.fecha < now() - interval '21 days')
+ order by b.id, cr.vence
+  ) por_vencer
+
+  union all
+
+  /* 4 · Se le venció y no renovó. Se corta a los 30 días porque después
+     el mensaje ya no es "renovalo" sino "hace rato que no venís", que es
+     el segmento 1 y tiene otro texto. */
+  select * from (
+  select distinct on (b.id)
+    'abono_vencido'::text, b.id, b.razon_social, b.tel,
+    cr.nombre || ' · venció hace ' || (current_date - cr.vence) || ' días',
+    (current_date - cr.vence)::int,
+    b.gastado,
+    u.fecha
+  from base b
+  join credito cr on cr.cliente_id = b.id and cr.estado = 'vencido'
+  left join ultimo u on u.cliente_id = b.id and u.motivo = 'abono_vencido'
+ where cr.vence >= current_date - 30
+   and not exists (select 1 from credito a2 where a2.cliente_id = b.id and a2.estado = 'activo')
+   and (u.fecha is null or u.fecha < now() - interval '21 days')
+ /* El más reciente: es el que la persona tiene fresco. */
+ order by b.id, cr.vence desc
+  ) vencidos
+
+  union all
+
+  /* 5 · Reserva y no viene. Este no es para venderle nada: es el que se
+     va a ir en dos meses y todavía se puede preguntar por qué. */
+  select
+    'falta_seguido'::text, b.id, b.razon_social, b.tel,
+    'Faltó ' || b.ausencias || ' de ' || (b.asistio + b.ausencias) || ' turnos',
+    b.ausencias::int,
+    b.gastado,
+    u.fecha
+  from base b
+  left join ultimo u on u.cliente_id = b.id and u.motivo = 'falta_seguido'
+ where b.asistio + b.ausencias >= 4
+   and b.asistencia < 0.7
+   and (u.fecha is null or u.fecha < now() - interval '21 days')
+$$;
+
+comment on function crm_segmentos is
+  'A quién conviene escribirle y por qué. Los segmentos se derivan, no se guardan: el criterio cambia y una marca guardada obligaría a recalcular el pasado.';
+
+grant execute on function crm_segmentos(uuid) to authenticated;
+
+
+/* ------------------------------------------------------------
+   3 · La sección en el menú
+
+   Dejaba de estar "próxima" y pasa a tener su módulo. Una fila, no un
+   componente: el menú sale de `rubros`.
+   ------------------------------------------------------------ */
+
+update rubros set menu = jsonb_set(
+  menu, '{6}',
+  '{
+    "clave":"crm", "nombre":"CRM y marketing", "i":"corazon",
+    "modulos":[
+      {"k":"crm","n":"Seguimiento","i":"corazon","d":"A quién conviene escribirle esta semana, y por qué"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 6 ->> 'clave' = 'crm';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['crm']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select segmento, count(*) as gente
+  from crm_segmentos((select id from empresas where nombre = 'Almha'))
+ group by segmento order by 2 desc;

--- a/supabase/migrations/0044_comunicaciones.sql
+++ b/supabase/migrations/0044_comunicaciones.sql
@@ -1,0 +1,191 @@
+/* ============================================================
+   0044 · COMUNICACIONES · lo que hay que avisar hoy
+   ============================================================
+
+   CRM contesta "a quién conviene escribirle esta semana". Esto contesta
+   otra cosa, todos los días: **a quién hay que avisarle algo ahora**.
+
+   Son dos módulos y no uno porque son dos trabajos distintos, los hace
+   gente distinta y se abren en momentos distintos. Recepción manda los
+   recordatorios de mañana cada tarde antes de irse; lo de CRM lo mira el
+   dueño una vez por semana. Meterlos en la misma pantalla haría que la
+   tarea diaria quede sepultada debajo de la semanal.
+
+   Lo que sí comparten es dónde queda anotado: `contactos`, una sola
+   tabla. Dos registros de mensajes enviados es la forma más rápida de no
+   saber nunca si a alguien ya se le escribió.
+
+   UN RECORDATORIO NO ES MARKETING
+   -------------------------------
+   Por eso `no contactar` —que sí frena todo lo de CRM— no frena esto.
+   Quien pidió que no le manden promociones no pidió que no le avisen que
+   mañana tiene turno a las nueve; si además se le deja de avisar, el que
+   queda mal es el negocio. Son dos cosas con el mismo medio y distinta
+   naturaleza, y el sistema tiene que poder distinguirlas.
+
+   NO SE AVISA DOS VECES
+   ---------------------
+   `contactos` gana `reserva_id`. Sin eso, la única forma de saber si a
+   alguien ya se le recordó su turno del martes sería mirar si se le
+   escribió "hace poco", y con dos turnos en la misma semana eso falla
+   siempre. La lista de pendientes excluye el turno que ya tiene su aviso,
+   no al cliente.
+
+   LAS PLANTILLAS GUARDAN LO QUE SE CAMBIÓ, NO TODO
+   ------------------------------------------------
+   Los textos de fábrica viven en el código. La tabla guarda únicamente
+   los que el comercio reescribió, así un comercio nuevo funciona el
+   primer día sin sembrarle nada y "volver al original" es borrar una
+   fila. Mismo criterio que `MEDIOS_INICIALES` en los ajustes.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · A qué turno correspondía el mensaje
+   ------------------------------------------------------------ */
+
+alter table contactos add column reserva_id uuid references reservas(id) on delete set null;
+
+create index on contactos (reserva_id) where reserva_id is not null;
+
+/* Y el cliente pasa a poder ir en null. Un turno se puede tomar con un
+   nombre y un teléfono y nada más —alguien que llama por primera vez— y
+   a esa persona también hay que recordarle que mañana viene. Con la
+   columna obligatoria, el único turno que no se puede avisar es
+   justamente el de quien todavía no es cliente de nadie.
+
+   Para CRM no cambia nada: ahí el cliente siempre existe, porque los
+   segmentos salen de `clientes_vista`. */
+alter table contactos alter column cliente_id drop not null;
+
+comment on column contactos.reserva_id is
+  'El turno que se recordó. Es lo que evita avisar dos veces del mismo turno sin bloquear al cliente entero.';
+
+
+/* ------------------------------------------------------------
+   2 · Los textos que el comercio reescribió
+   ------------------------------------------------------------ */
+
+create table plantillas (
+  id           uuid primary key default gen_random_uuid(),
+  empresa_id   uuid not null references empresas(id) on delete cascade,
+  clave        text not null,
+  texto        text not null,
+  actualizada  timestamptz not null default now(),
+  usuario_id   uuid references perfiles(id) on delete set null,
+  unique (empresa_id, clave)
+);
+
+comment on table plantillas is
+  'Solo lo que el comercio cambió. Los textos de fábrica están en el código: así un comercio nuevo anda sin semilla y volver al original es borrar la fila.';
+
+alter table plantillas enable row level security;
+
+create policy plantillas_ver on plantillas
+  for select using (public.puede_ver(empresa_id));
+
+create policy plantillas_escribir on plantillas
+  for insert with check (public.puede_ver(empresa_id));
+
+create policy plantillas_editar on plantillas
+  for update using (public.puede_ver(empresa_id));
+
+create policy plantillas_borrar on plantillas
+  for delete using (public.puede_ver(empresa_id));
+
+
+/* ------------------------------------------------------------
+   3 · Lo que hay que avisar
+
+   Todos los turnos que empiezan dentro de la ventana y todavía no
+   tienen su aviso. Las inscripciones a una clase entran una por una
+   —cada persona recibe su mensaje— y la clase en sí no: no tiene a
+   quién avisarle.
+   ------------------------------------------------------------ */
+
+create or replace function comunicaciones_pendientes(
+  p_empresa uuid,
+  p_horas   int default 24
+)
+returns table (
+  reserva_id  uuid,
+  cliente_id  uuid,
+  cliente     text,
+  tel         text,
+  desde       timestamptz,
+  estado      text,
+  servicio    text,
+  profesional text,
+  sala        text,
+  es_clase    boolean
+)
+language sql
+stable
+as $$
+  select
+    r.id, r.cliente_id,
+    coalesce(c.razon_social, r.nombre),
+    coalesce(c.tel, r.telefono),
+    r.desde, r.estado,
+    coalesce(i.nombre, r.nombre),
+    p.nombre,
+    re.nombre,
+    r.clase_id is not null
+  from reservas r
+  left join clientes c  on c.id  = r.cliente_id
+  left join items    i  on i.id  = r.item_id
+  left join personal p  on p.id  = r.personal_id
+  left join recursos re on re.id = r.recurso_id
+ where r.empresa_id = p_empresa
+   /* La clase con cupo es el contenedor: los avisos van a los anotados. */
+   and r.cupo is null
+   and r.estado in ('pendiente', 'confirmada')
+   and r.desde >= now()
+   and r.desde < now() + make_interval(hours => p_horas)
+   /* Ya avisado: se excluye el turno, no la persona. Alguien con dos
+      turnos esta semana tiene que recibir los dos recordatorios. */
+   and not exists (
+     select 1 from contactos k
+      where k.reserva_id = r.id and k.motivo = 'recordatorio'
+   )
+ order by r.desde, coalesce(c.razon_social, r.nombre)
+$$;
+
+comment on function comunicaciones_pendientes is
+  'Los turnos que empiezan dentro de la ventana y todavía no tienen su aviso. No filtra por "no contactar": un recordatorio de turno no es marketing.';
+
+grant execute on function comunicaciones_pendientes(uuid, int) to authenticated;
+
+
+/* ------------------------------------------------------------
+   4 · La sección en el menú
+   ------------------------------------------------------------ */
+
+update rubros set menu = jsonb_set(
+  menu, '{7}',
+  '{
+    "clave":"comunicaciones", "nombre":"Comunicaciones", "i":"mensaje",
+    "modulos":[
+      {"k":"comunicaciones","n":"Avisos","i":"mensaje","d":"Recordatorios de turno, plantillas y todo lo que se mandó"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 7 ->> 'clave' = 'comunicaciones';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['comunicaciones']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select count(*) as por_avisar
+  from comunicaciones_pendientes((select id from empresas where nombre = 'Almha'), 24);

--- a/supabase/migrations/0045_permisos_configurables.sql
+++ b/supabase/migrations/0045_permisos_configurables.sql
@@ -1,0 +1,355 @@
+/* ============================================================
+   0045 · PERMISOS CONFIGURABLES Y AUDITORÍA
+   ============================================================
+
+   Los roles vivían en una constante de JavaScript: cuatro, con sus
+   módulos y sus banderas escritos a mano. Funcionaban, y por eso el
+   encargo los dejó para el final. El problema no es que estén mal: es
+   que un comercio no puede decir "acá el que atiende sí puede dar
+   descuentos" sin que alguien toque el código y publique.
+
+   LO QUE ESTO CAMBIA PARA GASTRONOMÍA: NADA, HASTA QUE ALGUIEN EDITE
+   -----------------------------------------------------------------
+   Es lo primero que hay que saber porque toca dos políticas de RLS de
+   las que dependen los tres comercios.
+
+   Hoy dos políticas nombran roles a mano:
+
+     bitacora_leer        rol in ('dueno', 'encargado')
+     empresas_configurar  rol in ('dueno', 'encargado')
+
+   Pasan a preguntar por un permiso —`verBitacora` y `configurar`— cuyos
+   valores de fábrica son verdadero para dueño y encargado y falso para
+   cajero y repositor. Es decir: **exactamente la misma respuesta para
+   exactamente la misma gente**. Mientras nadie edite un rol, la tabla de
+   overrides está vacía y las dos políticas se comportan igual que antes.
+   Lo cubre `probar-rls.mjs`.
+
+   El cambio real es que a partir de ahora se puede editar, y que la
+   política ya no tiene nombres de roles adentro: agregar un rol nuevo
+   deja de ser tocar veinte lugares.
+
+   DOS TABLAS, NO UNA
+   ------------------
+   `roles_base` son los cuatro de fábrica y es dato de plataforma, como
+   `rubros`. `roles` guarda **solo lo que un comercio cambió**, y se
+   fusiona encima. Mismo criterio que las plantillas de Comunicaciones y
+   por las mismas dos razones: un comercio nuevo funciona sin que nadie
+   le siembre nada, y si mañana se corrige un valor de fábrica, el que
+   nunca lo tocó se lleva la corrección.
+
+   UNA DIFERENCIA QUE YA EXISTÍA Y NO SE TAPA
+   ------------------------------------------
+   El encargado tiene `ajustes: false` en la pantalla —no ve el módulo—
+   pero la política de `empresas` lo deja actualizar la fila. La interfaz
+   lo esconde y la base lo permite. Se preserva tal cual en vez de
+   cerrarlo por las nuestras: cambiar en silencio lo que puede hacer un
+   rol es justamente lo que este módulo viene a evitar. Ahora se ve en
+   pantalla y se apaga con un clic, que es donde tiene que decidirse.
+
+   NO SE PUEDE UNO DEJAR AFUERA
+   ----------------------------
+   Un disparador impide sacarle `configurar` al rol propio. Sin eso, el
+   primer accidente de este módulo es un dueño que se quita el permiso de
+   configurar y necesita que alguien entre por SQL a devolvérselo.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · Los roles de fábrica
+
+   `modulos` en null quiere decir "todos los que el comercio contrató".
+   Es lo que hoy expresa la cadena "todos" en el código.
+   ------------------------------------------------------------ */
+
+create table roles_base (
+  clave       text primary key,
+  nombre      text not null,
+  descripcion text,
+  modulos     text[],
+  permisos    jsonb not null default '{}'::jsonb,
+  orden       int not null default 0
+);
+
+comment on table roles_base is
+  'Los roles con los que arranca cualquier comercio. Es dato de plataforma, como rubros: un rubro nuevo no necesita roles nuevos.';
+
+alter table roles_base enable row level security;
+
+/* Los lee cualquiera que haya entrado: son la forma del sistema, no
+   datos de nadie. Escribirlos es de la plataforma. */
+create policy roles_base_ver on roles_base
+  for select to authenticated using (true);
+
+insert into roles_base (clave, nombre, descripcion, modulos, permisos, orden) values
+  ('dueno', 'Dueño', 'Acceso completo al comercio',
+   null,
+   '{"verCostos":true,"descuentos":true,"anular":true,"cerrarCaja":true,
+     "cambiarPrecios":true,"ajustes":true,"verBitacora":true,"configurar":true}'::jsonb, 1),
+
+  ('encargado', 'Encargado', 'Todo menos la configuración',
+   array['cobro','caja','comandas','productos','stock','compras','pedidos','clientes',
+         'equipo','agenda','ventas','finanzas','servicios','reportes','informes',
+         'crm','comunicaciones','asistente'],
+   /* `ajustes` en falso y `configurar` en verdadero es la diferencia que
+      se explica arriba: así estaba y así queda. */
+   '{"verCostos":true,"descuentos":true,"anular":true,"cerrarCaja":true,
+     "cambiarPrecios":true,"ajustes":false,"verBitacora":true,"configurar":true}'::jsonb, 2),
+
+  ('cajero', 'Cajero', 'Cobra, sin ver costos ni ganancias',
+   array['cobro','caja','comandas','pedidos','clientes','equipo','agenda',
+         'ventas','finanzas','servicios'],
+   '{"verCostos":false,"descuentos":false,"anular":false,"cerrarCaja":false,
+     "cambiarPrecios":false,"ajustes":false,"verBitacora":false,"configurar":false}'::jsonb, 3),
+
+  ('repositor', 'Repositor', 'Stock y preparación de pedidos',
+   array['stock','pedidos','productos'],
+   '{"verCostos":false,"descuentos":false,"anular":false,"cerrarCaja":false,
+     "cambiarPrecios":false,"ajustes":false,"verBitacora":false,"configurar":false}'::jsonb, 4);
+
+
+/* ------------------------------------------------------------
+   2 · Lo que cada comercio cambió
+   ------------------------------------------------------------ */
+
+create table roles (
+  id          uuid primary key default gen_random_uuid(),
+  empresa_id  uuid not null references empresas(id) on delete cascade,
+  clave       text not null references roles_base(clave) on delete cascade,
+  nombre      text,
+  /* En null: se usa el de fábrica. Un arreglo vacío es distinto y quiere
+     decir "ningún módulo", que es una decisión válida. */
+  modulos     text[],
+  permisos    jsonb not null default '{}'::jsonb,
+  actualizado timestamptz not null default now(),
+  usuario_id  uuid references perfiles(id) on delete set null,
+  unique (empresa_id, clave)
+);
+
+comment on table roles is
+  'Solo lo que el comercio cambió de un rol. Se fusiona encima de roles_base: lo que no está acá sigue siendo lo de fábrica.';
+
+alter table roles enable row level security;
+
+/* Las políticas de esta tabla van más abajo, después de las funciones:
+   `permisos_de` lee `roles` y las políticas de `roles` preguntan por
+   `permiso`. Se rompe el círculo creando la tabla primero, las funciones
+   después y las políticas al final. */
+
+
+/* ------------------------------------------------------------
+   3 · Qué puede hacer alguien
+
+   `permisos_de` toma el perfil como parámetro en vez de mirar solo
+   `auth.uid()`. Es lo que permite probarla —una función que solo se puede
+   ejecutar "siendo" cada rol no se prueba, se cruza los dedos— y es lo
+   que la pantalla necesita para mostrar la grilla entera.
+
+   Es `security definer` porque lee `perfiles` y `roles`, que están detrás
+   de RLS. Por eso mismo se limita a sí mismo o a perfiles del comercio
+   que el que pregunta ya puede ver: qué puede hacer un usuario no es un
+   dato grave, pero tampoco es de dominio público.
+   ------------------------------------------------------------ */
+
+create or replace function public.permisos_de(p_perfil uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select case
+    /* La plataforma entra a todo: es la misma decisión que ya toma
+       `puede_ver`, escrita una vez más y en el mismo lugar. */
+    when p.es_plataforma then (select permisos from roles_base where clave = 'dueno')
+    else coalesce(b.permisos, '{}'::jsonb) || coalesce(r.permisos, '{}'::jsonb)
+  end
+  from perfiles p
+  left join roles_base b on b.clave = p.rol
+  left join roles      r on r.empresa_id = p.empresa_id and r.clave = p.rol
+  where p.id = p_perfil
+    and (p_perfil = auth.uid() or public.puede_ver(p.empresa_id))
+$$;
+
+comment on function public.permisos_de is
+  'Las banderas de un perfil: las de fábrica de su rol, con lo que el comercio haya cambiado encima.';
+
+create or replace function public.permiso(p_clave text)
+returns boolean
+language sql
+stable
+as $$
+  select coalesce((public.permisos_de(auth.uid()) ->> p_clave)::boolean, false)
+$$;
+
+comment on function public.permiso is
+  'Si el que está preguntando tiene esa bandera. Es lo que usan las políticas, para que ninguna vuelva a tener nombres de roles adentro.';
+
+grant execute on function public.permisos_de(uuid) to authenticated;
+grant execute on function public.permiso(text) to authenticated;
+
+
+/* ------------------------------------------------------------
+   4 · Quién puede tocar los roles
+
+   Editar roles es configurar el comercio: el mismo permiso que tocar la
+   ficha de la empresa, y no uno propio. Dos permisos para lo mismo
+   terminan siempre con uno de los dos olvidado.
+   ------------------------------------------------------------ */
+
+create policy roles_ver on roles
+  for select using (public.puede_ver(empresa_id));
+
+create policy roles_escribir on roles
+  for insert with check (public.puede_ver(empresa_id) and public.permiso('configurar'));
+
+create policy roles_editar on roles
+  for update using (public.puede_ver(empresa_id) and public.permiso('configurar'));
+
+create policy roles_borrar on roles
+  for delete using (public.puede_ver(empresa_id) and public.permiso('configurar'));
+
+
+/* ------------------------------------------------------------
+   5 · Las dos políticas que nombraban roles
+
+   Se rehacen. El resultado es el mismo para todos los usuarios que
+   existen hoy; lo que cambia es que mañana se puede mover sin publicar
+   una versión.
+   ------------------------------------------------------------ */
+
+drop policy bitacora_leer on bitacora;
+
+create policy bitacora_leer on bitacora
+  for select using (
+    public.puede_ver(empresa_id) and public.permiso('verBitacora')
+  );
+
+drop policy empresas_configurar on empresas;
+
+create policy empresas_configurar on empresas
+  for update
+  using (id = public.empresa_actual() and public.permiso('configurar'))
+  with check (id = public.empresa_actual());
+
+
+/* ------------------------------------------------------------
+   6 · No dejarse afuera
+
+   El accidente que este módulo habilita: alguien le saca `configurar` a
+   su propio rol y necesita que otro entre por SQL a devolvérselo. La
+   base lo impide, que es donde tiene que impedirse: una validación en la
+   pantalla la saltea cualquier otra pantalla.
+   ------------------------------------------------------------ */
+
+create or replace function public.no_dejarse_afuera()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_mi_rol  text;
+  v_quedan  boolean;
+begin
+  if public.es_plataforma() then
+    return new;
+  end if;
+
+  select rol into v_mi_rol from perfiles where id = auth.uid();
+  if v_mi_rol is distinct from new.clave then
+    return new;
+  end if;
+
+  select coalesce(((coalesce(b.permisos, '{}'::jsonb) || new.permisos) ->> 'configurar')::boolean, false)
+    into v_quedan
+    from roles_base b where b.clave = new.clave;
+
+  if not v_quedan then
+    raise exception 'No podés sacarle a tu propio rol el permiso de configurar: te quedarías afuera.'
+      using errcode = 'P0070';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger roles_no_dejarse_afuera
+  before insert or update on roles
+  for each row execute function public.no_dejarse_afuera();
+
+
+/* ------------------------------------------------------------
+   7 · La auditoría
+
+   `bitacora` ya existía y nunca tuvo pantalla: se escribía y no la leía
+   nadie. Ahora se lee, y lo primero que tiene que registrar es esto
+   mismo. Un módulo de permisos que no deje rastro de quién cambió qué es
+   el único que no se puede auditar, que es al revés de lo que hace falta.
+   ------------------------------------------------------------ */
+
+create or replace function public.anotar_permiso()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into bitacora (empresa_id, usuario_id, accion, entidad, entidad_id, detalle)
+  values (
+    coalesce(new.empresa_id, old.empresa_id),
+    auth.uid(),
+    case tg_op when 'DELETE' then 'permisos.restaurar' else 'permisos.cambiar' end,
+    'rol',
+    coalesce(new.id, old.id),
+    jsonb_build_object(
+      'rol', coalesce(new.clave, old.clave),
+      'antes', case when tg_op = 'INSERT' then null else old.permisos end,
+      'despues', case when tg_op = 'DELETE' then null else new.permisos end,
+      'modulos', case when tg_op = 'DELETE' then null else to_jsonb(new.modulos) end
+    )
+  );
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger roles_bitacora
+  after insert or update or delete on roles
+  for each row execute function public.anotar_permiso();
+
+
+/* ------------------------------------------------------------
+   8 · La sección en el menú
+
+   Cuelga de Configuración, al lado de Ajustes. Solo para el rubro
+   servicios por ahora: los otros dos rubros lo reciben con un insert el
+   día que se decida, y no hay nada en el módulo que sea de servicios.
+   ------------------------------------------------------------ */
+
+update rubros set menu = jsonb_set(
+  menu, '{9}',
+  '{
+    "clave":"config", "nombre":"Configuración", "i":"tuerca",
+    "modulos":[
+      {"k":"ajustes","n":"Ajustes","i":"tuerca","d":"Configuración del negocio y del sistema"},
+      {"k":"permisos","n":"Permisos","i":"escudo","d":"Qué puede hacer cada rol, y quién cambió qué"}
+    ]
+  }'::jsonb
+)
+where clave = 'servicios'
+  and menu -> 9 ->> 'clave' = 'config';
+
+do $$
+declare v_plataforma uuid;
+begin
+  select id into v_plataforma from perfiles where es_plataforma limit 1;
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_plataforma, 'role', 'authenticated')::text, true);
+
+  update empresas
+     set modulos = array(select distinct unnest(modulos || array['permisos']))
+   where nombre = 'Almha';
+
+  perform set_config('request.jwt.claims', '', true);
+end;
+$$;
+
+select clave, nombre, cardinality(modulos) as modulos,
+       permisos ->> 'configurar' as configura,
+       permisos ->> 'verBitacora' as ve_bitacora
+  from roles_base order by orden;

--- a/supabase/seed/almha_historia.sql
+++ b/supabase/seed/almha_historia.sql
@@ -136,6 +136,7 @@ declare
   v_estado   text;
   v_medio    text;
   v_cobrada  boolean;
+  v_falla    boolean;
   v_hora     int;
   v_cuando   timestamptz;
   v_efectivo numeric;
@@ -269,7 +270,20 @@ raise notice 'Almha: 4 planes.';
    camilla. Una clienta de masajes que aparece anotada en reformer todas
    las semanas hace que la ocupación mienta.
    ------------------------------------------------------------ */
-create temp table semilla_clientes (id uuid, perfil text, alta date) on commit drop;
+/* `baja` y `falla` existen para que el negocio de ejemplo tenga las
+   situaciones que el sistema después tiene que resolver. Un comercio
+   donde todos vienen siempre y nadie falta no es un comercio: es una
+   planilla. Y con esos datos, CRM no tiene a quién mostrar.
+
+   `baja` es la fecha desde la cual la persona dejó de venir —sin avisar,
+   que es como pasa—. `falla` es el que reserva y no aparece. */
+create temp table semilla_clientes (
+  id     uuid,
+  perfil text,
+  alta   date,
+  baja   date,
+  falla  boolean default false
+) on commit drop;
 
 for v_off in 1..array_length(v_nombres, 1) loop
   /* Las altas se reparten en los cuatro meses, con más al principio: un
@@ -296,6 +310,7 @@ for v_off in 1..array_length(v_nombres, 1) loop
                       when random() < 0.62 then 'estetica'
                       else 'masajes' end, v_dia);
 
+
   /* Una nota cada tanto: la ficha con todas las fichas vacías no deja ver
      si el cuaderno se lee bien. */
   if random() < 0.35 then
@@ -304,6 +319,37 @@ for v_off in 1..array_length(v_nombres, 1) loop
             false, v_user, v_dia + time '10:05');
   end if;
 end loop;
+
+/* ------------------------------------------------------------
+   Los que se van, los que faltan y los que vinieron una sola vez
+
+   Un negocio real los tiene y un CRM existe por ellos. Sin esto los
+   segmentos de "hace rato que no viene" y "falta seguido" salen vacíos, y
+   una pantalla que solo se puede ver vacía no se puede dar por terminada.
+
+   Se eligen entre los que ya tienen unos meses encima: alguien que se dio
+   de alta la semana pasada no puede "haber dejado de venir".
+   ------------------------------------------------------------ */
+
+/* Seis que dejaron de venir de a poco, entre hace cuatro meses y hace
+   siete semanas. Sin avisar, que es como pasa. */
+update semilla_clientes set baja = v_hoy - (50 + floor(random() * 70)::int)
+ where id in (select id from semilla_clientes
+               where alta < v_hoy - 100 and perfil <> 'estetica'
+               order by random() limit 6);
+
+/* Cinco que reservan y no aparecen. */
+update semilla_clientes set falla = true
+ where id in (select id from semilla_clientes
+               where alta < v_hoy - 60 order by random() limit 5);
+
+/* Cuatro que vinieron una sola vez. La baja el mismo día del alta los
+   deja afuera del sorteo diario; el turno único se los carga después del
+   bucle, para que sea exactamente uno. */
+update semilla_clientes set baja = alta
+ where id in (select id from semilla_clientes
+               where alta between v_hoy - 110 and v_hoy - 20
+               order by random() limit 4);
 
 /* Las dos contraindicaciones destacadas: son las que la ficha saca a la
    superficie y las que aparecen al agendar un turno. */
@@ -434,8 +480,9 @@ for v_off in (v_inicio - v_hoy)..14 loop
                    * (0.7 + random() * 0.6))::int));
 
     for c in
-      select sc.id from semilla_clientes sc
+      select sc.id, sc.falla from semilla_clientes sc
        where sc.perfil = 'pilates' and sc.alta <= v_dia
+         and (sc.baja is null or sc.baja > v_dia)
        order by random() limit v_cuantos
     loop
       /* ¿Tiene crédito que cubra este día? Se pregunta por la ventana del
@@ -476,8 +523,10 @@ for v_off in (v_inicio - v_hoy)..14 loop
         returning id into v_abono;
       end if;
 
+      /* El que falla se anota igual y no viene, que es justamente lo que
+         lo hace un problema: ocupó el lugar. */
       if v_off < 0 then
-        v_estado := case when random() < 0.84 then 'cumplida'
+        v_estado := case when random() < (case when c.falla then 0.5 else 0.84 end) then 'cumplida'
                          when random() < 0.55 then 'ausente'
                          else 'cancelada' end;
       else
@@ -512,8 +561,9 @@ for v_off in (v_inicio - v_hoy)..14 loop
   for v_hora in 1..v_cuantos loop
     select * into s from semilla_agenda where not clase order by random() limit 1;
 
-    select sc.id into v_cli from semilla_clientes sc
+    select sc.id, sc.falla into v_cli, v_falla from semilla_clientes sc
      where sc.perfil = s.perfil and sc.alta <= v_dia
+       and (sc.baja is null or sc.baja > v_dia)
      order by random() limit 1;
     continue when v_cli is null;
 
@@ -521,7 +571,7 @@ for v_off in (v_inicio - v_hoy)..14 loop
                                   (array[0, 30])[1 + floor(random() * 2)::int], 0);
 
     if v_off < 0 then
-      v_estado := case when random() < 0.86 then 'cumplida'
+      v_estado := case when random() < (case when v_falla then 0.5 else 0.86 end) then 'cumplida'
                        when random() < 0.5  then 'ausente'
                        else 'cancelada' end;
     else
@@ -560,6 +610,34 @@ for v_off in (v_inicio - v_hoy)..14 loop
      where sesion_id = v_ses and tipo = 'ingreso' and medio = 'efectivo';
     update sesiones_caja set monto_declarado = 30000 + v_efectivo where id = v_ses;
   end if;
+end loop;
+
+/* Los que probaron una vez y no volvieron. Van fuera del bucle porque
+   tienen que ser exactamente uno: adentro del sorteo diario terminaban
+   con dos o con ninguno según el día. Es el segmento más barato de
+   recuperar y el que hoy no ve nadie. */
+for c in select sc.id, sc.alta, sc.perfil from semilla_clientes sc where sc.baja = sc.alta loop
+  select * into s from semilla_agenda where not clase and perfil = c.perfil order by random() limit 1;
+  continue when s is null;
+
+  v_cuando := (c.alta + 3) + time '17:00';
+  v_num := v_num + 1;
+
+  insert into reservas (
+    empresa_id, sucursal_id, recurso_id, personal_id, item_id,
+    cliente_id, nombre, personas, desde, duracion_min, estado,
+    usuario_id, campos_extra, creada_en
+  )
+  select v_emp, v_suc, s.recurso_id, s.personal_id, s.item_id,
+         c.id, cl.razon_social, 1, v_cuando, s.duracion, 'cumplida',
+         v_user, '{"demo": true}'::jsonb, c.alta + time '11:00'
+    from clientes cl where cl.id = c.id;
+
+  perform pg_temp.venta_demo(
+    v_emp, v_suc, v_user, c.id, s.item_id, s.nombre, s.precio,
+    v_cuando + interval '50 minutes',
+    (select id from sesiones_caja where empresa_id = v_emp and abierta_en::date = c.alta + 3 limit 1),
+    'efectivo', v_pv || '-' || lpad(v_num::text, 8, '0'), true);
 end loop;
 
 raise notice 'Almha: agenda y ventas de 120 días.';

--- a/supabase/seed/almha_historia.sql
+++ b/supabase/seed/almha_historia.sql
@@ -1,0 +1,719 @@
+/* ============================================================
+   SEMILLA · cuatro meses de historia en Almha
+   ============================================================
+
+   Almha tenía el catálogo cargado —nueve prestaciones, diez espacios,
+   cinco personas con sus horarios— y ni un solo día de operación: cero
+   clientes, cero turnos dictados, cero ventas, cero caja. Un informe es
+   una lectura del pasado, así que sin pasado no hay nada que leer ni,
+   sobre todo, nada que mirar para saber si la pantalla está bien hecha.
+
+   Esto llena ese hueco: cuatro meses enteros hacia atrás y dos semanas
+   hacia adelante, armados sobre el catálogo que YA está cargado. No
+   inventa servicios ni salas ni gente: usa los que están, así el día que
+   lleguen los datos de verdad lo único que cambia son los nombres.
+
+   TODO ES DE EJEMPLO y va marcado igual que el resto de Almha:
+
+     delete from reservas    where empresa_id = (select id from empresas where nombre = 'Almha')
+                               and campos_extra ->> 'demo' = 'true';
+     delete from operaciones where empresa_id = (select id from empresas where nombre = 'Almha')
+                               and campos_extra ->> 'demo' = 'true';
+     delete from clientes    where empresa_id = (select id from empresas where nombre = 'Almha')
+                               and campos_extra ->> 'demo' = 'true';
+
+   Los abonos, las notas de ficha y la lista de espera cuelgan del cliente
+   y se van con él por la cascada.
+
+   POR QUÉ SE NIEGA A CORRER EN UN COMERCIO DE VERDAD
+   --------------------------------------------------
+   La regla del proyecto es que los datos de ejemplo solo existen en
+   comercios marcados `demo` en su configuración. Esa regla estaba escrita
+   en un comentario de `tablero.js` y en la cabeza de quien la escribió;
+   acá está puesta como guarda, que es donde sirve. Si `config->>'demo'`
+   no es `true`, el archivo aborta y no escribe una línea.
+
+   El azar va sembrado con `setseed`, así que dos corridas dan lo mismo:
+   un informe que cambia de números cada vez que se vuelve a sembrar no
+   se puede comparar contra una captura.
+
+   Se puede correr las veces que haga falta: barre lo suyo antes.
+
+     node scripts/aplicar-sql.mjs supabase/seed/almha_historia.sql
+   ============================================================ */
+
+/* Una venta con su línea, su pago y su movimiento de caja. Va como
+   función temporal —vive lo que dura la conexión— porque el bloque de
+   abajo la llama desde cuatro lugares y repetir los cuatro inserts era
+   la forma más segura de que uno de ellos quedara distinto.
+
+   No usa `registrar_venta` a propósito: esa función estampa la fecha del
+   momento, y acá toda la gracia es que las ventas tengan la fecha del día
+   en que pasaron. */
+create function pg_temp.venta_demo(
+  p_emp     uuid,
+  p_suc     uuid,
+  p_user    uuid,
+  p_cliente uuid,
+  p_item    uuid,
+  p_detalle text,
+  p_precio  numeric,
+  p_fecha   timestamptz,
+  p_ses     uuid,
+  p_medio   text,
+  p_numero  text,
+  p_cobrada boolean
+) returns uuid
+language plpgsql
+as $fn$
+declare
+  v_op uuid := gen_random_uuid();
+begin
+  insert into operaciones (
+    id, empresa_id, sucursal_id, tipo, estado, numero, fecha, cliente_id,
+    usuario_id, subtotal, total, campos_extra, creada_en
+  ) values (
+    v_op, p_emp, p_suc, 'venta', 'confirmada', p_numero, p_fecha, p_cliente,
+    p_user, p_precio, p_precio, '{"demo": true}'::jsonb, p_fecha
+  );
+
+  insert into operacion_lineas (
+    operacion_id, empresa_id, item_id, descripcion, cantidad,
+    precio_unitario, total, estado, usuario_id
+  ) values (
+    v_op, p_emp, p_item, p_detalle, 1, p_precio, p_precio, 'entregado', p_user
+  );
+
+  /* Lo que no se cobró queda como operación confirmada sin pagos: así es
+     como el sistema representa una cuenta corriente, y es lo que lee
+     "Pendientes" en Finanzas. Un saldo guardado se desincroniza. */
+  if p_cobrada then
+    insert into pagos (operacion_id, empresa_id, medio, monto, fecha)
+    values (v_op, p_emp, p_medio, p_precio, p_fecha);
+
+    insert into movimientos_caja (
+      empresa_id, sucursal_id, sesion_id, tipo, medio, monto,
+      detalle, categoria, operacion_id, usuario_id, fecha
+    ) values (
+      p_emp, p_suc, p_ses, 'ingreso', p_medio, p_precio,
+      'Venta ' || coalesce(p_numero, ''),
+      case when p_detalle like 'Pack%' or p_detalle like 'Plan%' then 'abonos' else 'turnos' end,
+      v_op, p_user, p_fecha
+    );
+  end if;
+
+  return v_op;
+end;
+$fn$;
+
+
+do $semilla$
+declare
+  v_emp    uuid;
+  v_suc    uuid;
+  v_user   uuid;
+  v_pv     text;
+  v_num    int := 0;
+
+  v_hoy    date := current_date;
+  /* La historia arranca el 1 de un mes y no "hace 120 días" a secas. Un
+     informe mensual con un primer mes cortado por la mitad muestra una
+     caída que nunca pasó, y el ojo la lee antes que cualquier aclaración
+     al pie. */
+  v_inicio date := (date_trunc('month', current_date::timestamp) - interval '4 months')::date;
+  v_dia    date;
+  v_off    int;
+  v_dow    int;
+
+  v_ses    uuid;
+  v_cli    uuid;
+  v_clase  uuid;
+  v_abono  uuid;
+  v_op     uuid;
+
+  v_cuantos  int;
+  v_cupo     int;
+  v_estado   text;
+  v_medio    text;
+  v_cobrada  boolean;
+  v_hora     int;
+  v_cuando   timestamptz;
+  v_efectivo numeric;
+
+  v_horas   numeric;
+  v_clases  int;
+  v_total   numeric;
+  v_desde   date;
+  v_hasta   date;
+  v_liq     uuid;
+  v_mov     uuid;
+  v_semana  int;
+
+  /* Ojo con estos cuatro: plpgsql resuelve los nombres antes que el SQL,
+     así que un `join personal p` adentro de este bloque se lee como la
+     variable `p` y revienta con "record is not assigned yet". Por eso los
+     alias de las consultas de acá abajo son `per`, `cl`, `sc` y no las
+     iniciales de siempre. */
+  c   record;
+  s   record;
+  p   record;
+  pl  record;
+
+  v_nombres text[] := array[
+    'Florencia Silva',   'Martina López',     'Agustín Pérez',     'Belén Acosta',
+    'Julieta Román',     'Camila Torres',     'Antonella Vera',    'Lucía Fernández',
+    'Micaela Duarte',    'Sofía Benítez',     'Rocío Medina',      'Paula Cabrera',
+    'Carolina Ferreyra', 'Daniela Quiroga',   'Mariana Sosa',      'Aldana Bruno',
+    'Guadalupe Ibarra',  'Malena Ríos',       'Victoria Peralta',  'Abril Maldonado',
+    'Josefina Aguirre',  'Delfina Ocampo',    'Renata Vidal',      'Emilia Cardozo',
+    'Milagros Ponce',    'Ana Clara Vega',    'Bautista Correa',   'Tomás Herrera',
+    'Ignacio Bustos',    'Federico Ledesma',  'Nicolás Arias',     'Joaquín Escobar',
+    'Matías Villalba',   'Franco Miranda',    'Santiago Alvarado', 'Gonzalo Paz',
+    'Verónica Ramallo',  'Silvina Barrios',   'Patricia Godoy',    'Alejandra Núñez',
+    'Marcela Fuentes',   'Gabriela Molina',   'Natalia Cáceres',   'Andrea Sarmiento',
+    'Laura Bianchi',     'Cecilia Domínguez', 'Romina Ávalos',     'Vanesa Olmedo',
+    'Elena Zabala',      'Graciela Ferrari',  'Nadia Segovia',     'Ayelén Cortés',
+    'Brenda Salazar',    'Ximena Lucero',     'Priscila Ojeda'
+  ];
+
+  v_notas text[] := array[
+    'Prefiere turnos a la mañana temprano.',
+    'Viene derivada por su kinesióloga.',
+    'Trabaja cerca, puede venir en el horario del mediodía.',
+    'Le molesta el frío en la sala, dejar la estufa prendida.',
+    'Pidió que la avisemos si se libera un lugar los martes.',
+    'Paga siempre por transferencia el primer día del mes.'
+  ];
+begin
+
+/* ------------------------------------------------------------
+   1 · La guarda
+
+   No es una formalidad: esta semilla escribe ventas y movimientos de
+   caja, que es lo último que se quiere ver aparecer en un negocio real.
+   ------------------------------------------------------------ */
+select id into v_emp from empresas where nombre = 'Almha';
+if v_emp is null then
+  raise exception 'No existe Almha. Corré antes supabase/seed/almha.sql.';
+end if;
+
+if coalesce((select config ->> 'demo' from empresas where id = v_emp), 'false') <> 'true' then
+  raise exception 'Almha no está marcada como comercio de demostración. Esta semilla no corre sobre datos reales.';
+end if;
+
+select id into v_suc  from sucursales where empresa_id = v_emp limit 1;
+select id into v_user from perfiles    where es_plataforma limit 1;
+select coalesce(config -> 'fiscal' ->> 'puntoVenta', '0001') into v_pv from empresas where id = v_emp;
+
+perform setseed(0.20260822);
+
+/* ------------------------------------------------------------
+   2 · Barrer la corrida anterior
+
+   El orden lo manda la clave foránea: los movimientos primero, porque la
+   operación los deja huérfanos en vez de borrarlos y un arqueo con
+   ingresos de ventas que ya no existen no cierra nunca.
+
+   Se barre todo lo transaccional del comercio y no solo lo marcado: la
+   guarda de arriba ya garantizó que estamos en un comercio de
+   demostración, donde no hay nada que preservar. Los turnos de prueba
+   que quedaron de armar la agenda también se van acá, que es lo que se
+   quiere.
+   ------------------------------------------------------------ */
+delete from movimientos_caja where empresa_id = v_emp;
+delete from liquidaciones    where empresa_id = v_emp;
+delete from espera           where empresa_id = v_emp;
+delete from reservas         where empresa_id = v_emp;
+delete from abonos           where empresa_id = v_emp;
+delete from operaciones      where empresa_id = v_emp;
+delete from sesiones_caja    where empresa_id = v_emp;
+delete from clientes         where empresa_id = v_emp;
+delete from items            where empresa_id = v_emp and tipo = 'plan';
+
+raise notice 'Almha: barrido lo anterior.';
+
+/* ------------------------------------------------------------
+   3 · Los planes del catálogo
+
+   Un plan es un item con `tipo = 'plan'` y sus condiciones en
+   `campos_extra`. No es una tabla aparte a propósito: así se cobra, se
+   asienta en caja y aparece en los informes por el mismo camino que una
+   limpieza facial. Ver la migración 0035.
+   ------------------------------------------------------------ */
+for pl in
+  select * from (values
+    ('Pack 4 clases',      56000,  4,          null::int, 45),
+    ('Pack 8 clases',      100000, 8,          null::int, 60),
+    ('Plan 2 por semana',  95000,  null::int,  2,         30),
+    ('Plan libre mensual', 130000, null::int,  null::int, 30)
+  ) as x(nombre, precio, clases, tope, dias)
+loop
+  insert into items (
+    empresa_id, tipo, nombre, categoria, precio, costo,
+    controla_stock, activo, campos_extra
+  ) values (
+    v_emp, 'plan', pl.nombre, 'Pilates', pl.precio, 0,
+    false, true,
+    jsonb_build_object('demo', true, 'clases', pl.clases,
+                       'topeSemanal', pl.tope, 'vigenciaDias', pl.dias)
+  );
+end loop;
+
+raise notice 'Almha: 4 planes.';
+
+/* ------------------------------------------------------------
+   4 · La gente
+
+   `perfil` no es una columna de la base: es una tabla temporal para que
+   los bucles de abajo sepan a quién mandar a pilates y a quién a una
+   camilla. Una clienta de masajes que aparece anotada en reformer todas
+   las semanas hace que la ocupación mienta.
+   ------------------------------------------------------------ */
+create temp table semilla_clientes (id uuid, perfil text, alta date) on commit drop;
+
+for v_off in 1..array_length(v_nombres, 1) loop
+  /* Las altas se reparten en los cuatro meses, con más al principio: un
+     negocio que arranca su sistema carga la cartera que ya tenía y
+     después suma de a poco. Eso es lo que después se lee como "clientes
+     nuevos por mes", y con altas parejas ese informe no dice nada. */
+  v_dia := v_hoy - (case when v_off <= 30 then (v_hoy - v_inicio) - v_off
+                         else floor(random() * (v_hoy - v_inicio - 10))::int end);
+
+  insert into clientes (empresa_id, razon_social, tel, email, condicion, activo, campos_extra, creado_en)
+  values (
+    v_emp,
+    v_nombres[v_off],
+    '11' || lpad((floor(random() * 90000000) + 10000000)::text, 8, '0'),
+    lower(translate(split_part(v_nombres[v_off], ' ', 1), 'áéíóúñÁÉÍÓÚÑ', 'aeiounAEIOUN'))
+      || v_off || '@ejemplo.com',
+    'CF', true, '{"demo": true}'::jsonb,
+    v_dia + time '10:00'
+  )
+  returning id into v_cli;
+
+  insert into semilla_clientes (id, perfil, alta)
+  values (v_cli, case when random() < 0.58 then 'pilates'
+                      when random() < 0.62 then 'estetica'
+                      else 'masajes' end, v_dia);
+
+  /* Una nota cada tanto: la ficha con todas las fichas vacías no deja ver
+     si el cuaderno se lee bien. */
+  if random() < 0.35 then
+    insert into cliente_notas (empresa_id, cliente_id, texto, destacada, usuario_id, creada_en)
+    values (v_emp, v_cli, v_notas[1 + floor(random() * array_length(v_notas, 1))::int],
+            false, v_user, v_dia + time '10:05');
+  end if;
+end loop;
+
+/* Las dos contraindicaciones destacadas: son las que la ficha saca a la
+   superficie y las que aparecen al agendar un turno. */
+insert into cliente_notas (empresa_id, cliente_id, texto, destacada, usuario_id)
+select v_emp, id, 'Alérgica al ácido glicólico. No usar en limpieza facial.', true, v_user
+  from semilla_clientes where perfil = 'estetica' order by random() limit 1;
+
+insert into cliente_notas (empresa_id, cliente_id, texto, destacada, usuario_id)
+select v_emp, id, 'Hernia lumbar. No hacer flexión de columna cargada.', true, v_user
+  from semilla_clientes where perfil = 'pilates' order by random() limit 1;
+
+raise notice 'Almha: % clientes.', array_length(v_nombres, 1);
+
+/* ------------------------------------------------------------
+   5 · Qué se dicta y dónde
+
+   Se lee del catálogo real del comercio en vez de escribirlo acá: si
+   mañana se agrega una prestación de masajes, entra sola.
+   ------------------------------------------------------------ */
+create temp table semilla_agenda (
+  clase       boolean,
+  item_id     uuid,
+  nombre      text,
+  precio      numeric,
+  duracion    int,
+  personal_id uuid,
+  recurso_id  uuid,
+  cupo        int,
+  hora        int,
+  perfil      text
+) on commit drop;
+
+/* Las clases con cupo: tres por día de semana, en las salas grandes. El
+   horario fijo es lo que hace que la ocupación se pueda comparar de una
+   semana a la otra. */
+insert into semilla_agenda (clase, item_id, nombre, precio, duracion, personal_id, recurso_id, cupo, hora, perfil)
+select true, i.id, i.nombre, i.precio, i.duracion_min, per.id, r.id, r.capacidad, h.hora, 'pilates'
+  from (values ('Pilates Mat',      'Sala Mat 1',      'Sofía González',  9),
+               ('Pilates Reformer', 'Sala Reformer 1', 'Valentina Rojas', 18),
+               ('Pilates Reformer', 'Sala Reformer 2', 'Sofía González',  19)
+       ) as h(servicio, sala, profe, hora)
+  join items    i on i.empresa_id = v_emp and i.nombre = h.servicio
+  join recursos r on r.empresa_id = v_emp and r.nombre = h.sala
+  join personal per on per.empresa_id = v_emp and per.nombre = h.profe;
+
+/* Los turnos de a uno. La sala sale al azar entre las de su área, así los
+   boxes se llenan parejo y la ocupación no queda toda en uno. */
+insert into semilla_agenda (clase, item_id, nombre, precio, duracion, personal_id, recurso_id, cupo, hora, perfil)
+select false, i.id, i.nombre, i.precio, i.duracion_min, per.id, r.id, null, null,
+       case when i.categoria = 'Estética' then 'estetica' else 'masajes' end
+  from items i
+  join personal per on per.empresa_id = v_emp and per.especialidad = i.categoria
+  join recursos r on r.empresa_id = v_emp
+                 and r.nombre = any (case when i.categoria = 'Estética'
+                                          then array['Sala Estética', 'Gabinete 1', 'Gabinete 2']
+                                          else array['Box Masajes 1', 'Box Masajes 2', 'Consultorio 1'] end)
+ where i.empresa_id = v_emp and i.tipo = 'servicio'
+   and i.categoria in ('Estética', 'Masajes');
+
+/* Corporales lo da la de masajes: en el equipo de ejemplo nadie tiene esa
+   especialidad exacta, y sin esto el drenaje linfático no lo daría nadie
+   y no se vendería nunca. */
+insert into semilla_agenda (clase, item_id, nombre, precio, duracion, personal_id, recurso_id, cupo, hora, perfil)
+select false, i.id, i.nombre, i.precio, i.duracion_min, per.id, r.id, null, null, 'masajes'
+  from items i
+  cross join (select id from personal where empresa_id = v_emp and nombre = 'Agustina Pérez') per
+  join recursos r on r.empresa_id = v_emp and r.nombre = 'Box Masajes 2'
+ where i.empresa_id = v_emp and i.tipo = 'servicio' and i.categoria = 'Corporales';
+
+/* Pilates Personalizado es de a uno aunque sea pilates: va con la profe
+   de pilates y en un reformer. */
+insert into semilla_agenda (clase, item_id, nombre, precio, duracion, personal_id, recurso_id, cupo, hora, perfil)
+select false, i.id, i.nombre, i.precio, i.duracion_min, per.id, r.id, null, null, 'pilates'
+  from items i
+  cross join (select id from personal where empresa_id = v_emp and nombre = 'Valentina Rojas') per
+  join recursos r on r.empresa_id = v_emp and r.nombre = 'Sala Reformer 1'
+ where i.empresa_id = v_emp and i.tipo = 'servicio' and i.nombre = 'Pilates Personalizado';
+
+/* ------------------------------------------------------------
+   6 · Los días
+
+   De atrás para adelante: cuatro meses enteros de historia y dos semanas
+   de agenda por venir, que es lo que hace que la pantalla tenga algo que
+   mostrar arriba y algo que mostrar abajo.
+
+   Domingo cerrado, sábado a media máquina.
+   ------------------------------------------------------------ */
+for v_off in (v_inicio - v_hoy)..14 loop
+  v_dia := v_hoy + v_off;
+  v_dow := extract(dow from v_dia);
+  continue when v_dow = 0;
+
+  /* La caja del día. La de hoy queda abierta —es lo que espera encontrar
+     quien entra a cobrar— y las anteriores cerradas con su declarado. */
+  if v_off <= 0 then
+    insert into sesiones_caja (empresa_id, sucursal_id, abierta_en, cerrada_en, monto_inicial, abierta_por, cerrada_por)
+    values (v_emp, v_suc, v_dia + time '08:30',
+            case when v_off = 0 then null else v_dia + time '21:00' end,
+            30000, v_user, case when v_off = 0 then null else v_user end)
+    returning id into v_ses;
+  else
+    v_ses := null;
+  end if;
+
+  /* --- las clases con cupo --- */
+  for s in
+    select * from semilla_agenda
+     where clase and (v_dow between 1 and 5 or (v_dow = 6 and hora = 9))
+     order by hora
+  loop
+    insert into reservas (
+      empresa_id, sucursal_id, recurso_id, personal_id, item_id,
+      nombre, personas, desde, duracion_min, estado, cupo, usuario_id, campos_extra, creada_en
+    ) values (
+      v_emp, v_suc, s.recurso_id, s.personal_id, s.item_id,
+      s.nombre, 0, v_dia + make_time(s.hora, 0, 0), s.duracion,
+      case when v_off < 0 then 'cumplida' else 'confirmada' end,
+      s.cupo, v_user, '{"demo": true}'::jsonb, v_dia - 3 + time '12:00'
+    )
+    returning id into v_clase;
+
+    /* Cuánta gente se anota. Reformer llena más que mat y el turno de las
+       19 más que el de las 18: son las diferencias que después hacen que
+       el informe de ocupación sirva para decidir qué clase abrir. */
+    v_cupo := s.cupo;
+    v_cuantos := greatest(1, least(v_cupo,
+      round(v_cupo * (case when s.hora >= 18 then 0.80 else 0.55 end)
+                   * (0.7 + random() * 0.6))::int));
+
+    for c in
+      select sc.id from semilla_clientes sc
+       where sc.perfil = 'pilates' and sc.alta <= v_dia
+       order by random() limit v_cuantos
+    loop
+      /* ¿Tiene crédito que cubra este día? Se pregunta por la ventana del
+         abono y por lo consumido, no por su estado de hoy: un abono de
+         mayo hoy figura vencido, y en mayo servía. */
+      select a.id into v_abono
+        from abonos a
+       where a.cliente_id = c.id and not a.anulado
+         and a.desde <= v_dia and (a.vence is null or a.vence >= v_dia)
+         and (a.clases is null
+              or (select count(*) from reservas r
+                   where r.abono_id = a.id and r.estado <> 'cancelada') < a.clases)
+       order by a.desde desc limit 1;
+
+      /* Sin crédito casi siempre compra uno nuevo: así funciona un estudio
+         de pilates. El resto paga la clase suelta. */
+      if v_abono is null and v_off <= 0 and random() < 0.78 then
+        select * into pl from items
+         where empresa_id = v_emp and tipo = 'plan' order by random() limit 1;
+
+        v_num := v_num + 1;
+        v_medio := (array['efectivo','debito','credito','mp','transferencia'])[1 + floor(random() * 5)::int];
+        v_op := pg_temp.venta_demo(v_emp, v_suc, v_user, c.id, pl.id, pl.nombre, pl.precio,
+                                   v_dia + time '09:00', v_ses, v_medio,
+                                   v_pv || '-' || lpad(v_num::text, 8, '0'), true);
+
+        insert into abonos (
+          empresa_id, cliente_id, item_id, operacion_id, nombre, clases,
+          tope_semanal, desde, vence, usuario_id, creado_en
+        ) values (
+          v_emp, c.id, pl.id, v_op, pl.nombre,
+          nullif(pl.campos_extra ->> 'clases', '')::int,
+          nullif(pl.campos_extra ->> 'topeSemanal', '')::int,
+          v_dia,
+          v_dia + coalesce(nullif(pl.campos_extra ->> 'vigenciaDias', '')::int, 30),
+          v_user, v_dia + time '09:00'
+        )
+        returning id into v_abono;
+      end if;
+
+      if v_off < 0 then
+        v_estado := case when random() < 0.84 then 'cumplida'
+                         when random() < 0.55 then 'ausente'
+                         else 'cancelada' end;
+      else
+        v_estado := case when random() < 0.75 then 'confirmada' else 'pendiente' end;
+      end if;
+
+      insert into reservas (
+        empresa_id, sucursal_id, recurso_id, personal_id, item_id, clase_id,
+        cliente_id, nombre, personas, desde, duracion_min, estado, abono_id,
+        usuario_id, campos_extra, creada_en
+      )
+      select v_emp, v_suc, s.recurso_id, s.personal_id, s.item_id, v_clase,
+             c.id, cl.razon_social, 1, v_dia + make_time(s.hora, 0, 0), s.duracion,
+             v_estado, v_abono, v_user, '{"demo": true}'::jsonb, v_dia - 2 + time '18:00'
+        from clientes cl where cl.id = c.id;
+
+      /* Sin abono la clase se paga suelta. Cancelada no se cobra. */
+      if v_abono is null and v_estado <> 'cancelada' and v_off <= 0 then
+        v_num := v_num + 1;
+        v_medio := (array['efectivo','debito','mp','mp','transferencia'])[1 + floor(random() * 5)::int];
+        perform pg_temp.venta_demo(v_emp, v_suc, v_user, c.id, s.item_id, s.nombre, s.precio,
+                                   v_dia + make_time(s.hora, 30, 0), v_ses, v_medio,
+                                   v_pv || '-' || lpad(v_num::text, 8, '0'), true);
+      end if;
+    end loop;
+  end loop;
+
+  /* --- los turnos de a uno --- */
+  v_cuantos := case when v_dow = 6 then 2 + floor(random() * 2)::int
+                    else 4 + floor(random() * 4)::int end;
+
+  for v_hora in 1..v_cuantos loop
+    select * into s from semilla_agenda where not clase order by random() limit 1;
+
+    select sc.id into v_cli from semilla_clientes sc
+     where sc.perfil = s.perfil and sc.alta <= v_dia
+     order by random() limit 1;
+    continue when v_cli is null;
+
+    v_cuando := v_dia + make_time(10 + ((v_hora * 2 + floor(random() * 2)::int) % 9),
+                                  (array[0, 30])[1 + floor(random() * 2)::int], 0);
+
+    if v_off < 0 then
+      v_estado := case when random() < 0.86 then 'cumplida'
+                       when random() < 0.5  then 'ausente'
+                       else 'cancelada' end;
+    else
+      v_estado := case when random() < 0.7 then 'confirmada' else 'pendiente' end;
+    end if;
+
+    insert into reservas (
+      empresa_id, sucursal_id, recurso_id, personal_id, item_id,
+      cliente_id, nombre, personas, desde, duracion_min, estado,
+      usuario_id, campos_extra, creada_en
+    )
+    select v_emp, v_suc, s.recurso_id, s.personal_id, s.item_id,
+           v_cli, cl.razon_social, 1, v_cuando, s.duracion, v_estado,
+           v_user, '{"demo": true}'::jsonb, v_dia - 4 + time '11:00'
+      from clientes cl where cl.id = v_cli;
+
+    /* Un turno cumplido se cobra. Uno de cada ocho queda sin cobrar: es la
+       cuenta corriente que después hay que ir a buscar, y si la semilla no
+       la produce, "Pendientes" no se puede mirar. */
+    if v_estado = 'cumplida' then
+      v_num := v_num + 1;
+      v_cobrada := random() >= 0.12;
+      v_medio := (array['efectivo','efectivo','debito','credito','mp','transferencia'])[1 + floor(random() * 6)::int];
+      perform pg_temp.venta_demo(v_emp, v_suc, v_user, v_cli, s.item_id, s.nombre, s.precio,
+                                 v_cuando + interval '50 minutes', v_ses, v_medio,
+                                 v_pv || '-' || lpad(v_num::text, 8, '0'), v_cobrada);
+    end if;
+  end loop;
+
+  /* El declarado del arqueo: lo que entró en efectivo más el inicial.
+     Cierra clavado a propósito; las diferencias de arqueo son otra
+     historia y no las cuenta un informe. */
+  if v_off < 0 then
+    select coalesce(sum(monto), 0) into v_efectivo
+      from movimientos_caja
+     where sesion_id = v_ses and tipo = 'ingreso' and medio = 'efectivo';
+    update sesiones_caja set monto_declarado = 30000 + v_efectivo where id = v_ses;
+  end if;
+end loop;
+
+raise notice 'Almha: agenda y ventas de 120 días.';
+
+/* ------------------------------------------------------------
+   7 · La lista de espera
+
+   Solo sobre clases futuras que quedaron llenas: anotarse en una que ya
+   pasó no existe.
+   ------------------------------------------------------------ */
+for s in
+  select r.id, r.cupo, r.desde
+    from reservas r
+   where r.empresa_id = v_emp and r.cupo is not null and r.desde > now()
+     and (select count(*) from reservas i
+           where i.clase_id = r.id and i.estado not in ('cancelada', 'ausente')) >= r.cupo
+   order by r.desde limit 6
+loop
+  for c in
+    select sc.id from semilla_clientes sc
+     where sc.perfil = 'pilates'
+       and not exists (select 1 from reservas i where i.clase_id = s.id and i.cliente_id = sc.id)
+     order by random() limit 1 + floor(random() * 2)::int
+  loop
+    insert into espera (empresa_id, clase_id, cliente_id, nombre, telefono, estado, orden, usuario_id)
+    select v_emp, s.id, c.id, cl.razon_social, cl.tel, 'esperando',
+           (select count(*) from espera e where e.clase_id = s.id), v_user
+      from clientes cl where cl.id = c.id;
+  end loop;
+end loop;
+
+/* ------------------------------------------------------------
+   8 · Las liquidaciones
+
+   Semana de lunes a domingo. Las horas salen de la agenda —una clase
+   cuenta una vez y no una por alumno, por eso el filtro `clase_id is
+   null`— y recepción se liquida por horario, que no dicta nada.
+
+   La semana en curso queda en borrador: es la que se está mirando. Las
+   anteriores, pagadas y con su egreso escrito. Sin eso los egresos del
+   mes mienten por el gasto más grande y más regular del negocio.
+   ------------------------------------------------------------ */
+/* Todas las semanas de la historia, no las últimas doce: un mes con
+   ingresos y sin sueldos da un resultado que duplica al real, y eso
+   después se lee como una caída de rentabilidad que nunca existió. */
+for v_semana in 0..((v_hoy - v_inicio) / 7 + 1) loop
+  v_desde := (date_trunc('week', v_hoy::timestamp) - make_interval(weeks => v_semana))::date;
+  v_hasta := v_desde + 6;
+  /* Recepción cobra aunque no dicte nada, así que sin este corte
+     aparecería un sueldo de una semana en la que el negocio todavía no
+     existía para el sistema. */
+  continue when v_hasta < v_inicio;
+
+  for p in select * from personal where empresa_id = v_emp and activo loop
+    if p.tipo = 'recepcion' then
+      v_horas  := 40;
+      v_clases := 0;
+    else
+      select coalesce(sum(duracion_min), 0) / 60.0,
+             count(*) filter (where cupo is not null)
+        into v_horas, v_clases
+        from reservas
+       where empresa_id = v_emp and personal_id = p.id
+         and clase_id is null
+         and estado in ('cumplida', 'confirmada')
+         and desde::date between v_desde and v_hasta;
+    end if;
+
+    continue when coalesce(v_horas, 0) = 0;
+
+    v_total := round(v_horas * p.valor);
+
+    insert into liquidaciones (
+      empresa_id, personal_id, desde, hasta, modalidad, valor,
+      horas, clases, total, estado, usuario_id, creada_en
+    ) values (
+      v_emp, p.id, v_desde, v_hasta, p.modalidad, p.valor,
+      round(v_horas, 2), v_clases, v_total,
+      case when v_semana = 0 then 'borrador' else 'pagada' end,
+      v_user, v_hasta + time '20:00'
+    )
+    returning id into v_liq;
+
+    /* Pagada quiere decir que salió plata: el egreso va en el mismo acto,
+       igual que hace `pagar_liquidacion`. */
+    if v_semana > 0 then
+      insert into movimientos_caja (
+        empresa_id, sucursal_id, sesion_id, tipo, medio, monto,
+        detalle, categoria, usuario_id, fecha
+      ) values (
+        v_emp, v_suc,
+        (select id from sesiones_caja
+          where empresa_id = v_emp and abierta_en::date = v_hasta + 1 limit 1),
+        'egreso', 'transferencia', v_total,
+        'Sueldo ' || p.nombre || ' · ' || to_char(v_desde, 'DD/MM') || ' al ' || to_char(v_hasta, 'DD/MM'),
+        'sueldos', v_user, v_hasta + 1 + time '12:00'
+      )
+      returning id into v_mov;
+
+      update liquidaciones
+         set medio = 'transferencia', movimiento_id = v_mov,
+             pagada_en = v_hasta + 1 + time '12:00'
+       where id = v_liq;
+    end if;
+  end loop;
+end loop;
+
+/* Dos notas de reemplazo, pegadas al período que explican. */
+insert into liquidacion_notas (empresa_id, liquidacion_id, texto, usuario_id)
+select v_emp, l.id, 'Cubrió las clases del martes por ausencia de Valentina. Se le pagan a ella, que las dio.', v_user
+  from liquidaciones l
+  join personal p2 on p2.id = l.personal_id
+ where l.empresa_id = v_emp and p2.nombre = 'Sofía González'
+ order by l.desde desc limit 1 offset 2;
+
+insert into liquidacion_notas (empresa_id, liquidacion_id, texto, usuario_id)
+select v_emp, l.id, 'Semana corta por el feriado del lunes.', v_user
+  from liquidaciones l
+  join personal p2 on p2.id = l.personal_id
+ where l.empresa_id = v_emp and p2.nombre = 'Carla Gómez'
+ order by l.desde desc limit 1 offset 1;
+
+/* ------------------------------------------------------------
+   9 · Los gastos que no son sueldos
+
+   Un negocio cuyo único egreso son los sueldos da un resultado que no se
+   parece al real. Alquiler, servicios, insumos e impuestos, una vez por
+   mes.
+   ------------------------------------------------------------ */
+for v_semana in 0..4 loop
+  v_desde := (date_trunc('month', v_hoy::timestamp) - make_interval(months => v_semana))::date;
+  /* Ni antes de que el negocio existiera para el sistema, ni con fecha
+     futura: el `where` de abajo recorta el mes en curso, del que todavía
+     no vencieron todos los gastos. */
+  continue when v_desde < v_inicio;
+
+  insert into movimientos_caja (empresa_id, sucursal_id, tipo, medio, monto, detalle, categoria, usuario_id, fecha)
+  select v_emp, v_suc, 'egreso', g.medio, g.monto, g.detalle, g.categoria, v_user,
+         v_desde + g.dia + time '11:00'
+    from (values
+      (4,  'transferencia', 850000, 'Alquiler del local',            'alquiler'),
+      (9,  'transferencia', 145000, 'Luz, gas e internet',           'servicios'),
+      (6,  'efectivo',      98000,  'Insumos de cabina',             'insumos'),
+      (18, 'transferencia', 62000,  'Monotributo e Ingresos Brutos', 'impuestos')
+    ) as g(dia, medio, monto, detalle, categoria)
+   where v_desde + g.dia <= v_hoy;
+end loop;
+
+raise notice 'Almha: liquidaciones y gastos.';
+raise notice 'Listo. Clientes: %, turnos: %, ventas: %, movimientos: %.',
+  (select count(*) from clientes         where empresa_id = v_emp),
+  (select count(*) from reservas         where empresa_id = v_emp),
+  (select count(*) from operaciones      where empresa_id = v_emp),
+  (select count(*) from movimientos_caja where empresa_id = v_emp);
+
+end;
+$semilla$;


### PR DESCRIPTION
Cierra el encargo de `docs/pedido-negocios-de-servicios.md`. Las
migraciones 0039 a 0045 solo agregan, salvo dos políticas de RLS que se
reescriben preservando su comportamiento exacto —ver la última sección—.

## Servicios y recursos

Una prestación es un `item` con `tipo = 'servicio'` y una sala es un
`recurso`: estaba previsto desde la primera migración. Faltaba poder
verlos sin pasar por SQL. Del esquema se agrega un solo tipo de recurso,
**equipamiento**: una camilla es un lugar donde alguien se acuesta; un
reformer es una cosa que se reserva y puede moverse de sala.

## La ficha del cliente

**Un cuaderno fechado, no un campo que se pisa.** Una nota puede ir
destacada, y eso la saca de la ficha: aparece arriba de todo y también al
agendarle un turno. La asistencia se mide solo sobre los turnos que ya
pasaron.

## Cuatro meses de historia en Almha

Un informe es una lectura del pasado, y Almha tenía el catálogo cargado y
ni un día de operación.

La semilla se arma sobre el catálogo que ya está y **se niega a correr si
el comercio no está marcado `demo`**. Arranca el 1 de un mes: una ventana
corrida deja el primer mes cortado y el informe mensual muestra una caída
que nunca pasó. Tiene lo que un negocio real tiene y una planilla no:
gente que deja de venir, gente que reserva y no aparece, gente que probó
una vez.

## Informes

Reportes era el del minimercado, y peor que vacío: sus indicadores salen
de `DATA.diario`, una constante calculada sobre el catálogo simulado del
minimercado e igual para los tres comercios. Una estética veía la plata
inventada de Super 25.

- **La plata primero, la capacidad después.**
- **Dos ocupaciones que no son la misma.** Una sala de mat para ocho con
  tres personas está usada el 100% del tiempo y al 37% de su capacidad.
- **Una clase ocupa una vez**, no una por alumno.

## CRM y marketing

Cinco motivos concretos para escribirle a alguien. **Los segmentos se
derivan, no se guardan**, y **`contactos` es lo que hace que la lista se
vacíe**: escribirle a alguien lo saca del segmento por tres semanas, y
solo de ese segmento.

## Comunicaciones

Los recordatorios de mañana. **Se avisa por turno, no por persona** —quien
tiene dos turnos recibe los dos—, **un recordatorio no es marketing** —"no
contactar" no lo frena— y **las plantillas guardan lo que se cambió, no
todo**.

De paso: el link de `wa.me` estaba roto desde antes en la agenda y en la
ficha. Arreglado en los tres lugares con una función.

## Permisos configurables y auditoría

Los roles salían de una constante de JavaScript. Ahora salen de la base,
y no por prolijidad: **las políticas de RLS los tienen que poder leer**.

**Ninguna política vuelve a nombrar un rol.** `bitacora_leer` y
`empresas_configurar` decían `rol in ('dueno', 'encargado')` y ahora
preguntan por `permiso('verBitacora')` y `permiso('configurar')`.

**Dos permisos los verifica la base y seis apagan botones**, dicho así en
la pantalla con un candado al lado de los dos pesados. **No se puede uno
dejar afuera**: un disparador impide sacarle `configurar` al rol propio.
Y **cambiar un permiso queda en la bitácora**, que existía desde 0007 y
nunca había tenido pantalla.

Se preserva una diferencia que ya existía: el encargado no ve Ajustes pero
la política de `empresas` lo deja actualizar la fila. Cerrarla en silencio
sería justo lo que este módulo viene a evitar; ahora se ve y se apaga con
un clic.

## Verificación

- `npm run build` limpio; la app carga sin errores de consola.
- `scripts/probar-rls.mjs`: **154 verificaciones**, todas en verde (45
  nuevas). `probar-venta.mjs` y `probar-comanda.mjs`, que son
  gastronomía, siguen pasando.
- **Sobre el cambio de RLS**: los valores de fábrica dan la misma
  respuesta para la misma gente que el `rol in (...)` que reemplazan. Hay
  dos verificaciones que existen solo para probar eso, más una que apaga
  el permiso y comprueba que la política se entera.
- Las funciones nuevas reciben el `empresa_id` como parámetro obligatorio
  (regla 6); las vistas llevan `security_invoker = true`.
- Una prueba vieja de clases grupales se caía por un choque real de sala,
  porque abría una clase el lunes de esta semana y Almha dejó de tenerlo
  libre. Ahora corre en una semana sin nada.

**Falta mirar las pantallas contra la maqueta**, que es lo que pide
`DISENO.md` y no se puede hacer sin pasar del login.

Preview: https://genez-git-backend-supabase-nehuen1.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)