### PR TITLE
Reportes: menos gráficos, más decisión

### DIFF
--- a/scripts/probar-rls.mjs
+++ b/scripts/probar-rls.mjs
@@ -1398,6 +1398,95 @@ console.log("\nPermisos configurables");
   });
 }
 
+/* ------------------------------------------------------------
+   El informe del equipo
+
+   Lo que se prueba es el reparto del abono, que es la única cuenta del
+   informe que no se puede verificar mirando: si un pack de ocho clases
+   se dividiera mal, el número seguiría pareciendo razonable.
+   ------------------------------------------------------------ */
+console.log("\nInforme del equipo");
+
+if (ALMHA) {
+  await comoUsuario(PLATAFORMA, async () => {
+    const dia = (n) => new Date(Date.now() + n * 86400000).toISOString();
+
+    const per = await una(
+      `insert into personal (empresa_id, nombre, tipo, especialidad, modalidad, valor)
+       values ($1, 'Profe del informe', 'profesional', 'Pilates', 'hora', 1000) returning id`,
+      [ALMHA.id]);
+    const otro = await una(
+      `insert into personal (empresa_id, nombre, tipo, modalidad, valor)
+       values ($1, 'Otro profe', 'profesional', 'hora', 1000) returning id`, [ALMHA.id]);
+    const cli = await una(
+      `insert into clientes (empresa_id, razon_social) values ($1, 'Del informe') returning id`, [ALMHA.id]);
+
+    /* Un pack de $8.000 por dos clases. Se usan las dos: $4.000 cada una. */
+    const op = await una(
+      `insert into operaciones (id, empresa_id, tipo, estado, total, subtotal, fecha)
+       values (gen_random_uuid(), $1, 'venta', 'confirmada', 8000, 8000, now()) returning id`,
+      [ALMHA.id]);
+    const ab = await una(
+      `insert into abonos (empresa_id, cliente_id, operacion_id, nombre, clases, desde)
+       values ($1, $2, $3, 'Pack de prueba', 2, current_date - 1) returning id`,
+      [ALMHA.id, cli.id, op.id]);
+
+    const clase = (await una(
+      `insert into reservas (empresa_id, personal_id, nombre, personas, desde, duracion_min, estado, cupo)
+       values ($1, $2, 'Clase del informe', 0, $3, 60, 'cumplida', 6) returning id`,
+      [ALMHA.id, per.id, dia(-1)])).id;
+
+    for (let i = 0; i < 2; i++) {
+      await c.query(
+        `insert into reservas (empresa_id, personal_id, clase_id, cliente_id, abono_id, nombre, personas, desde, duracion_min, estado)
+         values ($1, $2, $3, $4, $5, 'Del informe', 1, $6, 60, 'cumplida')`,
+        [ALMHA.id, per.id, clase, cli.id, ab.id, dia(-1)]);
+    }
+
+    const leer = async (filtros) => await una(
+      `select turnos, cumplidos, clases, directo::float d, por_abono::float a
+         from informe_equipo($1, current_date - 2, current_date, $2::jsonb)
+        where personal_id = $3`,
+      [ALMHA.id, JSON.stringify(filtros || {}), per.id]);
+
+    const r = await leer();
+    decir(Number(r.a) === 8000, `el abono se reparte entre las clases que se usaron (${r.a})`);
+    decir(Number(r.d) === 0, "sin cobro directo, no inventa ingreso");
+    decir(Number(r.turnos) === 2 && Number(r.clases) === 1,
+      "cuenta dos personas atendidas en una sola clase dictada");
+
+    /* Un turno suelto cobrado sí suma derecho. */
+    const op2 = await una(
+      `insert into operaciones (id, empresa_id, tipo, estado, total, subtotal, fecha)
+       values (gen_random_uuid(), $1, 'venta', 'confirmada', 5000, 5000, now()) returning id`,
+      [ALMHA.id]);
+    await c.query(
+      `insert into reservas (empresa_id, personal_id, cliente_id, operacion_id, nombre, personas, desde, duracion_min, estado)
+       values ($1, $2, $3, $4, 'Del informe', 1, $5, 60, 'cumplida')`,
+      [ALMHA.id, per.id, cli.id, op2.id, dia(-1)]);
+
+    const r2 = await leer();
+    decir(Number(r2.d) === 5000, "el turno cobrado suma su venta al profesional que lo dio");
+
+    /* Y filtrando por otra persona, este no aparece. */
+    const filtrado = await una(
+      `select count(*)::int n from informe_equipo($1, current_date - 2, current_date, $2::jsonb)`,
+      [ALMHA.id, JSON.stringify({ personal: otro.id })]);
+    decir(filtrado.n === 1, "el filtro por profesional deja solo a esa persona");
+
+    const ocu = await una(
+      `select count(*)::int n from informe_ocupacion($1, current_date - 2, current_date, $2::jsonb)
+        where ambito = 'profesional'`,
+      [ALMHA.id, JSON.stringify({ personal: per.id })]);
+    decir(ocu.n === 1, "la ocupación acepta el mismo filtro");
+  });
+
+  await comoUsuario(MOZO, async () => {
+    const v = await una("select count(*)::int n from informe_equipo($1, current_date - 30, current_date)", [ALMHA.id]);
+    decir(v.n === 0, "un comercio no ve el equipo de otro");
+  });
+}
+
 console.log(fallas ? `\n${fallas} prueba(s) fallaron.` : "\nTodo bien.");
 await c.end();
 process.exitCode = fallas ? 1 : 0;

--- a/src/datos/informes.js
+++ b/src/datos/informes.js
@@ -1,52 +1,135 @@
 /* ============================================================
-   INFORMES · lo que pasó, para un negocio que vende horas
+   INFORMES · qué pasó, y dónde habría que actuar
    ============================================================
 
    El informe del minimercado responde "qué se vende y qué margen deja".
-   Acá las preguntas son otras cuatro, y en este orden:
+   Acá las preguntas son otras, y un informe no existe para mostrar datos
+   sino para ayudar a decidir. Cada bloque contesta una:
 
-     1. Cuánto entró, y de dónde.
-     2. Cuánto de lo que se podía vender se vendió.
-     3. Cuánta de la gente que sacó turno vino.
-     4. Quién es esa gente: cuántos nuevos, cuántos vuelven, cuántos se
-        fueron sin avisar.
+     Indicadores    ¿cómo está el negocio?
+     Insights       ¿qué está pasando?
+     Evolución      ¿cómo cambió?
+     Fuentes        ¿de dónde viene la plata?
+     Prestaciones   ¿qué estoy vendiendo?
+     Ocupación      ¿estoy aprovechando la capacidad?
+     Asistencia     ¿la gente viene?
+     Equipo         ¿cómo trabaja cada uno?
+     Clientes       ¿estoy creciendo?
+     Atención       ¿dónde tengo que actuar?
 
-   Las tres primeras se leen de tablas que ya existen. La ocupación no:
-   cruza cinco tablas y recorre el período día por día, así que la
-   resuelve `informe_ocupacion` en la base. Ver la migración 0042.
+   UN SOLO CONTEXTO
+   ----------------
+   El rango de fechas, la comparación y los filtros son de la pantalla
+   entera. Ninguna tarjeta consulta por su cuenta: se arma todo de una y
+   la vista dibuja. Dos tarjetas que muestren períodos distintos del mismo
+   negocio es la forma más rápida de que nadie vuelva a confiar en el
+   informe.
 
-   Todas las consultas filtran por `empresa_id` explícito (regla 6), y
-   las funciones revientan si no lo reciben: un id olvidado tiene que
-   fallar acá y no convertirse en los números de otro negocio.
+   Son siete lecturas en paralelo y no una por tarjeta.
 
-   LA FECHA ES LA DE VERDAD
-   ------------------------
-   Nada de `HOY` congelado. Este módulo no toca el generador: si un dato
-   no está en la base, no está.
+   LO QUE NO SE PUEDE FILTRAR, SE DICE
+   -----------------------------------
+   Los egresos viven en `movimientos_caja` y no tienen área ni
+   profesional: un alquiler no es de pilates ni de estética. Por eso el
+   resultado neto y la curva de egresos son siempre del negocio entero, y
+   cuando hay un filtro puesto la pantalla lo aclara en vez de mostrar un
+   número que parece filtrado y no lo está.
+
+   Todas las consultas filtran por `empresa_id` explícito (regla 6).
    ============================================================ */
 
 import { supabase } from "./supabase.js";
+import { cargarSegmentos } from "./crm.js";
 
 const n = (v) => (v === null || v === undefined ? 0 : Number(v));
 const suma = (xs, f) => xs.reduce((s, x) => s + n(f(x)), 0);
 const dia = 86400000;
 
 /* Sin base contra la que comparar no hay variación. Un "+100%" contra
-   cero no informa nada y encima alarma. Mismo criterio que el tablero. */
+   cero no informa nada y encima alarma. */
 const variacion = (ahora, antes) => (antes > 0 ? ahora / antes - 1 : null);
 
+const iso = (d) => d.toISOString().slice(0, 10);
+
+const alArrancar = (d) => { const x = new Date(d); x.setHours(0, 0, 0, 0); return x; };
+const alTerminar = (d) => { const x = new Date(d); x.setHours(23, 59, 59, 999); return x; };
+
+/* ------------------------------------------------------------
+   El período
+   ------------------------------------------------------------ */
+
 export const PERIODOS = [
-  { k: 7, n: "7 días" },
-  { k: 30, n: "30 días" },
-  { k: 90, n: "90 días" },
+  { k: "hoy", n: "Hoy" },
+  { k: "ayer", n: "Ayer" },
+  { k: "7d", n: "Últimos 7 días" },
+  { k: "30d", n: "Últimos 30 días" },
+  { k: "mes", n: "Este mes" },
+  { k: "mesAnterior", n: "Mes anterior" },
+  { k: "anio", n: "Este año" },
+  { k: "libre", n: "Personalizado" },
 ];
 
-/* Los cinco estados de un turno, en el orden en que se leen. `cumplida`
-   y `ausente` son las dos caras de lo mismo y por eso van juntas. */
+export function rangoDe(clave, hoy = new Date()) {
+  const h = alArrancar(hoy);
+  const y = h.getFullYear();
+  const m = h.getMonth();
+
+  switch (clave) {
+    case "hoy": return { desde: h, hasta: alTerminar(h) };
+    case "ayer": {
+      const a = new Date(h.getTime() - dia);
+      return { desde: a, hasta: alTerminar(a) };
+    }
+    case "7d": return { desde: new Date(h.getTime() - 6 * dia), hasta: alTerminar(h) };
+    case "30d": return { desde: new Date(h.getTime() - 29 * dia), hasta: alTerminar(h) };
+    case "mes": return { desde: new Date(y, m, 1), hasta: alTerminar(h) };
+    case "mesAnterior": return { desde: new Date(y, m - 1, 1), hasta: alTerminar(new Date(y, m, 0)) };
+    case "anio": return { desde: new Date(y, 0, 1), hasta: alTerminar(h) };
+    default: return { desde: new Date(h.getTime() - 29 * dia), hasta: alTerminar(h) };
+  }
+}
+
+export const COMPARACIONES = [
+  { k: "anterior", n: "Período anterior" },
+  { k: "anioAnterior", n: "Mismo período del año anterior" },
+  { k: "libre", n: "Personalizado" },
+  { k: "sin", n: "Sin comparación" },
+];
+
+/* El período anterior es tan largo como el elegido y termina justo antes.
+   Un mes de 31 días se compara contra 31 días y no contra "el mes pasado"
+   a secas: si no, febrero siempre parece peor que enero. */
+export function comparacionDe(modo, desde, hasta, libre) {
+  if (modo === "sin") return null;
+  if (modo === "libre") return libre && libre.desde && libre.hasta ? libre : null;
+
+  if (modo === "anioAnterior") {
+    const d = new Date(desde); d.setFullYear(d.getFullYear() - 1);
+    const h = new Date(hasta); h.setFullYear(h.getFullYear() - 1);
+    return { desde: d, hasta: h };
+  }
+
+  const largo = alArrancar(hasta).getTime() - alArrancar(desde).getTime() + dia;
+  return {
+    desde: new Date(alArrancar(desde).getTime() - largo),
+    hasta: alTerminar(new Date(alArrancar(desde).getTime() - dia)),
+  };
+}
+
+/* Cómo se agrupa la curva. Un año en barras diarias son 365 puntos que no
+   se leen; una semana en barras mensuales es un punto. Se elige solo y se
+   puede cambiar a mano. */
+export function granoSugerido(desde, hasta) {
+  const dias = Math.round((alArrancar(hasta) - alArrancar(desde)) / dia) + 1;
+  if (dias <= 31) return "dia";
+  if (dias <= 180) return "semana";
+  return "mes";
+}
+
 export const ESTADOS_TURNO = [
-  { k: "cumplida", n: "Vinieron", tono: "bien" },
+  { k: "cumplida", n: "Asistieron", tono: "bien" },
   { k: "ausente", n: "No vinieron", tono: "mal" },
-  { k: "cancelada", n: "Cancelaron", tono: "tenue" },
+  { k: "cancelada", n: "Cancelados", tono: "tenue" },
   { k: "confirmada", n: "Confirmados", tono: "info" },
   { k: "pendiente", n: "Sin confirmar", tono: "ojo" },
 ];
