### PR TITLE
A una estética no le va el botón de cobrar del minimercado

### DIFF
--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -1365,10 +1365,35 @@ function Sistema({ sesion, rubro, roles, onSalir, setComercios, tema, setTema })
      si va como el botón grande de arriba —cobrar en un minimercado, tomar
      la comanda en un bar— o como un renglón más del menú, que es lo que
      corresponde donde vender existe pero es la excepción. */
-  const accion = (rubro && rubro.accion) || (vender
-    ? { k: "cobro", n: vender === "comandas" ? "Comanda" : "Cobrar",
-        i: vender === "comandas" ? "planilla" : "barcode", destacada: true }
-    : null);
+  /* Ojo con el `||`: `accion` en null es una respuesta, no una falta de
+     respuesta. El rubro servicios la tiene en null a propósito —un
+     negocio de turnos no abre con un lector de códigos— y con `||` eso
+     se leía igual que "el rubro no dijo nada", caía en el respaldo y a
+     una estética le aparecía el botón de cobrar del minimercado. Encima
+     no se podía desactivar: `cobro` es módulo base.
+
+     El respaldo es para cuando NO hay rubro. Si el rubro cargó, manda él,
+     incluso cuando lo que dice es que acá no hay acción destacada. */
+  const accion = rubro
+    ? rubro.accion
+    : (vender
+      ? { k: "cobro", n: vender === "comandas" ? "Comanda" : "Cobrar",
+          i: vender === "comandas" ? "planilla" : "barcode", destacada: true }
+      : null);
+  /* El renglón de abajo del nombre. Sin rubro cargado se usa el de
+     siempre, que es el del minimercado: es el respaldo, no la regla.
+
+     Se lee derecho de `voces` y no con `voz()`: esa función devuelve la
+     clave cuando no encuentra la palabra —para que una pantalla nueva
+     muestre algo en vez de nada— y acá eso pondría la palabra "resumen"
+     debajo del nombre del comercio. Cuando no está, no va nada. */
+  const plantillaResumen = rubro
+    ? ((rubro.voces && rubro.voces.resumen) || "")
+    : "1 caja · {n} art.";
+  const resumenComercio = plantillaResumen
+    ? plantillaResumen.replace("{n}", nf.format(productos.length))
+    : "";
+
   const rotuloVender = accion ? accion.n : "Cobrar";
   const IconoAccion = iconoDe(accion ? accion.i : "barcode");
 
@@ -1600,7 +1625,11 @@ function Sistema({ sesion, rubro, roles, onSalir, setComercios, tema, setTema })
             <div className="w-8 h-8 rounded-xl bg-acento flex items-center justify-center text-sobre-acento"><Store size={17} /></div>
             <div className="min-w-0">
               <div className="f-d text-sm truncate">{ajustes.negocio}</div>
-              <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">1 caja · {nf.format(productos.length)} art.</div>
+              {/* Lo dice el rubro. Un rubro que no lo define no muestra
+                  nada: un número equivocado es peor que ninguno. */}
+              {resumenComercio && (
+                <div className="text-[10px] uppercase tracking-widest text-texto-tenue font-semibold">{resumenComercio}</div>
+              )}
             </div>
           </div>
           {accion && accion.destacada && (

--- a/supabase/migrations/0046_el_rotulo_es_del_rubro.sql
+++ b/supabase/migrations/0046_el_rotulo_es_del_rubro.sql
@@ -1,0 +1,26 @@
+/* ============================================================
+   0046 · EL RÓTULO DEBAJO DEL NOMBRE TAMBIÉN ES DEL RUBRO
+   ============================================================
+
+   Debajo del nombre del comercio, en la barra lateral, decía siempre
+   "1 caja · N art.". En un minimercado es lo que se quiere ver de un
+   vistazo. En una estética son dos datos que no existen: no hay una caja
+   registradora y no hay artículos, hay horas.
+
+   A Almha le mostraba "1 CAJA · 0 ART.", que es lo peor de las dos: un
+   rótulo ajeno y encima en cero.
+
+   Va a `voces`, que ya es jsonb y ya guarda cómo llama cada rubro a las
+   cosas. `{n}` lo reemplaza la pantalla con el catálogo contado.
+
+   El rubro servicios no lo define, y eso es una decisión y no un olvido:
+   un número equivocado es peor que ningún número. Cuando exista algo que
+   valga la pena contar ahí —turnos de hoy, gente esperando— se agrega la
+   fila y la pantalla no se toca.
+   ============================================================ */
+
+update rubros
+   set voces = coalesce(voces, '{}'::jsonb) || '{"resumen": "1 caja · {n} art."}'::jsonb
+ where clave in ('minimercado', 'gastronomia');
+
+select clave, voces ->> 'resumen' as rotulo from rubros order by clave;


### PR DESCRIPTION
Dos rótulos de minimercado que se le colaban a Almha, los dos de la misma
familia: código que decide algo que ya es dato del rubro.

**El botón "Cobrar F10".** El rubro servicios tiene `accion` en `null` a
propósito desde `cef0127` —un negocio de turnos no abre con un lector de
códigos— pero el código hacía:

```js
const accion = (rubro && rubro.accion) || (vender ? {...Cobrar...} : null)
```

El `||` no distingue "el rubro no dijo nada" de "el rubro dijo que no hay
acción". Caía en el respaldo, y encima no había forma de sacarlo: `cobro`
es módulo base y no se puede desactivar. El respaldo es para cuando **no
hay rubro**; si el rubro cargó, manda él, incluso cuando lo que dice es
que acá no hay botón.

**El "1 CAJA · 0 ART."** debajo del nombre estaba escrito fijo. Pasa a
`voces`, que ya es jsonb y ya guarda cómo llama cada rubro a las cosas.
Servicios no lo define, y eso es una decisión y no un olvido: un número
equivocado es peor que ninguno.

Se lee derecho de `voces` y no con `voz()`, porque esa función devuelve la
clave cuando no encuentra la palabra y acá habría puesto la palabra
"resumen" debajo del nombre del comercio.

## Verificación

- `npm run build` limpio; la app carga sin errores de consola.
- `probar-rls.mjs`: 154 verificaciones en verde.
- Super 25 y el Bar Rivadavia quedan igual: la migración 0046 les escribe
  en `voces` el mismo rótulo que tenían, y sus `accion` ya estaban
  definidas en la base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)