@@ -55,117 +138,263 @@ export const ESTADOS_TURNO = [
    Las lecturas
    ------------------------------------------------------------ */
 
-/* Se traen dos períodos de una y se parten en memoria: es una consulta en
-   vez de dos y la comparación sale gratis. */
-async function lineasVendidas(empresaId, desde, hasta) {
+/* Los egresos no tienen área ni profesional, así que este bloque nunca se
+   filtra. Es a propósito y la pantalla lo dice. */
+async function caja(empresaId, desde, hasta) {
   const { data, error } = await supabase
+    .from("movimientos_caja")
+    .select("tipo, monto, categoria, fecha, operacion_id")
+    .eq("empresa_id", empresaId)
+    .gte("fecha", desde.toISOString())
+    .lte("fecha", hasta.toISOString())
+    .limit(20000);
+  if (error) throw error;
+  return data || [];
+}
+
+async function lineas(empresaId, desde, hasta, filtros) {
+  let q = supabase
     .from("operacion_lineas")
-    .select("descripcion, cantidad, total, item_id, items(categoria, tipo), operaciones!inner(fecha, estado, tipo, cliente_id)")
+    .select("descripcion, cantidad, total, item_id, items(categoria, tipo), operaciones!inner(id, fecha, estado, tipo, cliente_id)")
     .eq("empresa_id", empresaId)
     .eq("operaciones.estado", "confirmada")
     .in("operaciones.tipo", ["venta", "comanda"])
     .gte("operaciones.fecha", desde.toISOString())
-    .lt("operaciones.fecha", hasta.toISOString())
-    .limit(6000);
+    .lte("operaciones.fecha", hasta.toISOString())
+    .limit(20000);
+
+  if (filtros.item) q = q.eq("item_id", filtros.item);
+  const { data, error } = await q;
   if (error) throw error;
-  return data || [];
+
+  /* El área se filtra acá y no en la consulta porque vive en el item
+     enlazado, y filtrar por una tabla anidada obligaría a un `inner` que
+     tiraría las líneas sin item —las de un concepto suelto— que también
+     son plata que entró. */
+  return (data || []).filter((l) =>
+    !filtros.area || (l.items && l.items.categoria === filtros.area));
 }
 
-/* La agenda del período y de los seis meses previos: los previos no se
-   dibujan, sirven para saber quién ya venía. Sin eso no se puede
-   distinguir un cliente nuevo de uno que volvió. */
-async function turnos(empresaId, desde, hasta) {
-  const { data, error } = await supabase
+async function agenda(empresaId, desde, hasta, filtros) {
+  let q = supabase
     .from("agenda_vista")
-    .select("id, desde, estado, forma, cliente_id, cliente, servicio, area, profesional, sala, precio, duracion_min")
+    .select("id, desde, estado, forma, cliente_id, cliente, servicio, area, profesional, personal_id, sala, recurso_id, item_id, duracion_min")
     .eq("empresa_id", empresaId)
     .gte("desde", desde.toISOString())
-    .lt("desde", hasta.toISOString())
+    .lte("desde", hasta.toISOString())
     .order("desde")
-    .limit(8000);
+    .limit(20000);
+
+  if (filtros.personal) q = q.eq("personal_id", filtros.personal);
+  if (filtros.item) q = q.eq("item_id", filtros.item);
+  if (filtros.recurso) q = q.eq("recurso_id", filtros.recurso);
+  if (filtros.area) q = q.eq("area", filtros.area);
+
+  const { data, error } = await q;
   if (error) throw error;
   return data || [];
 }
 
-async function ocupacion(empresaId, desde, hasta) {
-  const iso = (d) => d.toISOString().slice(0, 10);
+const limpio = (f) => Object.fromEntries(
+  Object.entries(f || {}).filter(([, v]) => v !== null && v !== undefined && v !== ""));
+
+async function ocupacion(empresaId, desde, hasta, filtros) {
   const { data, error } = await supabase.rpc("informe_ocupacion", {
-    p_empresa: empresaId,
-    p_desde: iso(desde),
-    p_hasta: iso(hasta),
+    p_empresa: empresaId, p_desde: iso(desde), p_hasta: iso(hasta), p_filtros: limpio(filtros),
   });
   if (error) throw error;
   return data || [];
 }
 
-async function altas(empresaId, desde) {
-  const { data, error } = await supabase
-    .from("clientes")
-    .select("id, razon_social, creado_en")
-    .eq("empresa_id", empresaId)
-    .eq("activo", true)
-    .gte("creado_en", desde.toISOString())
-    .limit(3000);
+async function equipo(empresaId, desde, hasta, filtros) {
+  const { data, error } = await supabase.rpc("informe_equipo", {
+    p_empresa: empresaId, p_desde: iso(desde), p_hasta: iso(hasta), p_filtros: limpio(filtros),
+  });
   if (error) throw error;
   return data || [];
 }
 
-/* ------------------------------------------------------------
-   El informe
+async function altas(empresaId, desde, hasta) {
+  const { data, error } = await supabase
+    .from("clientes")
+    .select("id, creado_en")
+    .eq("empresa_id", empresaId)
+    .eq("activo", true)
+    .gte("creado_en", desde.toISOString())
+    .lte("creado_en", hasta.toISOString())
+    .limit(5000);
+  if (error) throw error;
+  return data || [];
+}
 
-   Una sola función arma las cuatro secciones. La pantalla recibe un
-   objeto y dibuja: mismo trato que el tablero, y por la misma razón —que
-   dos lugares del sistema no puedan decir números distintos del mismo
-   período—.
-   ------------------------------------------------------------ */
-export async function cargarInforme(empresaId, dias = 30) {
-  if (!empresaId) throw new Error("cargarInforme necesita saber de qué comercio.");
-
-  const hasta = new Date();
-  hasta.setHours(23, 59, 59, 999);
-  const desde = new Date(hasta.getTime() - (dias - 1) * dia);
-  desde.setHours(0, 0, 0, 0);
-  const previo = new Date(desde.getTime() - dias * dia);
-  const historia = new Date(desde.getTime() - 180 * dia);
-
-  const [lineas, agenda, ocup, nuevos] = await Promise.all([
-    lineasVendidas(empresaId, previo, hasta),
-    turnos(empresaId, historia, hasta),
-    ocupacion(empresaId, desde, hasta),
-    altas(empresaId, previo),
+/* Lo que hay para elegir en los filtros. Sale del catálogo del comercio y
+   no de lo que aparezca en el período: un servicio que no se vendió este
+   mes tiene que poder elegirse, justamente para ver que no se vendió. */
+async function opciones(empresaId) {
+  const [items, personal, recursos] = await Promise.all([
+    supabase.from("items").select("id, nombre, categoria, tipo")
+      .eq("empresa_id", empresaId).eq("activo", true).in("tipo", ["servicio", "plan"]).order("nombre"),
+    supabase.from("personal").select("id, nombre")
+      .eq("empresa_id", empresaId).eq("activo", true).eq("tipo", "profesional").order("orden"),
+    supabase.from("recursos").select("id, nombre")
+      .eq("empresa_id", empresaId).eq("activo", true).order("orden"),
   ]);
+  if (items.error) throw items.error;
+  if (personal.error) throw personal.error;
+  if (recursos.error) throw recursos.error;
 
+  const areas = [...new Set((items.data || []).map((i) => i.categoria).filter(Boolean))].sort();
   return {
-    dias,
-    desde,
-    hasta,
-    ingresos: armarIngresos(lineas, desde, hasta, dias),
-    ocupacion: armarOcupacion(ocup),
-    asistencia: armarAsistencia(agenda, desde, hasta),
-    clientes: armarClientes(agenda, nuevos, desde, previo),
+    areas: areas.map((a) => ({ k: a, n: a })),
+    profesionales: (personal.data || []).map((p) => ({ k: p.id, n: p.nombre })),
+    servicios: (items.data || []).map((i) => ({ k: i.id, n: i.nombre })),
+    salas: (recursos.data || []).map((r) => ({ k: r.id, n: r.nombre })),
   };
 }
 
 /* ------------------------------------------------------------
-   1 · Cuánto entró y de dónde
+   El informe
    ------------------------------------------------------------ */
 
-function armarIngresos(lineas, desde, hasta, dias) {
-  const enPeriodo = lineas.filter((l) => new Date(l.operaciones.fecha) >= desde);
-  const enPrevio = lineas.filter((l) => new Date(l.operaciones.fecha) < desde);
+export async function cargarInforme(empresaId, { desde, hasta, comparar = null, filtros = {}, grano = null } = {}) {
+  if (!empresaId) throw new Error("cargarInforme necesita saber de qué comercio.");
+  if (!desde || !hasta) throw new Error("cargarInforme necesita un desde y un hasta.");
 
-  const total = suma(enPeriodo, (l) => l.total);
-  const totalPrevio = suma(enPrevio, (l) => l.total);
+  const d = alArrancar(desde);
+  const h = alTerminar(hasta);
+  const f = limpio(filtros);
+  const hayFiltro = Object.keys(f).length > 0;
 
-  /* Un abono no es un turno: es plata que entró hoy por horas que se van
-     a dar en las próximas ocho semanas. Mezclarlos hace que un mes con
-     muchas renovaciones parezca un mes de mucha actividad. */
-  const esPlan = (l) => (l.items && l.items.tipo === "plan");
-  const abonos = suma(enPeriodo.filter(esPlan), (l) => l.total);
+  /* El período de comparación se lee en la misma tanda. Cuando no hay
+     comparación se pide igual un rango vacío para no ramificar la
+     cantidad de consultas según la opción elegida. */
+  const c = comparar ? { desde: alArrancar(comparar.desde), hasta: alTerminar(comparar.hasta) } : null;
+  const desdeTodo = c ? new Date(Math.min(d.getTime(), c.desde.getTime())) : d;
+  const hastaTodo = c ? new Date(Math.max(h.getTime(), c.hasta.getTime())) : h;
+
+  const [mov, lin, age, ocu, eq, nuevos, opc, segmentos] = await Promise.all([
+    caja(empresaId, desdeTodo, hastaTodo),
+    lineas(empresaId, desdeTodo, hastaTodo, f),
+    agenda(empresaId, desdeTodo, hastaTodo, f),
+    ocupacion(empresaId, d, h, f),
+    equipo(empresaId, d, h, f),
+    altas(empresaId, desdeTodo, hastaTodo),
+    opciones(empresaId),
+    /* Las oportunidades no dependen del período: son el estado del
+       negocio hoy. Se piden acá igual para no hacer una consulta suelta
+       desde la pantalla. */
+    cargarSegmentos(empresaId).catch(() => []),
+  ]);
+
+  const enRango = (fecha, r) => {
+    const t = new Date(fecha).getTime();
+    return t >= r.desde.getTime() && t <= r.hasta.getTime();
+  };
+  const actual = { desde: d, hasta: h };
+
+  const movAhora = mov.filter((x) => enRango(x.fecha, actual));
+  const linAhora = lin.filter((x) => enRango(x.operaciones.fecha, actual));
+  const ageAhora = age.filter((x) => enRango(x.desde, actual));
+  const nuevosAhora = nuevos.filter((x) => enRango(x.creado_en, actual));
+
+  const movAntes = c ? mov.filter((x) => enRango(x.fecha, c)) : [];
+  const linAntes = c ? lin.filter((x) => enRango(x.operaciones.fecha, c)) : [];
+  const ageAntes = c ? age.filter((x) => enRango(x.desde, c)) : [];
+  const nuevosAntes = c ? nuevos.filter((x) => enRango(x.creado_en, c)) : [];
+
+  const ocuArmada = armarOcupacion(ocu);
+  const ingresos = armarIngresos(linAhora, linAntes, c);
+  const asistencia = armarAsistencia(ageAhora, ageAntes, c);
+  const finanzas = armarFinanzas(movAhora, movAntes, c);
+  const clientes = armarClientes(ageAhora, ageAntes, nuevosAhora, nuevosAntes, c);
+  const equipoArmado = armarEquipo(eq, ocuArmada);
+  const { porDia, horasPorServicio, horasTotales } = armarCarga(ageAhora);
+
+  const base = {
+    desde: d,
+    hasta: h,
+    comparar: c,
+    hayFiltro,
+    grano: grano || granoSugerido(d, h),
+    opciones: opc,
+    generado: new Date(),
+
+    kpis: {
+      ingresos: { valor: ingresos.total, delta: ingresos.delta },
+      resultado: { valor: finanzas.resultado, delta: finanzas.deltaResultado },
+      turnos: { valor: asistencia.total, delta: asistencia.deltaTurnos },
+      ocupacion: { valor: ocuArmada.promedio, delta: null },
+      clientes: { valor: clientes.activos, delta: clientes.deltaActivos },
+      ticket: { valor: ingresos.ticket, delta: ingresos.deltaTicket },
+    },
+
+    evolucion: armarEvolucion(movAhora, d, h, grano || granoSugerido(d, h)),
+    ingresos,
+    finanzas,
+    ocupacion: ocuArmada,
+    asistencia,
+    equipo: equipoArmado,
+    clientes,
+    porDia,
+    horasPorServicio,
+    horasTotales,
+  };
+
+  /* Los insights se calculan al final porque leen el informe ya armado:
+     no hay un motor aparte ni una consulta más. Si un número no está, el
+     insight no aparece. */
+  return {
+    ...base,
+    insights: armarInsights(base),
+    oportunidades: armarOportunidades(segmentos),
+  };
+}
+
+/* Cuánto se trabajó, repartido por día de la semana y por prestación.
+   Las inscripciones no suman horas: la clase ocupa su hora una vez, la
+   den dos personas o seis. Mismo criterio que la ocupación y que las
+   liquidaciones. */
+function armarCarga(agenda) {
+  const DIAS = ["domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado"];
+  const dictado = agenda.filter((t) => t.forma !== "inscripcion" && t.estado !== "cancelada");
+
+  const porDia = DIAS.map((nombre, i) => ({
+    i, nombre,
+    turnos: agenda.filter((t) => t.forma !== "clase" && t.estado !== "cancelada" && new Date(t.desde).getDay() === i).length,
+  })).filter((x) => x.turnos > 0);
+
+  const horasPorServicio = new Map();
+  for (const t of dictado) {
+    const k = t.servicio || "Sin prestación";
+    horasPorServicio.set(k, (horasPorServicio.get(k) || 0) + n(t.duracion_min) / 60);
+  }
+
+  return {
+    porDia,
+    horasPorServicio,
+    horasTotales: suma(dictado, (t) => t.duracion_min) / 60,
+  };
+}
+
+/* ------------------------------------------------------------
+   1 · De dónde viene la plata
+   ------------------------------------------------------------ */
+
+function armarIngresos(ahora, antes, hayComparacion) {
+  const total = suma(ahora, (l) => l.total);
+  const totalAntes = suma(antes, (l) => l.total);
+
+  const esPlan = (l) => l.items && l.items.tipo === "plan";
+  const esProducto = (l) => l.items && l.items.tipo === "producto";
+
+  const abonos = suma(ahora.filter(esPlan), (l) => l.total);
+  const productos = suma(ahora.filter(esProducto), (l) => l.total);
+  const turnos = suma(ahora.filter((l) => l.items && l.items.tipo === "servicio"), (l) => l.total);
+  const otros = total - abonos - productos - turnos;
 
   const porArea = new Map();
   const porServicio = new Map();
-  for (const l of enPeriodo) {
+  for (const l of ahora) {
     const area = (l.items && l.items.categoria) || "Sin área";
     porArea.set(area, (porArea.get(area) || 0) + n(l.total));
     const s = porServicio.get(l.descripcion) || { nombre: l.descripcion, cantidad: 0, total: 0, plan: esPlan(l) };
@@ -174,41 +403,103 @@ function armarIngresos(lineas, desde, hasta, dias) {
     porServicio.set(l.descripcion, s);
   }
 
-  /* Una operación puede traer varias líneas; el ticket se cuenta por
-     operación y no por línea, o un pack vendido junto con una crema
-     bajaría el promedio sin que nadie haya gastado menos. */
-  const ops = new Set(enPeriodo.map((l) => l.operaciones.fecha + "|" + (l.operaciones.cliente_id || "")));
+  /* El ticket se cuenta por operación y no por línea: un pack vendido
+     junto con una crema bajaría el promedio sin que nadie haya gastado
+     menos. */
+  const ops = new Set(ahora.map((l) => l.operaciones.id));
+  const opsAntes = new Set(antes.map((l) => l.operaciones.id));
+  const ticket = ops.size ? Math.round(total / ops.size) : 0;
+  const ticketAntes = opsAntes.size ? totalAntes / opsAntes.size : 0;
 
-  const fin = new Date(hasta);
-  fin.setHours(0, 0, 0, 0);
-  const serie = new Array(dias).fill(0);
-  for (const l of enPeriodo) {
-    const f = new Date(l.operaciones.fecha);
-    f.setHours(0, 0, 0, 0);
-    const d = Math.round((fin.getTime() - f.getTime()) / dia);
-    if (d >= 0 && d < dias) serie[dias - 1 - d] += n(l.total);
-  }
+  /* Solo se muestran las fuentes que existen: un anillo con tres porciones
+     en cero es ruido con forma de gráfico. */
+  const fuentes = [
+    { k: "turnos", n: "Turnos", v: turnos, tono: "acento" },
+    { k: "abonos", n: "Abonos y packs", v: abonos, tono: "info" },
+    { k: "productos", n: "Productos", v: productos, tono: "bien" },
+    { k: "otros", n: "Otros", v: Math.max(0, otros), tono: "tenue" },
+  ].filter((x) => x.v > 0);
 
   return {
     total,
-    delta: variacion(total, totalPrevio),
-    ticket: ops.size ? Math.round(total / ops.size) : 0,
+    delta: hayComparacion ? variacion(total, totalAntes) : null,
+    ticket,
+    deltaTicket: hayComparacion ? variacion(ticket, ticketAntes) : null,
     operaciones: ops.size,
-    promedioDiario: Math.round(total / dias),
-    abonos,
-    sueltos: total - abonos,
-    serie,
+    fuentes,
     porArea: [...porArea.entries()].map(([nombre, t]) => ({ nombre, total: t })).sort((a, b) => b.total - a.total),
-    porServicio: [...porServicio.values()].sort((a, b) => b.total - a.total).slice(0, 10),
+    porServicio: [...porServicio.values()].sort((a, b) => b.total - a.total),
   };
 }
 
 /* ------------------------------------------------------------
-   2 · Cuánto de lo que se podía vender se vendió
+   2 · Ingresos, egresos y resultado
+   ------------------------------------------------------------ */
 
-   Dos ocupaciones distintas y las dos ciertas: una sala de mat para ocho
-   con tres personas adentro está usada el 100% del tiempo y al 37% de su
-   capacidad. Ver el comentario de la migración 0042.
+function armarFinanzas(ahora, antes, hayComparacion) {
+  const entra = (xs) => suma(xs.filter((m) => m.tipo === "ingreso"), (m) => m.monto);
+  const sale = (xs) => suma(xs.filter((m) => m.tipo === "egreso"), (m) => m.monto);
+
+  const ingresos = entra(ahora);
+  const egresos = sale(ahora);
+  const resultado = ingresos - egresos;
+  const resultadoAntes = entra(antes) - sale(antes);
+
+  const porCategoria = new Map();
+  for (const m of ahora.filter((x) => x.tipo === "egreso")) {
+    const k = m.categoria || "otros";
+    porCategoria.set(k, (porCategoria.get(k) || 0) + n(m.monto));
+  }
+
+  return {
+    ingresos,
+    egresos,
+    resultado,
+    deltaResultado: hayComparacion ? variacion(resultado, resultadoAntes) : null,
+    margen: ingresos > 0 ? resultado / ingresos : null,
+    egresosPorCategoria: [...porCategoria.entries()]
+      .map(([nombre, total]) => ({ nombre, total })).sort((a, b) => b.total - a.total),
+  };
+}
+
+function armarEvolucion(movs, desde, hasta, grano) {
+  const clave = (f) => {
+    const d = new Date(f);
+    if (grano === "mes") return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    if (grano === "semana") {
+      const l = alArrancar(d);
+      l.setDate(l.getDate() - ((l.getDay() + 6) % 7));   // al lunes
+      return iso(l);
+    }
+    return iso(alArrancar(d));
+  };
+
+  const rotulo = (k) => {
+    if (grano === "mes") {
+      const [a, m] = k.split("-");
+      return new Date(Number(a), Number(m) - 1, 1)
+        .toLocaleDateString("es-AR", { month: "short", year: "2-digit" });
+    }
+    const d = new Date(`${k}T12:00:00`);
+    return d.toLocaleDateString("es-AR", { day: "2-digit", month: "2-digit" });
+  };
+
+  const cubos = new Map();
+  for (const m of movs) {
+    const k = clave(m.fecha);
+    const c = cubos.get(k) || { k, ingresos: 0, egresos: 0 };
+    if (m.tipo === "ingreso") c.ingresos += n(m.monto);
+    else c.egresos += n(m.monto);
+    cubos.set(k, c);
+  }
+
+  return [...cubos.values()]
+    .sort((a, b) => (a.k < b.k ? -1 : 1))
+    .map((c) => ({ label: rotulo(c.k), ...c, resultado: c.ingresos - c.egresos }));
+}
+
+/* ------------------------------------------------------------
+   3 · La capacidad
    ------------------------------------------------------------ */
 
 function armarOcupacion(filas) {
@@ -227,7 +518,13 @@ function armarOcupacion(filas) {
   const profesionales = filas.filter((f) => f.ambito === "profesional").map(armar)
     .sort((a, b) => (b.pct || 0) - (a.pct || 0));
   const salas = filas.filter((f) => f.ambito === "sala").map(armar)
-    .sort((a, b) => b.horasOcupadas - a.horasOcupadas);
+    .sort((a, b) => (b.pct || 0) - (a.pct || 0));
+
+  /* El promedio se pondera por horas ofrecidas: alguien que trabaja
+     cuatro horas por semana no puede mover el número del equipo igual que
+     alguien de tiempo completo. */
+  const ofrecidas = suma(profesionales, (p) => p.horasOfrecidas);
+  const promedio = ofrecidas > 0 ? suma(profesionales, (p) => p.horasOcupadas) / ofrecidas : 0;
 
   const lugares = suma(profesionales, (p) => p.lugares);
   const tomados = suma(profesionales, (p) => p.tomados);
@@ -235,30 +532,24 @@ function armarOcupacion(filas) {
   return {
     profesionales,
     salas,
+    promedio,
     clases: { lugares, tomados, pct: lugares > 0 ? tomados / lugares : null },
   };
 }
 
 /* ------------------------------------------------------------
-   3 · Cuánta de la gente que sacó turno vino
-
-   Solo sobre turnos que ya pasaron. Contar los futuros como "no vino"
-   hunde el porcentaje sin motivo: es el mismo criterio que usa la ficha
-   del cliente, y tiene que seguir siendo el mismo.
+   4 · ¿Vienen?
    ------------------------------------------------------------ */
 
-function armarAsistencia(agenda, desde, hasta) {
-  const ahora = Date.now();
+function armarAsistencia(ahora, antes, hayComparacion) {
   /* Las clases no se cuentan: la clase no falta ni viene, faltan o vienen
-     los inscriptos. Contarlas mezcla una unidad con la otra. */
-  const delPeriodo = agenda.filter((t) => {
-    const f = new Date(t.desde);
-    return f >= desde && f <= hasta && t.forma !== "clase";
-  });
+     los inscriptos. Contarlas mezcla dos unidades. */
+  const turnos = ahora.filter((t) => t.forma !== "clase");
+  const turnosAntes = antes.filter((t) => t.forma !== "clase");
+  const ya = Date.now();
+  const pasados = turnos.filter((t) => new Date(t.desde).getTime() < ya);
 
-  const pasados = delPeriodo.filter((t) => new Date(t.desde).getTime() < ahora);
   const cuenta = (k) => pasados.filter((t) => t.estado === k).length;
-
   const cumplidas = cuenta("cumplida");
   const ausentes = cuenta("ausente");
   const canceladas = cuenta("cancelada");
@@ -266,7 +557,7 @@ function armarAsistencia(agenda, desde, hasta) {
 
   const porServicio = new Map();
   for (const t of pasados) {
-    const k = t.servicio || "Sin servicio";
+    const k = t.servicio || "Sin prestación";
     const s = porServicio.get(k) || { nombre: k, area: t.area || "", total: 0, vino: 0, falto: 0 };
     s.total += 1;
     if (t.estado === "cumplida") s.vino += 1;
@@ -275,75 +566,201 @@ function armarAsistencia(agenda, desde, hasta) {
   }
 
   return {
-    total: delPeriodo.length,
+    total: turnos.length,
+    deltaTurnos: hayComparacion ? variacion(turnos.length, turnosAntes.length) : null,
     pasados: pasados.length,
     cumplidas,
     ausentes,
     canceladas,
-    /* Sobre vinieron + faltaron, no sobre el total: una cancelación
-       avisada a tiempo no es una inasistencia, es un turno que se pudo
-       volver a vender. */
+    /* Sobre vinieron + faltaron: una cancelación avisada a tiempo no es
+       una inasistencia, es un turno que se pudo volver a vender. */
     pct: base > 0 ? cumplidas / base : null,
-    pctCancelacion: pasados.length > 0 ? canceladas / pasados.length : null,
-    porEstado: ESTADOS_TURNO.map((e) => ({
-      ...e,
-      v: delPeriodo.filter((t) => t.estado === e.k).length,
-    })).filter((e) => e.v > 0),
+    porEstado: ESTADOS_TURNO
+      .map((e) => ({ ...e, v: turnos.filter((t) => t.estado === e.k).length }))
+      .filter((e) => e.v > 0),
     porServicio: [...porServicio.values()]
       .filter((s) => s.vino + s.falto >= 3)
       .map((s) => ({ ...s, pct: s.vino / (s.vino + s.falto) }))
-      .sort((a, b) => a.pct - b.pct)
-      .slice(0, 8),
+      .sort((a, b) => a.pct - b.pct),
   };
 }
 
 /* ------------------------------------------------------------
-   4 · Quién es la gente
-
-   La antesala del CRM. Todavía no manda un mensaje: dice a quién habría
-   que mandárselo.
+   5 · El equipo
    ------------------------------------------------------------ */
 
-function armarClientes(agenda, nuevos, desde, previo) {
-  const delPeriodo = nuevos.filter((c) => new Date(c.creado_en) >= desde);
-  const delPrevio = nuevos.filter((c) => new Date(c.creado_en) < desde && new Date(c.creado_en) >= previo);
+function armarEquipo(filas, ocu) {
+  const porId = new Map(ocu.profesionales.map((p) => [p.id, p]));
 
-  const vinieron = agenda.filter((t) => t.estado === "cumplida" && t.cliente_id);
+  return (filas || []).map((f) => {
+    const o = porId.get(f.personal_id);
+    const base = n(f.cumplidos) + n(f.ausentes);
+    return {
+      id: f.personal_id,
+      nombre: f.nombre,
+      especialidad: f.especialidad || "",
+      turnos: n(f.turnos),
+      clases: n(f.clases),
+      alumnos: n(f.alumnos),
+      asistencia: base > 0 ? n(f.cumplidos) / base : null,
+      /* Lo cobrado derecho al turno más la parte del abono que consumió
+         cada clase. La regla está explicada en la pantalla. */
+      ingresos: n(f.directo) + n(f.por_abono),
+      directo: n(f.directo),
+      porAbono: n(f.por_abono),
+      ocupacion: o ? o.pct : null,
+      horasOcupadas: o ? o.horasOcupadas : 0,
+    };
+  }).sort((a, b) => b.ingresos - a.ingresos);
+}
 
-  /* La última vez de cada uno, sobre los seis meses que se trajeron. */
-  const ultima = new Map();
-  const veces = new Map();
-  for (const t of vinieron) {
-    const f = new Date(t.desde);
-    if (f > new Date()) continue;
-    if (!ultima.has(t.cliente_id) || f > ultima.get(t.cliente_id).fecha) {
-      ultima.set(t.cliente_id, { fecha: f, nombre: t.cliente || null });
+/* ------------------------------------------------------------
+   6 · La gente
+   ------------------------------------------------------------ */
+
+function armarClientes(agenda, agendaAntes, nuevos, nuevosAntes, hayComparacion) {
+  /* Activo es quien efectivamente vino, no quien tiene un turno tomado:
+     la agenda llena de gente que no aparece no es un negocio que crece. */
+  const distintos = (xs) => {
+    const veces = new Map();
+    for (const t of xs.filter((r) => r.estado === "cumplida" && r.cliente_id)) {
+      veces.set(t.cliente_id, (veces.get(t.cliente_id) || 0) + 1);
     }
-    veces.set(t.cliente_id, (veces.get(t.cliente_id) || 0) + 1);
-  }
+    return veces;
+  };
 
-  const enPeriodo = new Map();
-  for (const t of vinieron) {
-    const f = new Date(t.desde);
-    if (f < desde) continue;
-    enPeriodo.set(t.cliente_id, (enPeriodo.get(t.cliente_id) || 0) + 1);
-  }
-
-  /* Dormido: vino alguna vez y hace más de 45 días que no aparece. No es
-     "cliente perdido" —eso lo decide el negocio, no el sistema— es a
-     quién conviene llamar. */
-  const corte = Date.now() - 45 * dia;
-  const dormidos = [...ultima.entries()]
-    .filter(([, u]) => u.fecha.getTime() < corte)
-    .map(([id, u]) => ({ id, nombre: u.nombre, ultima: u.fecha, veces: veces.get(id) || 0, dias: Math.round((Date.now() - u.fecha.getTime()) / dia) }))
-    .sort((a, b) => b.veces - a.veces);
+  const veces = distintos(agenda);
+  const vecesAntes = distintos(agendaAntes);
 
   return {
-    nuevos: delPeriodo.length,
-    deltaNuevos: variacion(delPeriodo.length, delPrevio.length),
-    activos: enPeriodo.size,
-    recurrentes: [...enPeriodo.values()].filter((v) => v >= 2).length,
-    dormidos: dormidos.slice(0, 8),
-    dormidosTotal: dormidos.length,
+    nuevos: nuevos.length,
+    deltaNuevos: hayComparacion ? variacion(nuevos.length, nuevosAntes.length) : null,
+    activos: veces.size,
+    deltaActivos: hayComparacion ? variacion(veces.size, vecesAntes.size) : null,
+    recurrentes: [...veces.values()].filter((v) => v >= 2).length,
   };
+}
+
+/* ------------------------------------------------------------
+   7 · Lo que hay que mirar
+
+   Insights y oportunidades salen del mismo informe que ya se calculó: no
+   hay una consulta más ni un motor aparte. Cada uno nace de un número
+   concreto y si ese número no existe, el insight no aparece. Ninguno se
+   escribe "por las dudas".
+
+   La diferencia entre los dos bloques: un insight explica lo que pasó en
+   el período; una oportunidad es algo para hacer hoy, y por eso sale de
+   `crm_segmentos`, que mira el estado actual del negocio y no la ventana
+   elegida. Está dicho en la pantalla.
+   ------------------------------------------------------------ */
+
+const pctTexto = (v) => (v * 100).toFixed(0).replace(".", ",") + "%";
+
+export function armarInsights(d) {
+  const xs = [];
+
+  /* Crecer en turnos y caer en ticket es la historia que más veces se
+     lee mal: más trabajo por menos plata. Se dice junta o no se dice. */
+  if (d.comparar && d.asistencia.deltaTurnos !== null && d.kpis.ticket.delta !== null) {
+    const t = d.asistencia.deltaTurnos;
+    const k = d.kpis.ticket.delta;
+    if (Math.abs(t) >= 0.05 || Math.abs(k) >= 0.05) {
+      xs.push({
+        k: "turnos-ticket",
+        tono: t >= 0 && k < 0 ? "ojo" : t >= 0 ? "bien" : "mal",
+        texto: `Los turnos ${t >= 0 ? "crecieron" : "cayeron"} ${pctTexto(Math.abs(t))} respecto al período anterior` +
+          (Math.abs(k) >= 0.03
+            ? `, y el ticket promedio ${k >= 0 ? "subió" : "cayó"} ${pctTexto(Math.abs(k))}.`
+            : "."),
+        accion: "Ver evolución",
+        ancla: "evolucion",
+      });
+    }
+  }
+
+  /* Qué día de la semana rinde menos. Se compara contra el promedio de
+     los días que el negocio abre, no contra los siete: incluir el domingo
+     cerrado haría que todos los días parezcan buenos. */
+  if (d.porDia && d.porDia.length >= 3) {
+    const activos = d.porDia.filter((x) => x.turnos > 0);
+    const prom = suma(activos, (x) => x.turnos) / Math.max(1, activos.length);
+    const peor = activos.slice().sort((a, b) => a.turnos - b.turnos)[0];
+    if (peor && prom > 0 && peor.turnos < prom * 0.8) {
+      xs.push({
+        k: "dia-flojo",
+        tono: "ojo",
+        texto: `Los ${peor.nombre} tienen ${pctTexto(1 - peor.turnos / prom)} menos turnos que el promedio de la semana.`,
+        accion: "Ver la agenda",
+        tab: "agenda",
+      });
+    }
+  }
+
+  /* La prestación que sostiene el negocio. Con su parte de las horas al
+     lado: no es lo mismo que la mitad de los ingresos venga de algo que
+     ocupa un quinto del tiempo que de algo que ocupa la mitad. */
+  const top = d.ingresos.porServicio[0];
+  if (top && d.ingresos.total > 0) {
+    const parte = top.total / d.ingresos.total;
+    if (parte >= 0.2) {
+      const horas = d.horasPorServicio && d.horasPorServicio.get(top.nombre);
+      const totalHoras = d.horasTotales || 0;
+      xs.push({
+        k: "concentracion",
+        tono: parte >= 0.5 ? "ojo" : "info",
+        texto: `${top.nombre} genera el ${pctTexto(parte)} de los ingresos` +
+          (horas && totalHoras > 0 ? ` y ocupa el ${pctTexto(horas / totalHoras)} de las horas dictadas.` : "."),
+        accion: "Ver prestaciones",
+        ancla: "prestaciones",
+      });
+    }
+  }
+
+  /* Dónde se está yendo la agenda. Solo si hay suficientes turnos como
+     para que el porcentaje signifique algo. */
+  if (d.asistencia.pct !== null && d.asistencia.pasados >= 20 && d.asistencia.pct < 0.85) {
+    xs.push({
+      k: "asistencia",
+      tono: "mal",
+      texto: `${d.asistencia.ausentes} de cada ${d.asistencia.cumplidas + d.asistencia.ausentes} turnos terminaron en ausencia: ${pctTexto(1 - d.asistencia.pct)} del total.`,
+      accion: "Mandar recordatorios",
+      tab: "comunicaciones",
+    });
+  }
+
+  /* Capacidad ociosa. El número que define si conviene abrir otra clase
+     o cerrar una sala. */
+  const flojos = d.ocupacion.profesionales.filter((p) => p.pct !== null && p.pct < 0.5);
+  if (flojos.length && d.ocupacion.profesionales.length > 1) {
+    xs.push({
+      k: "ocupacion",
+      tono: "ojo",
+      texto: flojos.length === 1
+        ? `${flojos[0].nombre} tiene ${pctTexto(1 - flojos[0].pct)} de su horario sin usar.`
+        : `${flojos.length} profesionales tienen más de la mitad de su horario sin usar.`,
+      accion: "Ver ocupación",
+      ancla: "ocupacion",
+    });
+  }
+
+  return xs;
+}
+
+/* Las oportunidades salen enteras de CRM: los segmentos ya están
+   calculados, probados y con su acción detrás. Rehacerlos acá sería tener
+   dos definiciones de "cliente que se está yendo" y que un día dejen de
+   coincidir. */
+export function armarOportunidades(segmentos) {
+  const tono = { se_van: "mal", sin_segunda: "ojo", abono_por_vencer: "info", abono_vencido: "ojo", falta_seguido: "tenue" };
+  return (segmentos || [])
+    .filter((s) => s.gente.length > 0)
+    .map((s) => ({
+      k: s.k,
+      tono: tono[s.k] || "tenue",
+      texto: `${s.gente.length} ${s.gente.length === 1 ? "cliente" : "clientes"}: ${s.n.toLowerCase()}.`,
+      detalle: s.d,
+      accion: "Ver en CRM",
+      tab: "crm",
+    }));
 }

--- a/src/genez/PanelGenez.jsx
+++ b/src/genez/PanelGenez.jsx
@@ -1801,7 +1801,7 @@ function Sistema({ sesion, rubro, roles, onSalir, setComercios, tema, setTema })
             <Reportes productos={productos} k={k} ir={ir}
               empresaId={empresaId} conPedidos={modulos.includes("comandas")} />
           )}
-          {tab === "informes" && <Informes empresaId={empresaId} />}
+          {tab === "informes" && <Informes empresaId={empresaId} ir={ir} />}
           {tab === "crm" && <Crm empresaId={empresaId} rubro={rubro} toast={toast} />}
           {tab === "comunicaciones" && (
             <Comunicaciones empresaId={empresaId} rubro={rubro}

--- a/src/modulos/Informes.jsx
+++ b/src/modulos/Informes.jsx
@@ -1,375 +1,566 @@
 /* ============================================================
-   20. INFORMES · para un negocio que vende horas
+   20. REPORTES · cómo va el negocio y dónde habría que actuar
    ============================================================
 
-   El informe que había —y que sigue vivo para el minimercado y el bar—
-   responde "qué se vende y qué margen deja". Un negocio de turnos no
-   tiene margen por unidad: tiene horas, y las horas que no se vendieron
-   no se recuperan. Por eso el orden de esta pantalla es otro.
+   Un reporte no existe para mostrar datos: existe para ayudar a decidir.
+   Por eso el orden de la pantalla no es "primero los gráficos lindos"
+   sino el de las preguntas que se hace alguien que abre esto un lunes a
+   la mañana. Cada bloque contesta una y solo una; el que no contestaba
+   ninguna no está.
 
-   ARRIBA VA LA PLATA, DESPUÉS LA CAPACIDAD
-   ----------------------------------------
-   Cuánto entró es lo que todos vienen a mirar. Pero lo que hace que ese
-   número cambie el mes que viene es la ocupación, así que va segunda y no
-   escondida abajo.
+   UN SOLO CONTEXTO PARA TODA LA PANTALLA
+   --------------------------------------
+   El rango de fechas, la comparación y los filtros valen para todo lo que
+   se ve. Ninguna tarjeta consulta por su cuenta ni elige su propio
+   período: `cargarInforme` arma todo de una y acá solo se dibuja. Dos
+   tarjetas mostrando ventanas distintas del mismo negocio es la forma más
+   rápida de que nadie vuelva a confiar en el informe.
 
-   Y se muestran las horas además del porcentaje. "Sala Mat 2: 0%" no dice
-   nada; "0 de 305 horas" dice que hay una sala que no se está usando.
+   LO QUE NO SE PUEDE FILTRAR SE ACLARA, NO SE DISIMULA
+   ----------------------------------------------------
+   Un alquiler no es de pilates ni de estética: los egresos no tienen
+   área. Así que con un filtro puesto, el resultado neto y la curva de
+   egresos siguen siendo del negocio entero y la pantalla lo dice. La
+   alternativa —mostrar un número que parece filtrado y no lo está— es
+   peor que no mostrarlo.
 
-   LOS COLORES SALEN DE LAS VARIABLES
-   ----------------------------------
-   Los gráficos también. `rgb(var(--acento))` funciona como cualquier
-   color en un atributo SVG, así que un gráfico no queda con el naranja
-   escrito a mano y encima cambia solo entre el tema claro y el oscuro.
+   LO QUE TODAVÍA NO SE PUEDE CALCULAR, NO SE INVENTA
+   --------------------------------------------------
+   No hay costo cargado en las prestaciones y los egresos no se imputan a
+   un área, así que "rentabilidad por área" es hoy "ingresos por área", y
+   está dicho al pie de la tarjeta. Un margen inventado en un informe
+   financiero no es un detalle estético: es alguien tomando una decisión
+   con un número falso.
    ============================================================ */
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import {
-  AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend,
 } from "recharts";
-import { CalendarClock, Wallet, Users, UserCheck } from "lucide-react";
-import { cargarInforme, PERIODOS } from "../datos/informes.js";
+import {
+  Wallet, TrendingUp, CalendarClock, PieChart as IconoTorta, Users, Receipt,
+  Calendar, GitCompareArrows, Download, X, Sparkles, ArrowRight, RefreshCw,
+} from "lucide-react";
+import {
+  cargarInforme, rangoDe, comparacionDe, PERIODOS, COMPARACIONES,
+} from "../datos/informes.js";
 import { money, moneyk, pct, nf } from "../utils/helpers.js";
-import { Kpi, Card, Vacio, Cargando, ErrorEstado, TablaSimple, Sello } from "../ui/Base.jsx";
+import {
+  Card, Boton, Tabs, Kpi, Vacio, Cargando, ErrorEstado, TablaSimple, Apagado,
+} from "../ui/Base.jsx";
+import { Anillo, Referencia, BarraDato } from "../ui/Graficos.jsx";
+import { inputCls } from "../ui/Campos.jsx";
 
 const ROTULO = "text-[11px] uppercase tracking-[0.1em] text-texto-tenue font-bold";
 
-function Rotulo({ children, ayuda }) {
+const fecha = (d) => d.toLocaleDateString("es-AR", { day: "2-digit", month: "short", year: "numeric" });
+const paraInput = (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+const deInput = (s) => { const [a, m, d] = s.split("-").map(Number); return new Date(a, m - 1, d); };
+
+const GRANOS = [{ k: "dia", n: "Diario" }, { k: "semana", n: "Semanal" }, { k: "mes", n: "Mensual" }];
+
+const PESTANAS = [
+  { k: "resumen", n: "Resumen general" },
+  { k: "turnos", n: "Turnos" },
+  { k: "finanzas", n: "Finanzas" },
+  { k: "servicios", n: "Servicios" },
+  { k: "profesionales", n: "Profesionales" },
+  { k: "salas", n: "Salas" },
+  { k: "clientes", n: "Clientes" },
+];
+
+/* Rótulo de sección con su pregunta al lado. La pregunta no es adorno: es
+   la única forma de que quien mira sepa para qué está ese bloque, y de
+   que el que lo mantenga sepa cuándo sacarlo. */
+function Titulo({ children, pregunta, extra }) {
   return (
-    <div className="mb-3">
-      <div className={ROTULO}>{children}</div>
-      {ayuda && <p className="text-xs text-texto-suave mt-1">{ayuda}</p>}
+    <div className="flex items-start justify-between gap-4 flex-wrap mb-4">
+      <div className="min-w-0">
+        <div className={ROTULO}>{children}</div>
+        {pregunta && <p className="text-xs text-texto-suave mt-1">{pregunta}</p>}
+      </div>
+      {extra}
     </div>
   );
 }
 
-/* Una fila con barra. Se repite en cuatro bloques y en todos significa lo
-   mismo: esto es cuánto, comparado con el más grande de la lista. */
-function Barra({ nombre, sub, valor, proporcion, tono = "acento" }) {
-  const color = tono === "bien" ? "bg-bien" : tono === "mal" ? "bg-mal" : "bg-acento";
+function Pastilla({ activo, onClick, children }) {
   return (
-    <li>
-      <div className="flex justify-between text-sm gap-3">
-        <span className="truncate text-texto">{nombre}</span>
-        <span className="f-m shrink-0 text-texto-suave">{valor}</span>
-      </div>
-      <div className="h-1.5 bg-superficie-2 rounded-full mt-1.5 overflow-hidden">
-        <div className={`h-full rounded-full ${color}`}
-          style={{ width: `${Math.max(2, Math.round((proporcion || 0) * 100))}%` }} />
-      </div>
-      {sub && <div className="text-[11px] text-texto-tenue mt-1">{sub}</div>}
-    </li>
+    <button onClick={onClick}
+      className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
+        activo
+          ? "bg-superficie-3 text-texto border-superficie-3"
+          : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
+      {children}
+    </button>
   );
 }
 
-const fechaCorta = (d) => d.toLocaleDateString("es-AR", { day: "2-digit", month: "short" });
-
-export function Informes({ empresaId }) {
-  const [dias, setDias] = useState(30);
-  const [d, setD] = useState(null);
-  const [cargando, setCargando] = useState(true);
-  const [error, setError] = useState("");
-  const [intento, setIntento] = useState(0);
-
-  useEffect(() => {
-    let vigente = true;
-    setCargando(true);
-    setError("");
-    cargarInforme(empresaId, dias)
-      .then((r) => { if (vigente) setD(r); })
-      .catch((e) => { if (vigente) setError(e.message || "No pudimos armar el informe."); })
-      .finally(() => { if (vigente) setCargando(false); });
-    return () => { vigente = false; };
-  }, [empresaId, dias, intento]);
-
-  const serie = useMemo(() => {
-    if (!d) return [];
-    const fin = new Date(d.hasta);
-    return d.ingresos.serie.map((v, i) => {
-      const f = new Date(fin.getTime() - (d.ingresos.serie.length - 1 - i) * 86400000);
-      return { label: fechaCorta(f), ingresos: v };
-    });
-  }, [d]);
-
-  if (error) return <ErrorEstado onReintentar={() => setIntento((x) => x + 1)}>{error}</ErrorEstado>;
-  if (cargando && !d) return <Cargando>Armando el informe…</Cargando>;
-  if (!d) return null;
-
-  const { ingresos, ocupacion, asistencia, clientes } = d;
-  const sinNada = ingresos.total === 0 && asistencia.total === 0;
-
-  const maxArea = Math.max(1, ...ingresos.porArea.map((a) => a.total));
-  const maxServicio = Math.max(1, ...ingresos.porServicio.map((s) => s.total));
-  const maxSala = Math.max(1, ...ocupacion.salas.map((s) => s.horasOcupadas));
-
+function Selector({ label, valor, onChange, opciones, todos = "Todas" }) {
   return (
-    <div className="space-y-5">
-      <div className="flex items-center gap-1.5">
-        {PERIODOS.map((p) => (
-          <button key={p.k} onClick={() => setDias(p.k)}
-            className={`text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors ${
-              dias === p.k
-                ? "bg-superficie-3 text-texto border-superficie-3"
-                : "bg-superficie border-borde text-texto-suave hover:bg-superficie-2"}`}>
-            {p.n}
-          </button>
-        ))}
-        {cargando && <span className="text-xs text-texto-tenue ml-2">actualizando…</span>}
-      </div>
+    <div className="min-w-0 flex-1">
+      <label className={ROTULO}>{label}</label>
+      <select value={valor || ""} onChange={(e) => onChange(e.target.value || null)}
+        className={`${inputCls} mt-1.5`}>
+        <option value="">{todos}</option>
+        {opciones.map((o) => <option key={o.k} value={o.k}>{o.n}</option>)}
+      </select>
+    </div>
+  );
+}
 
-      {sinNada ? (
-        <Card className="p-6">
-          <Vacio>
-            Todavía no hay turnos dictados ni ventas en este período. Cuando
-            empiecen a cargarse, el informe se arma solo.
-          </Vacio>
-        </Card>
-      ) : (
-        <>
-          {/* ---------------------------------------------------------
-              1 · La plata
-              --------------------------------------------------------- */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-            <Kpi label={`Ingresos ${dias} días`} valor={money(ingresos.total)}
-              delta={ingresos.delta} icono={Wallet}
-              sub={`${money(ingresos.promedioDiario)} por día`} />
-            <Kpi label="Ticket promedio" valor={money(ingresos.ticket)}
-              sub={`${nf.format(ingresos.operaciones)} ventas`} />
-            <Kpi label="Ocupación del equipo"
-              valor={ocupacion.profesionales.length ? pct(promedio(ocupacion.profesionales), 0) : "—"}
-              icono={CalendarClock}
-              sub="de las horas que tienen cargadas" />
-            <Kpi label="Asistencia"
-              valor={asistencia.pct === null ? "—" : pct(asistencia.pct, 0)}
-              tono={asistencia.pct !== null && asistencia.pct < 0.8 ? "mal" : "bien"}
-              icono={UserCheck}
-              sub={`${nf.format(asistencia.cumplidas)} de ${nf.format(asistencia.cumplidas + asistencia.ausentes)}`} />
-          </div>
+const TONO_INSIGHT = {
+  bien: "text-bien border-bien bg-bien-suave",
+  mal: "text-mal border-mal bg-mal-suave",
+  ojo: "text-ojo border-ojo bg-ojo-suave",
+  info: "text-info border-info bg-info-suave",
+  tenue: "text-texto-tenue border-borde bg-superficie-2",
+};
 
-          <Card className="p-5">
-            <div className="flex items-start justify-between gap-4 flex-wrap">
-              <Rotulo ayuda="Turnos cobrados y abonos vendidos, por día.">Ingresos</Rotulo>
-              {/* Un abono es plata que entró hoy por horas que se van a dar
-                  en las próximas ocho semanas. Sin este corte, un mes de
-                  muchas renovaciones parece un mes de mucha actividad. */}
-              <div className="flex items-center gap-5 text-right">
-                <div>
-                  <div className={ROTULO}>Turnos</div>
-                  <div className="f-m text-sm mt-0.5">{money(ingresos.sueltos)}</div>
-                </div>
-                <div>
-                  <div className={ROTULO}>Abonos y packs</div>
-                  <div className="f-m text-sm mt-0.5">{money(ingresos.abonos)}</div>
-                </div>
-              </div>
-            </div>
-            <ResponsiveContainer width="100%" height={230}>
-              <AreaChart data={serie} margin={{ top: 4, right: 8, left: -14, bottom: 0 }}>
-                <defs>
-                  <linearGradient id="gIngresos" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor="rgb(var(--acento))" stopOpacity={0.3} />
-                    <stop offset="100%" stopColor="rgb(var(--acento))" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="2 4" stroke="rgb(var(--borde))" vertical={false} />
-                <XAxis dataKey="label" tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
-                  interval={Math.max(0, Math.floor(dias / 8))} axisLine={false} tickLine={false} />
-                <YAxis tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
-                  tickFormatter={moneyk} axisLine={false} tickLine={false} width={60} />
-                <Tooltip formatter={(v) => [money(v), "Ingresos"]}
-                  contentStyle={{ fontSize: 12, borderRadius: 10, border: "1px solid rgb(var(--borde))", background: "rgb(var(--superficie))" }} />
-                <Area type="monotone" dataKey="ingresos" stroke="rgb(var(--acento))" strokeWidth={2} fill="url(#gIngresos)" />
-              </AreaChart>
-            </ResponsiveContainer>
-          </Card>
-
-          <div className="grid lg:grid-cols-2 gap-4">
-            <Card className="p-5">
-              <Rotulo ayuda="De qué parte del negocio viene cada peso.">Por área</Rotulo>
-              {!ingresos.porArea.length ? <Vacio>Nada facturado en el período.</Vacio> : (
-                <ul className="space-y-3">
-                  {ingresos.porArea.map((a) => (
-                    <Barra key={a.nombre} nombre={a.nombre} valor={money(a.total)}
-                      proporcion={a.total / maxArea}
-                      sub={pct(a.total / (ingresos.total || 1), 0) + " del total"} />
-                  ))}
-                </ul>
-              )}
-            </Card>
-
-            <Card className="p-5">
-              <Rotulo ayuda="Lo que más entra, contando cuántas veces se vendió.">Prestaciones y planes</Rotulo>
-              {!ingresos.porServicio.length ? <Vacio>Nada facturado en el período.</Vacio> : (
-                <ul className="space-y-3">
-                  {ingresos.porServicio.map((s) => (
-                    <Barra key={s.nombre} nombre={s.nombre} valor={money(s.total)}
-                      proporcion={s.total / maxServicio}
-                      sub={`${nf.format(s.cantidad)} ${s.plan ? "vendidos" : "turnos"}`} />
-                  ))}
-                </ul>
-              )}
-            </Card>
-          </div>
-
-          {/* ---------------------------------------------------------
-              2 · La capacidad
-              --------------------------------------------------------- */}
-          <div className="grid lg:grid-cols-2 gap-4">
-            <Card className="p-5">
-              <Rotulo ayuda="Horas agendadas sobre las horas que cada uno tiene cargadas en su horario.">
-                Ocupación del equipo
-              </Rotulo>
-              {!ocupacion.profesionales.length ? (
-                <Vacio>Nadie tiene horarios cargados todavía.</Vacio>
-              ) : (
-                <ul className="space-y-3">
-                  {ocupacion.profesionales.map((p) => (
-                    <Barra key={p.id} nombre={p.nombre}
-                      valor={p.pct === null ? "sin horario" : pct(p.pct, 0)}
-                      proporcion={p.pct || 0}
-                      tono={p.pct !== null && p.pct < 0.4 ? "mal" : "acento"}
-                      sub={`${p.horasOcupadas.toFixed(1)} de ${p.horasOfrecidas.toFixed(0)} hs · ${p.detalle}`} />
-                  ))}
-                </ul>
-              )}
-            </Card>
-
-            <Card className="p-5">
-              <Rotulo ayuda="Sobre las horas que abre el local. Una sala vacía no cuesta un sueldo, pero sí un alquiler.">
-                Uso de los espacios
-              </Rotulo>
-              {!ocupacion.salas.length ? <Vacio>No hay espacios cargados.</Vacio> : (
-                <ul className="space-y-3">
-                  {ocupacion.salas.map((s) => (
-                    <Barra key={s.id} nombre={s.nombre}
-                      valor={`${s.horasOcupadas.toFixed(1)} hs`}
-                      proporcion={s.horasOcupadas / maxSala}
-                      tono={s.horasOcupadas === 0 ? "mal" : "acento"}
-                      sub={s.horasOcupadas === 0
-                        ? "sin usar en todo el período"
-                        : `${pct(s.pct || 0, 0)} de las ${s.horasOfrecidas.toFixed(0)} hs que abre el local`} />
-                  ))}
-                </ul>
-              )}
-            </Card>
-          </div>
-
-          {ocupacion.clases.lugares > 0 && (
-            <Card className="p-5">
-              <div className="flex items-start justify-between gap-4 flex-wrap">
-                <Rotulo ayuda="Una sala llena de tiempo puede estar medio vacía de gente: son dos cosas distintas y las dos deciden si conviene abrir otra clase.">
-                  Lugares de clase
-                </Rotulo>
-                <div className="text-right">
-                  <div className="f-d text-3xl tabular-nums">{pct(ocupacion.clases.pct || 0, 0)}</div>
-                  <div className="text-xs text-texto-tenue">
-                    {nf.format(ocupacion.clases.tomados)} de {nf.format(ocupacion.clases.lugares)} lugares
-                  </div>
-                </div>
-              </div>
-              <ul className="space-y-3 mt-1">
-                {ocupacion.profesionales.filter((p) => p.lugares > 0).map((p) => (
-                  <Barra key={p.id} nombre={p.nombre}
-                    valor={pct(p.pctCupo || 0, 0)}
-                    proporcion={p.pctCupo || 0}
-                    tono={p.pctCupo !== null && p.pctCupo < 0.5 ? "mal" : "bien"}
-                    sub={`${nf.format(p.tomados)} de ${nf.format(p.lugares)} lugares ofrecidos`} />
-                ))}
-              </ul>
-            </Card>
-          )}
-
-          {/* ---------------------------------------------------------
-              3 · La asistencia
-              --------------------------------------------------------- */}
-          <Card className="p-5">
-            <div className="flex items-start justify-between gap-4 flex-wrap">
-              <Rotulo ayuda="Solo sobre turnos que ya pasaron. Contar los de la semana que viene como faltas hunde el número sin motivo.">
-                Asistencia
-              </Rotulo>
-              <div className="flex flex-wrap items-center gap-2">
-                {asistencia.porEstado.map((e) => (
-                  <Sello key={e.k} tono={e.tono}>{e.n} {nf.format(e.v)}</Sello>
-                ))}
-              </div>
-            </div>
-
-            {!asistencia.porServicio.length ? (
-              <Vacio>Todavía no hay suficientes turnos cumplidos para sacar conclusiones por prestación.</Vacio>
-            ) : (
-              <>
-                <p className="text-xs text-texto-suave mb-3">
-                  Dónde más se falta. Es por acá por donde se va la agenda de una semana.
-                </p>
-                <TablaSimple
-                  cols={["Prestación", "Turnos", "Vinieron", "Faltaron", "Asistencia"]}
-                  filas={asistencia.porServicio.map((s) => [
-                    <div key="a">
-                      <div className="font-medium">{s.nombre}</div>
-                      <div className="text-[11px] text-texto-tenue">{s.area}</div>
-                    </div>,
-                    <span className="f-m text-texto-tenue">{nf.format(s.total)}</span>,
-                    <span className="f-m">{nf.format(s.vino)}</span>,
-                    <span className="f-m">{nf.format(s.falto)}</span>,
-                    <span className={`f-m font-semibold ${s.pct < 0.8 ? "text-mal" : "text-bien"}`}>
-                      {pct(s.pct, 0)}
-                    </span>,
-                  ])}
-                  vacio="Sin datos."
-                />
-              </>
-            )}
-          </Card>
-
-          {/* ---------------------------------------------------------
-              4 · La gente
-              --------------------------------------------------------- */}
-          <div className="grid lg:grid-cols-3 gap-3">
-            <Kpi label="Clientes nuevos" valor={nf.format(clientes.nuevos)}
-              delta={clientes.deltaNuevos} icono={Users}
-              sub={`en ${dias} días`} />
-            <Kpi label="Vinieron al menos una vez" valor={nf.format(clientes.activos)} />
-            <Kpi label="Volvieron" valor={nf.format(clientes.recurrentes)}
-              sub={clientes.activos ? `${pct(clientes.recurrentes / clientes.activos, 0)} de los que vinieron` : null} />
-          </div>
-
-          <Card className="p-5">
-            <Rotulo ayuda="Vinieron alguna vez y hace más de 45 días que no aparecen. No están perdidos: están sin llamar.">
-              Hace rato que no vienen
-            </Rotulo>
-            {!clientes.dormidos.length ? (
-              <Vacio>Nadie se quedó sin volver. Poco común y buena señal.</Vacio>
-            ) : (
-              <>
-                <TablaSimple
-                  cols={["Cliente", "Veces que vino", "Última vez", "Hace"]}
-                  filas={clientes.dormidos.map((c) => [
-                    <span key="a" className="font-medium">{c.nombre || "Sin nombre"}</span>,
-                    <span className="f-m">{nf.format(c.veces)}</span>,
-                    <span className="f-m text-texto-suave">{fechaCorta(c.ultima)}</span>,
-                    <span className="f-m">{nf.format(c.dias)} días</span>,
-                  ])}
-                  vacio="Sin datos."
-                />
-                {clientes.dormidosTotal > clientes.dormidos.length && (
-                  <p className="text-xs text-texto-tenue mt-3">
-                    Y {nf.format(clientes.dormidosTotal - clientes.dormidos.length)} más.
-                  </p>
-                )}
-              </>
-            )}
-          </Card>
-        </>
+function Tarjeta({ tono, texto, accion, onAccion }) {
+  return (
+    <div className="border border-borde rounded-lg p-4 flex flex-col gap-2 min-w-0">
+      <span className={`w-7 h-7 rounded-lg border flex items-center justify-center shrink-0 ${TONO_INSIGHT[tono] || TONO_INSIGHT.tenue}`}>
+        <Sparkles size={13} />
+      </span>
+      <p className="text-sm text-texto leading-relaxed">{texto}</p>
+      {accion && (
+        <button onClick={onAccion}
+          className="text-xs font-semibold text-acento hover:underline flex items-center gap-1 mt-auto self-start">
+          {accion} <ArrowRight size={12} />
+        </button>
       )}
     </div>
   );
 }
 
-/* El promedio se pondera por horas ofrecidas y no por persona: alguien
-   que trabaja cuatro horas por semana no puede mover el número del equipo
-   igual que alguien de tiempo completo. */
-function promedio(profesionales) {
-  const ofrecidas = profesionales.reduce((s, p) => s + p.horasOfrecidas, 0);
-  if (!ofrecidas) return 0;
-  return profesionales.reduce((s, p) => s + p.horasOcupadas, 0) / ofrecidas;
+export function Informes({ empresaId, ir }) {
+  const [pestana, setPestana] = useState("resumen");
+
+  const [preset, setPreset] = useState("30d");
+  const [rango, setRango] = useState(() => rangoDe("30d"));
+  const [modoComparar, setModoComparar] = useState("anterior");
+  const [comparaLibre, setComparaLibre] = useState(null);
+  const [filtros, setFiltros] = useState({});
+  const [grano, setGrano] = useState(null);
+
+  const [abierto, setAbierto] = useState(null);   // 'periodo' | 'comparar'
+  const [d, setD] = useState(null);
+  const [cargando, setCargando] = useState(true);
+  const [error, setError] = useState("");
+  const [intento, setIntento] = useState(0);
+
+  const comparar = useMemo(
+    () => comparacionDe(modoComparar, rango.desde, rango.hasta, comparaLibre),
+    [modoComparar, rango, comparaLibre]);
+
+  useEffect(() => {
+    let vigente = true;
+    setCargando(true);
+    setError("");
+    cargarInforme(empresaId, { ...rango, comparar, filtros, grano })
+      .then((r) => { if (vigente) setD(r); })
+      .catch((e) => { if (vigente) setError(e.message || "No pudimos armar el informe."); })
+      .finally(() => { if (vigente) setCargando(false); });
+    return () => { vigente = false; };
+  }, [empresaId, rango, comparar, filtros, grano, intento]);
+
+  const elegirPreset = useCallback((k) => {
+    setPreset(k);
+    if (k !== "libre") { setRango(rangoDe(k)); setGrano(null); setAbierto(null); }
+  }, []);
+
+  const setFiltro = (k, v) => setFiltros((f) => {
+    const nuevo = { ...f };
+    if (v) nuevo[k] = v; else delete nuevo[k];
+    return nuevo;
+  });
+
+  const hayFiltro = Object.keys(filtros).length > 0;
+
+  if (error) return <ErrorEstado onReintentar={() => setIntento((x) => x + 1)}>{error}</ErrorEstado>;
+  if (cargando && !d) return <Cargando>Armando el informe…</Cargando>;
+  if (!d) return null;
+
+  const { kpis, ingresos, finanzas, ocupacion, asistencia, equipo, clientes } = d;
+  const sinNada = ingresos.total === 0 && asistencia.total === 0;
+
+  const irA = (x) => { if (x.tab && ir) ir(x.tab); };
+
+  return (
+    <div className="space-y-5">
+      {/* ============ ENCABEZADO ============ */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="min-w-0">
+          <h2 className="f-d text-2xl">Reportes</h2>
+          <p className="text-sm text-texto-suave mt-0.5">
+            Analizá el rendimiento de tu negocio y descubrí dónde actuar.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Boton variant="ghost" onClick={() => setAbierto(abierto === "periodo" ? null : "periodo")}>
+            <Calendar size={15} /> {fecha(d.desde)} — {fecha(d.hasta)}
+          </Boton>
+          <Boton variant="ghost" onClick={() => setAbierto(abierto === "comparar" ? null : "comparar")}>
+            <GitCompareArrows size={15} />
+            {(COMPARACIONES.find((x) => x.k === modoComparar) || {}).n}
+          </Boton>
+          {/* No hay exportación en el sistema todavía. Un botón que no
+              exporta nada es peor que uno apagado que dice por qué. */}
+          <Apagado motivo="Exportar" className="px-4 py-2.5 rounded-md text-sm font-semibold">
+            <Download size={15} /> Exportar
+          </Apagado>
+        </div>
+      </div>
+
+      {/* ============ PERÍODO ============ */}
+      {abierto === "periodo" && (
+        <Card className="p-5">
+          <Titulo pregunta="Todo lo que se ve abajo usa este rango."
+            extra={<button onClick={() => setAbierto(null)} className="text-texto-tenue hover:text-texto"><X size={16} /></button>}>
+            Período
+          </Titulo>
+          <div className="flex flex-wrap gap-1.5">
+            {PERIODOS.map((p) => (
+              <Pastilla key={p.k} activo={preset === p.k} onClick={() => elegirPreset(p.k)}>{p.n}</Pastilla>
+            ))}
+          </div>
+          {preset === "libre" && (
+            <div className="flex flex-wrap items-end gap-3 mt-4">
+              <div>
+                <label className={ROTULO}>Desde</label>
+                <input type="date" value={paraInput(d.desde)}
+                  onChange={(e) => { setRango((r) => ({ ...r, desde: deInput(e.target.value) })); setGrano(null); }}
+                  className={`${inputCls} mt-1.5`} />
+              </div>
+              <div>
+                <label className={ROTULO}>Hasta</label>
+                <input type="date" value={paraInput(d.hasta)}
+                  onChange={(e) => { setRango((r) => ({ ...r, hasta: deInput(e.target.value) })); setGrano(null); }}
+                  className={`${inputCls} mt-1.5`} />
+              </div>
+              <p className="text-xs text-texto-tenue pb-2">Cualquier rango, no solo meses enteros.</p>
+            </div>
+          )}
+        </Card>
+      )}
+
+      {/* ============ COMPARACIÓN ============ */}
+      {abierto === "comparar" && (
+        <Card className="p-5">
+          <Titulo pregunta="Contra qué se calculan las variaciones de los indicadores."
+            extra={<button onClick={() => setAbierto(null)} className="text-texto-tenue hover:text-texto"><X size={16} /></button>}>
+            Comparar con
+          </Titulo>
+          <div className="flex flex-wrap gap-1.5">
+            {COMPARACIONES.map((c) => (
+              <Pastilla key={c.k} activo={modoComparar === c.k} onClick={() => setModoComparar(c.k)}>{c.n}</Pastilla>
+            ))}
+          </div>
+          {modoComparar === "libre" && (
+            <div className="flex flex-wrap items-end gap-3 mt-4">
+              <div>
+                <label className={ROTULO}>Desde</label>
+                <input type="date" value={comparaLibre ? paraInput(comparaLibre.desde) : ""}
+                  onChange={(e) => setComparaLibre((c) => ({ desde: deInput(e.target.value), hasta: (c && c.hasta) || deInput(e.target.value) }))}
+                  className={`${inputCls} mt-1.5`} />
+              </div>
+              <div>
+                <label className={ROTULO}>Hasta</label>
+                <input type="date" value={comparaLibre ? paraInput(comparaLibre.hasta) : ""}
+                  onChange={(e) => setComparaLibre((c) => ({ desde: (c && c.desde) || deInput(e.target.value), hasta: deInput(e.target.value) }))}
+                  className={`${inputCls} mt-1.5`} />
+              </div>
+            </div>
+          )}
+          {d.comparar && (
+            <p className="text-xs text-texto-tenue mt-3">
+              Comparando contra {fecha(d.comparar.desde)} — {fecha(d.comparar.hasta)}.
+            </p>
+          )}
+        </Card>
+      )}
+
+      {/* ============ FILTROS ============ */}
+      <Card className="p-5">
+        <div className="flex flex-wrap items-end gap-4">
+          {/* Un filtro que no discrimina nada confunde más que ayuda. */}
+          <div className="min-w-0 flex-1">
+            <label className={ROTULO}>Sucursal</label>
+            <Apagado motivo="Una sola sucursal" className={`${inputCls} mt-1.5 !justify-start`}>Todas</Apagado>
+          </div>
+          <Selector label="Área" valor={filtros.area} opciones={d.opciones.areas}
+            onChange={(v) => setFiltro("area", v)} />
+          <Selector label="Profesional" valor={filtros.personal} opciones={d.opciones.profesionales}
+            onChange={(v) => setFiltro("personal", v)} todos="Todos" />
+          <Selector label="Prestación" valor={filtros.item} opciones={d.opciones.servicios}
+            onChange={(v) => setFiltro("item", v)} todos="Todas" />
+          <Selector label="Sala o recurso" valor={filtros.recurso} opciones={d.opciones.salas}
+            onChange={(v) => setFiltro("recurso", v)} />
+          {hayFiltro && (
+            <button onClick={() => setFiltros({})}
+              className="text-xs font-semibold text-acento hover:underline flex items-center gap-1 pb-2.5 shrink-0">
+              <X size={13} /> Limpiar filtros
+            </button>
+          )}
+        </div>
+        {hayFiltro && (
+          <p className="text-xs text-ojo mt-3">
+            Con un filtro puesto, el resultado neto y los egresos siguen siendo del
+            negocio entero: un alquiler no pertenece a un área ni a una persona.
+          </p>
+        )}
+      </Card>
+
+      <Tabs value={pestana} onChange={setPestana} items={PESTANAS} />
+
+      {pestana !== "resumen" ? (
+        <Card className="p-6">
+          <Apagado motivo={(PESTANAS.find((p) => p.k === pestana) || {}).n}>
+            Esta pestaña todavía no existe. Lo que se puede calcular hoy con datos
+            reales está en el resumen; el resto llega cuando haya de dónde sacarlo.
+          </Apagado>
+        </Card>
+      ) : sinNada ? (
+        <Card className="p-6">
+          <Vacio>
+            No hay movimiento en este período. Probá con un rango más amplio o
+            sacando los filtros.
+          </Vacio>
+        </Card>
+      ) : (
+        <>
+          {/* ============ 1 · ¿CÓMO ESTÁ EL NEGOCIO? ============ */}
+          <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
+            <Kpi label="Ingresos totales" valor={money(ingresos.total)} delta={kpis.ingresos.delta}
+              icono={Wallet} sub={d.comparar ? "vs período anterior" : null} />
+            <Kpi label="Resultado neto" valor={money(finanzas.resultado)} delta={kpis.resultado.delta}
+              icono={TrendingUp} tono={finanzas.resultado >= 0 ? "bien" : "mal"}
+              sub={finanzas.margen !== null ? `${pct(finanzas.margen, 0)} de margen` : null} />
+            <Kpi label="Turnos totales" valor={nf.format(asistencia.total)} delta={kpis.turnos.delta}
+              icono={CalendarClock} />
+            <Kpi label="Ocupación promedio" valor={ocupacion.promedio ? pct(ocupacion.promedio, 0) : "—"}
+              icono={IconoTorta} sub="del horario del equipo" />
+            <Kpi label="Clientes activos" valor={nf.format(clientes.activos)} delta={kpis.clientes.delta}
+              icono={Users} sub="vinieron al menos una vez" />
+            <Kpi label="Ticket promedio" valor={money(ingresos.ticket)} delta={kpis.ticket.delta}
+              icono={Receipt} sub={`${nf.format(ingresos.operaciones)} ventas`} />
+          </div>
+
+          {/* ============ 2 · ¿QUÉ ESTÁ PASANDO? ============ */}
+          {d.insights.length > 0 && (
+            <Card className="p-5">
+              <Titulo pregunta="Lo que dicen los números de arriba, dicho en palabras. Sale de este mismo informe.">
+                Insights de Genez
+              </Titulo>
+              <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-3">
+                {d.insights.map((x) => (
+                  <Tarjeta key={x.k} tono={x.tono} texto={x.texto} accion={x.accion} onAccion={() => irA(x)} />
+                ))}
+              </div>
+            </Card>
+          )}
+
+          {/* ============ 3 · ¿CÓMO CAMBIÓ? · ¿DE DÓNDE VIENE? ============ */}
+          <div className="grid xl:grid-cols-3 gap-4">
+            <Card className="p-5 xl:col-span-2">
+              <Titulo pregunta="Lo que entró, lo que salió y lo que quedó."
+                extra={
+                  <div className="flex gap-1.5">
+                    {GRANOS.map((g) => (
+                      <Pastilla key={g.k} activo={(grano || d.grano) === g.k} onClick={() => setGrano(g.k)}>{g.n}</Pastilla>
+                    ))}
+                  </div>
+                }>
+                Evolución
+              </Titulo>
+              {!d.evolucion.length ? <Vacio>Sin movimientos de caja en este período.</Vacio> : (
+                <ResponsiveContainer width="100%" height={260}>
+                  <LineChart data={d.evolucion} margin={{ top: 4, right: 8, left: -12, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="2 4" stroke="rgb(var(--borde))" vertical={false} />
+                    <XAxis dataKey="label" tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
+                      axisLine={false} tickLine={false}
+                      interval={Math.max(0, Math.floor(d.evolucion.length / 10))} />
+                    <YAxis tick={{ fontSize: 10, fill: "rgb(var(--texto-tenue))" }}
+                      tickFormatter={moneyk} axisLine={false} tickLine={false} width={58} />
+                    <Tooltip formatter={(v, k) => [money(v), k[0].toUpperCase() + k.slice(1)]}
+                      contentStyle={{ fontSize: 12, borderRadius: 10, border: "1px solid rgb(var(--borde))", background: "rgb(var(--superficie))" }} />
+                    <Legend wrapperStyle={{ fontSize: 11 }} iconType="plainline" />
+                    <Line type="monotone" dataKey="ingresos" name="Ingresos" stroke="rgb(var(--bien))" strokeWidth={2} dot={false} />
+                    <Line type="monotone" dataKey="egresos" name="Egresos" stroke="rgb(var(--mal))" strokeWidth={2} dot={false} />
+                    <Line type="monotone" dataKey="resultado" name="Resultado" stroke="rgb(var(--acento))" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </Card>
+
+            <Card className="p-5">
+              <Titulo pregunta="Un abono es plata de hoy por horas de las próximas semanas.">
+                Ingresos por fuente
+              </Titulo>
+              <Anillo datos={ingresos.fuentes} centro={moneyk(ingresos.total)} sub="en el período" />
+              <div className="mt-3">
+                <Referencia datos={ingresos.fuentes}
+                  formato={(x) => `${money(x.v)} · ${pct(x.v / (ingresos.total || 1), 0)}`} />
+              </div>
+            </Card>
+          </div>
+
+          {/* ============ 4 · ¿QUÉ VENDO? · ¿USO LA CAPACIDAD? ============ */}
+          <div className="grid xl:grid-cols-2 gap-4">
+            <Card className="p-5">
+              <Titulo pregunta="Ordenado por lo que factura, no por lo que se vende más veces.">
+                Prestaciones y planes
+              </Titulo>
+              {!ingresos.porServicio.length ? <Vacio>Nada facturado en el período.</Vacio> : (
+                <div className="space-y-3">
+                  {ingresos.porServicio.slice(0, 5).map((s, i) => (
+                    <div key={s.nombre} className="flex gap-3">
+                      <span className="f-m text-xs text-texto-tenue w-4 shrink-0 pt-0.5">{i + 1}</span>
+                      <div className="min-w-0 flex-1">
+                        <BarraDato nombre={s.nombre} valor={s.total} total={ingresos.total} formato={money} />
+                        <div className="text-[11px] text-texto-tenue mt-1">
+                          {nf.format(s.cantidad)} {s.plan ? "vendidos" : "turnos"}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+
+            <Card className="p-5">
+              <Titulo pregunta="Horas usadas sobre las horas que el espacio está disponible.">
+                Ocupación por sala
+              </Titulo>
+              {!ocupacion.salas.length ? <Vacio>No hay espacios cargados.</Vacio> : (
+                <div className="space-y-3">
+                  {ocupacion.salas.map((s) => (
+                    <div key={s.id}>
+                      <div className="flex items-baseline justify-between gap-3 text-sm">
+                        <span className="truncate text-texto">{s.nombre}</span>
+                        <span className="f-m text-xs shrink-0">
+                          {s.pct === null ? "—" : pct(s.pct, 0)}
+                        </span>
+                      </div>
+                      <div className="h-1.5 rounded-full bg-superficie-2 overflow-hidden mt-1.5">
+                        <div className={`h-full rounded-full ${s.horasOcupadas === 0 ? "bg-mal" : "bg-acento"}`}
+                          style={{ width: `${Math.max(2, Math.round((s.pct || 0) * 100))}%` }} />
+                      </div>
+                      <div className="text-[11px] text-texto-tenue mt-1">
+                        {s.horasOcupadas.toFixed(1)} de {s.horasOfrecidas.toFixed(0)} hs
+                        {s.lugares > 0 && ` · ${nf.format(s.tomados)} de ${nf.format(s.lugares)} lugares`}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+          </div>
+
+          {/* ============ 5 · ¿VIENEN? · ¿DÓNDE GANO? ============ */}
+          <div className="grid xl:grid-cols-2 gap-4">
+            <Card className="p-5">
+              <Titulo pregunta="Sobre turnos que ya pasaron: los de la semana que viene no faltaron todavía.">
+                Asistencia
+              </Titulo>
+              {!asistencia.porEstado.length ? <Vacio>Sin turnos en este período.</Vacio> : (
+                <div className="grid sm:grid-cols-2 gap-4 items-center">
+                  <Anillo datos={asistencia.porEstado}
+                    centro={asistencia.pct === null ? "—" : pct(asistencia.pct, 0)} sub="asistencia" />
+                  <Referencia datos={asistencia.porEstado} formato={(x) => nf.format(x.v)} />
+                </div>
+              )}
+              {asistencia.porServicio.length > 0 && (
+                <p className="text-xs text-texto-suave mt-4">
+                  Donde más se falta: <span className="text-texto">{asistencia.porServicio[0].nombre}</span>,
+                  {" "}{pct(asistencia.porServicio[0].pct, 0)} de asistencia.
+                </p>
+              )}
+            </Card>
+
+            <Card className="p-5">
+              <Titulo pregunta="De qué parte del negocio viene cada peso.">
+                Ingresos por área
+              </Titulo>
+              {!ingresos.porArea.length ? <Vacio>Nada facturado en el período.</Vacio> : (
+                <div className="space-y-3">
+                  {ingresos.porArea.map((a) => (
+                    <BarraDato key={a.nombre} nombre={a.nombre} valor={a.total}
+                      total={ingresos.total} formato={money} />
+                  ))}
+                </div>
+              )}
+              {/* Esto la maqueta lo pedía como "rentabilidad". No se puede
+                  todavía y decirlo es parte del trabajo. */}
+              <p className="text-xs text-texto-tenue mt-4 leading-relaxed">
+                Sin costos: las prestaciones no tienen costo cargado y los egresos
+                —alquiler, sueldos, insumos— no se imputan a un área. Cuando existan
+                esos dos datos, acá van también el resultado y el margen.
+              </p>
+            </Card>
+          </div>
+
+          {/* ============ 6 · ¿CÓMO TRABAJA EL EQUIPO? ============ */}
+          <Card className="overflow-hidden">
+            <div className="px-5 pt-5">
+              <Titulo pregunta="Cuánto atendió cada uno, cuánto de su horario usó y cuánto facturó.">
+                Rendimiento del equipo
+              </Titulo>
+            </div>
+            <TablaSimple
+              cols={["Profesional", "Atendidos", "Asistencia", "Ocupación", "Ingresos"]}
+              filas={equipo.map((p) => [
+                <div key="a">
+                  <div className="font-medium">{p.nombre}</div>
+                  <div className="text-[11px] text-texto-tenue">
+                    {p.especialidad}
+                    {p.clases > 0 && ` · ${nf.format(p.clases)} clases`}
+                  </div>
+                </div>,
+                <span className="f-m">{nf.format(p.turnos)}</span>,
+                <span className={`f-m ${p.asistencia !== null && p.asistencia < 0.8 ? "text-mal" : ""}`}>
+                  {p.asistencia === null ? "—" : pct(p.asistencia, 0)}
+                </span>,
+                <span className="f-m">{p.ocupacion === null ? "—" : pct(p.ocupacion, 0)}</span>,
+                <span className="f-m font-semibold">{money(p.ingresos)}</span>,
+              ])}
+              vacio="No hay profesionales con actividad en este período."
+            />
+            <p className="text-xs text-texto-tenue px-5 pb-5 pt-3 leading-relaxed">
+              El ingreso junta dos caminos: lo que se cobró derecho al turno y la
+              parte del abono que consumió cada clase —un pack de ocho clases pone
+              un octavo en cada una—. Lo no consumido todavía no es de nadie.
+            </p>
+          </Card>
+
+          {/* ============ 7 · ¿DÓNDE TENGO QUE ACTUAR? ============ */}
+          {d.oportunidades.length > 0 && (
+            <Card className="p-5">
+              <Titulo pregunta="Esto no mira el período elegido: es cómo está el negocio hoy. Sale de los mismos segmentos que usa CRM.">
+                Atención y oportunidades
+              </Titulo>
+              <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-3">
+                {d.oportunidades.map((x) => (
+                  <Tarjeta key={x.k} tono={x.tono} texto={x.texto} accion={x.accion} onAccion={() => irA(x)} />
+                ))}
+              </div>
+            </Card>
+          )}
+
+          {/* ============ PIE ============ */}
+          <div className="flex items-center justify-between gap-4 flex-wrap text-xs text-texto-tenue px-1">
+            <span className="flex items-center gap-2">
+              <RefreshCw size={12} className={cargando ? "animate-spin" : ""} />
+              Calculado el {d.generado.toLocaleDateString("es-AR")} a las{" "}
+              {d.generado.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", hour12: false })}
+            </span>
+            {/* No hay caché ni proceso diferido: cada carga consulta la base.
+                Decir "tiempo real" cuando no lo es sería peor que no decir nada. */}
+            <span>Se lee de la base en el momento. Al cambiar un filtro se recalcula todo.</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/supabase/migrations/0047_informes_con_filtros.sql
+++ b/supabase/migrations/0047_informes_con_filtros.sql
@@ -1,0 +1,287 @@
+/* ============================================================
+   0047 · EL INFORME, FILTRABLE Y CON EL EQUIPO ADENTRO
+   ============================================================
+
+   Dos cosas para que Reportes pueda ser lo que tiene que ser: que los
+   filtros del encabezado lleguen hasta el fondo, y que se pueda decir
+   cuánto factura cada profesional.
+
+   LOS FILTROS VAN EN UN JSONB Y NO EN CUATRO PARÁMETROS
+   -----------------------------------------------------
+   `informe_ocupacion` ya se llamaba con tres argumentos y tiene sus
+   pruebas escritas así. Sumarle cuatro parámetros sueltos obligaba a
+   tocarlas y a repetir la firma cada vez que aparezca un filtro nuevo.
+   Con un `jsonb` con valor por defecto, la llamada vieja sigue andando y
+   la nueva pasa lo que quiera:
+
+     informe_ocupacion(emp, desde, hasta)
+     informe_ocupacion(emp, desde, hasta, '{"area":"Pilates"}')
+
+   Filtra por área, profesional, prestación y sala. Todos opcionales.
+
+   CUÁNTO FACTURA UN PROFESIONAL: DOS CAMINOS, NO UNO
+   --------------------------------------------------
+   Un turno suelto cobrado apunta a su venta con `reservas.operacion_id`,
+   así que ahí la plata es directa.
+
+   Una clase de pilates no. La persona pagó un pack de ocho hace tres
+   semanas y hoy usa la cuarta. Si solo se contara lo directo, la profe
+   que da todas las clases de mat aparecería facturando cero, que es
+   exactamente al revés de lo que pasa.
+
+   Entonces el abono se reparte entre las clases que se usaron: un pack de
+   $100.000 consumido en ocho clases pone $12.500 en cada una. Es una
+   regla de imputación y como tal está dicha en la pantalla, no escondida
+   acá: quien lee el número tiene que saber cómo se armó.
+
+   Se divide por las clases consumidas de ese abono **en toda su vida** y
+   no por las del período. Si se dividiera por las del período, el mismo
+   pack repartiría distinto según qué fechas se miren, y dos informes del
+   mismo negocio dirían cosas diferentes.
+
+   Lo no consumido no se imputa a nadie: es plata cobrada por clases que
+   todavía no se dieron, y en el informe del mes que viene aparecerá donde
+   corresponda.
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1 · La ocupación, ahora filtrable
+   ------------------------------------------------------------ */
+
+/* Agregar el parámetro no reemplaza: crea una sobrecarga, y quedaban las
+   dos funciones vivas con la vieja sin filtros. Se tira primero. Las
+   llamadas de tres argumentos que ya existen —las pruebas, entre otras—
+   siguen andando contra la nueva porque el cuarto tiene valor por
+   defecto. */
+drop function if exists informe_ocupacion(uuid, date, date);
+
+create or replace function informe_ocupacion(
+  p_empresa uuid,
+  p_desde   date,
+  p_hasta   date,
+  p_filtros jsonb default '{}'::jsonb
+)
+returns table (
+  ambito    text,
+  id        uuid,
+  nombre    text,
+  detalle   text,
+  ofrecidos numeric,
+  ocupados  numeric,
+  lugares   numeric,
+  tomados   numeric
+)
+language sql
+stable
+as $$
+  with f as (
+    select nullif(p_filtros ->> 'area', '')        as area,
+           nullif(p_filtros ->> 'personal', '')::uuid as personal,
+           nullif(p_filtros ->> 'item', '')::uuid  as item,
+           nullif(p_filtros ->> 'recurso', '')::uuid as recurso
+  ),
+  dias as (
+    select d::date as dia, extract(dow from d)::smallint as dow
+      from generate_series(p_desde, p_hasta, interval '1 day') d
+  ),
+
+  turno_persona as (
+    select h.personal_id, d.dia,
+           greatest(0, extract(epoch from (h.hasta - h.desde)) / 60
+             - coalesce((
+                 select sum(greatest(0, extract(epoch from (
+                          least(x.hasta, d.dia + h.hasta) - greatest(x.desde, d.dia + h.desde)
+                        )) / 60))
+                   from excepciones x
+                  where x.empresa_id = p_empresa
+                    and x.personal_id = h.personal_id
+                    and x.desde < d.dia + h.hasta
+                    and x.hasta > d.dia + h.desde
+               ), 0)
+           ) as minutos
+      from horarios h
+      join dias d on d.dow = h.dia
+     where h.empresa_id = p_empresa and h.activo and h.personal_id is not null
+  ),
+
+  apertura as (
+    select d.dia,
+           coalesce(extract(epoch from (max(h.hasta) - min(h.desde))) / 60, 0) as minutos
+      from dias d
+      left join horarios h on h.dia = d.dow and h.empresa_id = p_empresa and h.activo
+     group by d.dia
+  ),
+
+  /* El filtro se aplica sobre lo agendado y no sobre el catálogo: las
+     horas ofrecidas de una sala no cambian porque se mire una prestación
+     en particular, lo que cambia es cuánto de esas horas se usó para eso.
+     Al revés daría porcentajes por encima de cien. */
+  agendado as (
+    select r.personal_id, r.recurso_id, r.duracion_min, r.cupo, r.id
+      from reservas r
+      left join items i on i.id = r.item_id
+      cross join f
+     where r.empresa_id = p_empresa
+       and r.clase_id is null
+       and r.estado <> 'cancelada'
+       and r.desde >= p_desde
+       and r.desde < (p_hasta + 1)
+       and (f.area     is null or i.categoria   = f.area)
+       and (f.personal is null or r.personal_id = f.personal)
+       and (f.item     is null or r.item_id     = f.item)
+       and (f.recurso  is null or r.recurso_id  = f.recurso)
+  ),
+
+  inscriptos as (
+    select i.clase_id, count(*) as tomados
+      from reservas i
+     where i.empresa_id = p_empresa
+       and i.clase_id is not null
+       and i.estado not in ('cancelada', 'ausente')
+     group by i.clase_id
+  )
+
+  select
+    'profesional'::text,
+    per.id,
+    per.nombre,
+    coalesce(per.especialidad, ''),
+    coalesce((select sum(t.minutos) from turno_persona t where t.personal_id = per.id), 0),
+    coalesce((select sum(a.duracion_min) from agendado a where a.personal_id = per.id), 0),
+    coalesce((select sum(a.cupo) from agendado a where a.personal_id = per.id and a.cupo is not null), 0),
+    coalesce((select sum(ins.tomados) from agendado a
+                join inscriptos ins on ins.clase_id = a.id
+               where a.personal_id = per.id), 0)
+  from personal per
+  cross join f
+ where per.empresa_id = p_empresa and per.activo and per.tipo = 'profesional'
+   and (f.personal is null or per.id = f.personal)
+
+  union all
+
+  select
+    'sala'::text,
+    re.id,
+    re.nombre,
+    coalesce(re.tipo, ''),
+    coalesce(
+      nullif((select sum(extract(epoch from (h.hasta - h.desde)) / 60)
+                from horarios h join dias d on d.dow = h.dia
+               where h.empresa_id = p_empresa and h.activo and h.recurso_id = re.id), 0),
+      (select sum(ap.minutos) from apertura ap), 0),
+    coalesce((select sum(a.duracion_min) from agendado a where a.recurso_id = re.id), 0),
+    coalesce((select sum(a.cupo) from agendado a where a.recurso_id = re.id and a.cupo is not null), 0),
+    coalesce((select sum(ins.tomados) from agendado a
+                join inscriptos ins on ins.clase_id = a.id
+               where a.recurso_id = re.id), 0)
+  from recursos re
+  cross join f
+ where re.empresa_id = p_empresa and re.activo
+   and (f.recurso is null or re.id = f.recurso)
+$$;
+
+comment on function informe_ocupacion(uuid, date, date, jsonb) is
+  'Cuánto de lo que se podía vender se vendió, por profesional y por sala. Los filtros se aplican a lo agendado y no a la capacidad: la capacidad no cambia porque se mire una prestación.';
+
+grant execute on function informe_ocupacion(uuid, date, date, jsonb) to authenticated;
+
+
+/* ------------------------------------------------------------
+   2 · Cuánto trabajó y cuánto facturó cada uno
+   ------------------------------------------------------------ */
+
+create or replace function informe_equipo(
+  p_empresa uuid,
+  p_desde   date,
+  p_hasta   date,
+  p_filtros jsonb default '{}'::jsonb
+)
+returns table (
+  personal_id  uuid,
+  nombre       text,
+  especialidad text,
+  turnos       int,
+  cumplidos    int,
+  ausentes     int,
+  clases       int,
+  alumnos      int,
+  directo      numeric,
+  por_abono    numeric
+)
+language sql
+stable
+as $$
+  with f as (
+    select nullif(p_filtros ->> 'area', '')           as area,
+           nullif(p_filtros ->> 'personal', '')::uuid as personal,
+           nullif(p_filtros ->> 'item', '')::uuid     as item,
+           nullif(p_filtros ->> 'recurso', '')::uuid  as recurso
+  ),
+
+  /* Cuánto vale una clase de cada abono: lo que se pagó dividido por las
+     clases que se usaron en toda la vida del abono. Ver la cabecera. */
+  valor_clase as (
+    select a.id,
+           case when u.usadas > 0 then o.total / u.usadas else 0 end as valor
+      from abonos a
+      join operaciones o on o.id = a.operacion_id and o.estado = 'confirmada'
+      cross join lateral (
+        select count(*) as usadas
+          from reservas r
+         where r.abono_id = a.id and r.estado not in ('cancelada')
+      ) u
+     where a.empresa_id = p_empresa and not a.anulado
+  ),
+
+  /* Lo que hizo cada uno en el período. Las inscripciones a una clase
+     cuentan para asistencia y para el reparto del abono; la clase en sí
+     cuenta como clase dictada. Son dos unidades distintas y las dos
+     hacen falta. */
+  hechos as (
+    select r.personal_id,
+           r.estado,
+           r.cupo,
+           r.clase_id,
+           coalesce(o.total, 0)      as directo,
+           coalesce(vc.valor, 0)     as del_abono
+      from reservas r
+      left join items i on i.id = r.item_id
+      left join operaciones o on o.id = r.operacion_id and o.estado = 'confirmada'
+      left join valor_clase vc on vc.id = r.abono_id
+      cross join f
+     where r.empresa_id = p_empresa
+       and r.personal_id is not null
+       and r.desde >= p_desde
+       and r.desde < (p_hasta + 1)
+       and (f.area     is null or i.categoria   = f.area)
+       and (f.personal is null or r.personal_id = f.personal)
+       and (f.item     is null or r.item_id     = f.item)
+       and (f.recurso  is null or r.recurso_id  = f.recurso)
+  )
+
+  select
+    per.id,
+    per.nombre,
+    coalesce(per.especialidad, ''),
+    /* Turnos atendidos: los de a uno más los alumnos de las clases. La
+       clase vacía no es un turno. */
+    coalesce(count(*) filter (where h.cupo is null), 0)::int,
+    coalesce(count(*) filter (where h.cupo is null and h.estado = 'cumplida'), 0)::int,
+    coalesce(count(*) filter (where h.cupo is null and h.estado = 'ausente'), 0)::int,
+    coalesce(count(*) filter (where h.cupo is not null), 0)::int,
+    coalesce(count(*) filter (where h.clase_id is not null and h.estado not in ('cancelada', 'ausente')), 0)::int,
+    coalesce(sum(h.directo) filter (where h.estado <> 'cancelada'), 0),
+    coalesce(sum(h.del_abono) filter (where h.estado <> 'cancelada'), 0)
+  from personal per
+  cross join f
+  left join hechos h on h.personal_id = per.id
+ where per.empresa_id = p_empresa and per.activo and per.tipo = 'profesional'
+   and (f.personal is null or per.id = f.personal)
+ group by per.id, per.nombre, per.especialidad, per.orden
+ order by per.orden, per.nombre
+$$;
+
+comment on function informe_equipo(uuid, date, date, jsonb) is
+  'Qué hizo y cuánto facturó cada profesional. El ingreso viene por dos caminos: lo cobrado derecho al turno y la parte del abono que consumió cada clase.';
+
+grant execute on function informe_equipo(uuid, date, date, jsonb) to authenticated;

--- a/supabase/seed/almha_historia.sql
+++ b/supabase/seed/almha_historia.sql
@@ -128,6 +128,7 @@ declare
   v_ses    uuid;
   v_cli    uuid;
   v_clase  uuid;
+  v_turno  uuid;
   v_abono  uuid;
   v_op     uuid;
 
@@ -586,7 +587,8 @@ for v_off in (v_inicio - v_hoy)..14 loop
     select v_emp, v_suc, s.recurso_id, s.personal_id, s.item_id,
            v_cli, cl.razon_social, 1, v_cuando, s.duracion, v_estado,
            v_user, '{"demo": true}'::jsonb, v_dia - 4 + time '11:00'
-      from clientes cl where cl.id = v_cli;
+      from clientes cl where cl.id = v_cli
+    returning id into v_turno;
 
     /* Un turno cumplido se cobra. Uno de cada ocho queda sin cobrar: es la
        cuenta corriente que después hay que ir a buscar, y si la semilla no
@@ -595,9 +597,21 @@ for v_off in (v_inicio - v_hoy)..14 loop
       v_num := v_num + 1;
       v_cobrada := random() >= 0.12;
       v_medio := (array['efectivo','efectivo','debito','credito','mp','transferencia'])[1 + floor(random() * 6)::int];
-      perform pg_temp.venta_demo(v_emp, v_suc, v_user, v_cli, s.item_id, s.nombre, s.precio,
+      v_op := pg_temp.venta_demo(v_emp, v_suc, v_user, v_cli, s.item_id, s.nombre, s.precio,
                                  v_cuando + interval '50 minutes', v_ses, v_medio,
                                  v_pv || '-' || lpad(v_num::text, 8, '0'), v_cobrada);
+
+      /* El turno queda apuntando a la venta que lo cobró. `reservas`
+         tiene la columna desde 0024 y hasta ahora nadie la escribía,
+         porque cobrar un turno todavía no existe como pantalla: el único
+         cobro del sistema es el del mostrador.
+
+         Sin este vínculo no hay forma de saber qué plata entró por qué
+         turno, y por lo tanto tampoco cuánto factura cada profesional.
+         Es el mismo dato que va a necesitar la modalidad de pago por
+         comisión. Cuando exista la pantalla de cobro, lo único que tiene
+         que hacer es escribir esto. */
+      update reservas set operacion_id = v_op where id = v_turno;
     end if;
   end loop;
 


### PR DESCRIPTION
Reportes reconstruido sobre la maqueta, con una regla que manda sobre todo
lo demás: **un reporte no existe para mostrar datos, existe para ayudar a
decidir.** Cada bloque contesta una pregunta y lleva la pregunta escrita al
lado; el que no contestaba ninguna no está.

## Un solo contexto

El rango de fechas, la comparación y los filtros valen para la pantalla
entera. Ninguna tarjeta consulta por su cuenta: son siete lecturas en
paralelo y después se dibuja.

Ocho períodos, rango libre de cualquier fecha a cualquier fecha, y cuatro
formas de comparar. El período anterior es tan largo como el elegido y
termina justo antes: si fuera "el mes pasado" a secas, febrero siempre
parecería peor que enero.

## Lo que no se puede filtrar se aclara

Un alquiler no es de pilates ni de estética: los egresos no tienen área.
Con un filtro puesto, el resultado neto y la curva de egresos siguen siendo
del negocio entero y la pantalla lo dice. Mostrar un número que parece
filtrado y no lo está es peor que no mostrarlo.

## Lo que no se puede calcular, no se inventa

| Pedía la maqueta | Quedó |
|---|---|
| Rentabilidad por área (costos, margen) | **Ingresos por área**, con nota al pie: faltan el costo de las prestaciones y la imputación de egresos |
| Filtro de sucursal | Apagado — hay una sola |
| Exportar | Apagado — no hay exportación en el sistema |
| "No-show" aparte de "Ausentes" | Solo las 4 categorías que el modelo distingue |
| Las otras 7 pestañas | `Apagado`, diciendo por qué |

Un margen inventado en un informe financiero no es un detalle estético: es
alguien decidiendo con un número falso.

## Cuánto factura cada profesional: dos caminos

Un turno suelto cobrado apunta a su venta. Una clase no: la persona pagó un
pack hace tres semanas y hoy usa la cuarta. Contando solo lo directo, la
profe que da todas las clases de mat aparecía facturando cero.

El abono se reparte entre las clases que se usaron —un pack de ocho pone un
octavo en cada una— y se divide por las de toda la vida del abono y no por
las del período: si no, el mismo pack repartiría distinto según qué fechas
se miren. La regla está dicha en la pantalla, no escondida en el SQL.

## `reservas.operacion_id` existía y nadie lo escribía

Desde la migración 0024. La semilla creaba la venta del turno y no las
vinculaba, así que no había forma de saber qué plata entró por qué turno.
Cobrar un turno todavía no existe como pantalla —lo dice `Agenda.jsx`— y
cuando exista, lo único que tiene que hacer es escribir esa columna. Es el
mismo dato que necesita la modalidad de pago por comisión.

## Lo que se reutilizó

`Anillo`, `Referencia` y `BarraDato` de `ui/Graficos.jsx`, que ya existían y
que la versión anterior no usaba. Los segmentos de CRM son el bloque de
oportunidades entero, sin recalcular nada: dos definiciones de "cliente que
se está yendo" un día dejan de coincidir. Sin librerías nuevas.

## Verificación

- `npm run build` limpio; la app carga sin errores de consola.
- `probar-rls.mjs`: **161 verificaciones**, todas en verde (7 nuevas sobre
  el reparto del abono, que es la única cuenta del informe que no se puede
  verificar mirando).
- `informe_ocupacion` e `informe_equipo` reciben el `empresa_id` como
  parámetro obligatorio (regla 6) y no son `security definer`.

**Falta mirarlo contra la maqueta**, que no se puede hacer sin pasar del
login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)